### PR TITLE
Updated module config key from `inactive_users` to `inactive-users`

### DIFF
--- a/modules/inactive-users/inactive-users.php
+++ b/modules/inactive-users/inactive-users.php
@@ -28,10 +28,11 @@ class Inactive_Users {
 		}
 	
 		$configs               = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
-		$inactive_user_configs = $configs['inactive_users'] ?? [];
+		$module_configs        = $configs[ 'module_configs' ] ?? [];
+		$inactive_user_configs = $module_configs[ 'inactive-users' ] ?? [];
 
-		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
-		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
+		self::$mode                           = $inactive_user_configs[ 'mode' ] ?? 'REPORT';
+		self::$considered_inactive_after_days = $inactive_user_configs[ 'considered_inactive_after_days' ] ?? 90;
 		self::$release_date = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 
 		// Use a global cache group since users are shared among network sites.
@@ -144,32 +145,32 @@ class Inactive_Users {
 	}
 
 	public static function add_last_seen_column_head( $columns ) {
-		$columns['last_seen'] = __( 'Last seen', 'wpvip' );
+		$columns[ 'last_seen' ] = __( 'Last seen', 'wpvip' );
 		return $columns;
 	}
 
 	public static function add_last_seen_sortable_column( $columns ) {
-		$columns['last_seen'] = 'last_seen';
+		$columns[ 'last_seen' ] = 'last_seen';
 
 		return $columns;
 	}
 
 	public static function last_seen_order_by_query_args( $vars ) {
-		if ( isset( $vars['orderby'] ) && 'last_seen' === $vars['orderby'] ) {
-			$vars['meta_key'] = self::LAST_SEEN_META_KEY;
-			$vars['orderby']  = 'meta_value_num';
+		if ( isset( $vars[ 'orderby' ] ) && 'last_seen' === $vars[ 'orderby' ] ) {
+			$vars[ 'meta_key' ] = self::LAST_SEEN_META_KEY;
+			$vars[ 'orderby' ]  = 'meta_value_num';
 		}
 
 		return $vars;
 	}
 
 	public static function last_seen_blocked_users_filter_query_args( $vars ) {
-		if ( isset( $_GET['last_seen_filter'] ) && 'blocked' === $_GET['last_seen_filter'] && isset( $_GET['last_seen_filter_nonce'] ) && wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' ) ) {
-			$vars['meta_key'] = self::LAST_SEEN_META_KEY;
+		if ( isset( $_GET[ 'last_seen_filter' ] ) && 'blocked' === $_GET[ 'last_seen_filter' ] && isset( $_GET[ 'last_seen_filter_nonce' ] ) && wp_verify_nonce( sanitize_text_field( $_GET[ 'last_seen_filter_nonce' ] ), 'last_seen_filter' ) ) {
+			$vars[ 'meta_key' ] = self::LAST_SEEN_META_KEY;
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			$vars['meta_value']   = self::get_inactivity_timestamp();
-			$vars['meta_type']    = 'NUMERIC';
-			$vars['meta_compare'] = '<';
+			$vars[ 'meta_value' ]   = self::get_inactivity_timestamp();
+			$vars[ 'meta_type' ]    = 'NUMERIC';
+			$vars[ 'meta_compare' ] = '<';
 		}
 
 		return $vars;
@@ -193,7 +194,7 @@ class Inactive_Users {
 		}
 
 		if ( ! self::is_block_action_enabled() || ! self::is_considered_inactive( $user_id ) ) {
-			return sprintf( '<span>%s</span>', esc_html( $date ) );
+			return sprintf( '<span>%s %s</span>', esc_html( $date ), self::is_block_action_enabled() ? 'BLOCK' : 'REPORT' );
 		}
 
 		$unblock_link = '';
@@ -226,7 +227,7 @@ class Inactive_Users {
 			),
 		);
 
-		$views['blocked_users'] = __( 'Blocked Users', 'wpvip' );
+		$views[ 'blocked_users' ] = __( 'Blocked Users', 'wpvip' );
 
 		if ( ! $users_query->get_results() ) {
 			return $views;
@@ -238,11 +239,11 @@ class Inactive_Users {
 		) );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$class = isset( $_GET['last_seen_filter'] ) ? 'current' : '';
+		$class = isset( $_GET[ 'last_seen_filter' ] ) ? 'current' : '';
 
-		$view = '<a class="' . esc_attr( $class ) . '" href="' . esc_url( $url ) . '">' . esc_html( $views['blocked_users'] ) . '</a>';
+		$view = '<a class="' . esc_attr( $class ) . '" href="' . esc_url( $url ) . '">' . esc_html( $views[ 'blocked_users' ] ) . '</a>';
 
-		$views['blocked_users'] = $view;
+		$views[ 'blocked_users' ] = $view;
 
 		return $views;
 	}
@@ -250,7 +251,7 @@ class Inactive_Users {
 	public static function last_seen_unblock_action() {
 		$admin_notices_hook_name = is_network_admin() ? 'network_admin_notices' : 'admin_notices';
 
-		if ( isset( $_GET['reset_last_seen_success'] ) && '1' === $_GET['reset_last_seen_success'] ) {
+		if ( isset( $_GET[ 'reset_last_seen_success' ] ) && '1' === $_GET[ 'reset_last_seen_success' ] ) {
 			add_action( $admin_notices_hook_name, function () {
 				$class = 'notice notice-success is-dismissible';
 				$error = __( 'User unblocked.', 'wpvip' );
@@ -259,14 +260,14 @@ class Inactive_Users {
 			} );
 		}
 
-		if ( ! isset( $_GET['user_id'], $_GET['action'] ) || 'reset_last_seen' !== $_GET['action'] ) {
+		if ( ! isset( $_GET[ 'user_id' ], $_GET[ 'action' ] ) || 'reset_last_seen' !== $_GET[ 'action' ] ) {
 			return;
 		}
 
-		$user_id = absint( $_GET['user_id'] );
+		$user_id = absint( $_GET[ 'user_id' ] );
 
 		$error = null;
-		if ( ! isset( $_GET['reset_last_seen_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_GET['reset_last_seen_nonce'] ), 'reset_last_seen_action' ) ) {
+		if ( ! isset( $_GET[ 'reset_last_seen_nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ 'reset_last_seen_nonce' ] ), 'reset_last_seen_action' ) ) {
 			$error = __( 'Unable to verify your request', 'wpvip' );
 		}
 


### PR DESCRIPTION
## Description

Our configuration service will provide configurations using the `inactive-users` key.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->