### PR TITLE
Highlight users not using MFA

### DIFF
--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -15,59 +15,116 @@ class Highlight_MFA_Users {
 		self::$mode          = $highlight_mfa_users['mode'] ?? 'REPORT';
 
 		if ( in_array( self::$mode, array( 'REPORT', 'HIGHLIGHT' ) ) ) {
-			add_filter( 'wpmu_users_columns', [ __CLASS__, 'add_mfa_status_column_head' ] );
-			add_filter( 'manage_users_columns', [ __CLASS__, 'add_mfa_status_column_head' ] );
-			add_filter( 'manage_users_custom_column', [ __CLASS__, 'add_mfa_status_column_content' ], 10, 3 );
+			add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
+			add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
 		}
 	}
-	
-	public static function add_mfa_status_column_head( $columns ) {
-		$columns['mfa_status'] = __( 'MFA Status', 'wpvip' );
-		return $columns;
-	}
 
-	public static function add_mfa_status_column_content( $output, $column_name, $user_id ) {
-		if ( 'mfa_status' !== $column_name ) {
-			return $output;
+	/**
+	 * Display an admin notice on the Users page showing the count of users with MFA disabled.
+	 */
+	public static function display_mfa_disabled_notice() {
+		// Check if the Two Factor plugin is active
+		// TODO: if Two_Factor_Core is disabled, do we display all admin users?
+		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+			return; // Exit if Two Factor plugin isn't active
 		}
 
-		// Check if user should be skipped via filter
-		/**
-		 * Filters whether to skip the MFA status check for a specific user via code.
-		 * Returning true will prevent the "Enabled" or "Disabled" status from being displayed for this user.
-		 * @param bool $skip    Whether to skip the check. Default false.
-		 * @param int  $user_id The ID of the user being checked.
-		 */
-		$skip_via_filter = apply_filters( 'vip_security_mfa_skip_user_check', false, $user_id );
-
-		if ( $skip_via_filter ) {
-			return $output;
+		// Only show on the main users list table
+		$screen = get_current_screen();
+		if ( ! $screen || 'users' !== $screen->id ) {
+			return;
 		}
 
-		// Check if user should be skipped via option
+
 		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 		if ( ! is_array( $skipped_user_ids ) ) {
 			$skipped_user_ids = [];
 		}
 
-		if ( in_array( $user_id, $skipped_user_ids, true ) ) {
-			return $output;
+		// Query for administrator user IDs, excluding skipped ones
+		$args = [
+			'role'    => 'administrator', // Only administrators
+			'fields'  => 'ID',
+			'exclude' => $skipped_user_ids,
+			'number'  => -1, // Get all relevant users
+		];
+		$user_query = new \WP_User_Query( $args );
+		$user_ids   = $user_query->get_results();
+
+		$mfa_disabled_count = 0;
+		foreach ( $user_ids as $user_id ) {
+			// Use the reliable check from the Two Factor plugin
+			if ( ! \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
+				$mfa_disabled_count++;
+			}
 		}
 
-		// Proceed with MFA check if not skipped
-		$mfa_enabled = false;
-
-		if ( class_exists( 'Two_Factor_Core' ) && \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
-			$mfa_enabled = true;
-		} else {
-			// $mfa_enabled = get_user_meta( $user_id, 'my_custom_mfa_status_meta_key', true );
+		if ( $mfa_disabled_count > 0 ) {
+			$filter_url = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+			printf(
+				'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+				sprintf(
+					_n(
+						'There is %d administrator with MFA disabled.',
+						'There are %d administrators with MFA disabled.',
+						$mfa_disabled_count,
+						'wpvip'
+					),
+					number_format_i18n( $mfa_disabled_count )
+				),
+				esc_url( $filter_url ),
+				esc_html__( 'Filter list to show these users.', 'wpvip' )
+			);
 		}
+	}
 
+	/**
+		* Modify the user query on the Users page to filter by MFA status if requested.
+		* @param \WP_User_Query $query The WP_User_Query instance (passed by reference).
+		*/
+	public static function filter_users_by_mfa_status( $query ) {
+		global $pagenow;
+		if ( is_admin() && 'users.php' === $pagenow && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
+			
+			// Ensure we don't break other meta queries
+			$meta_query = $query->get( 'meta_query' );
+			if ( ! is_array( $meta_query ) ) {
+				$meta_query = [];
+			}
 
-		if ( $mfa_enabled ) {
-			return __( 'Enabled', 'wpvip' );
-		} else {
-			return sprintf( '<strong style="color: red;">%s</strong>', __( 'Disabled', 'wpvip' ) );
+			$meta_query[] = [
+				'relation' => 'OR',
+				[
+					'key'     => '_two_factor_enabled_providers',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_two_factor_enabled_providers',
+					'value'   => 'a:0:{}',
+					'compare' => '=',
+				],
+				[
+					'key'     => '_two_factor_enabled_providers',
+					'value'   => '',
+					'compare' => '=',
+				],
+			];
+			$query->set( 'role__in', ['administrator'] );
+			$query->set( 'meta_query', $meta_query );
+
+			// Exclude skipped users
+			$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+			if ( ! is_array( $skipped_user_ids ) ) {
+				$skipped_user_ids = [];
+			}
+			if ( ! empty( $skipped_user_ids ) ) {
+				$exclude_ids = $query->get( 'exclude' );
+				if ( ! is_array( $exclude_ids ) ) {
+					$exclude_ids = [];
+				}
+				$query->set( 'exclude', array_unique( array_merge( $exclude_ids, $skipped_user_ids ) ) );
+			}
 		}
 	}
 }

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -11,8 +11,8 @@ class Highlight_MFA_Users {
 	}
 
 	/**
-	 * Display an admin notice on the Users page showing the count of users with MFA disabled.
-	 */
+		* Display an admin notice on the Users page showing the count of users with MFA disabled.
+		*/
 	public static function display_mfa_disabled_notice() {
 		// TODO: if Two_Factor_Core is disabled, do we display all admin users?
 		if ( ! class_exists( 'Two_Factor_Core' ) ) {
@@ -20,13 +20,12 @@ class Highlight_MFA_Users {
 		}
 
 		// Only show on the main users list table
-		$screen = \get_current_screen();
+		$screen = get_current_screen();
 		if ( ! $screen || 'users' !== $screen->id ) {
 			return;
 		}
 
-
-		$skipped_user_ids = \get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 		if ( ! is_array( $skipped_user_ids ) ) {
 			$skipped_user_ids = [];
 		}
@@ -43,7 +42,6 @@ class Highlight_MFA_Users {
 
 		$mfa_disabled_count = 0;
 		foreach ( $user_ids as $user_id ) {
-			// Use the reliable check from the Two Factor plugin
 			if ( ! \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
 				$mfa_disabled_count++;
 			}
@@ -55,29 +53,37 @@ class Highlight_MFA_Users {
 
 			if ( $is_filtered ) {
 				// Display notice for when the list IS filtered
-				$show_all_url = \remove_query_arg( 'filter_mfa_disabled', \admin_url( 'users.php' ) );
+				$show_all_url = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
 				printf(
-					'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Using notice-info for filtered view
-					\esc_html__( 'Showing administrators without MFA enabled.', 'wpvip' ),
-					\esc_url( $show_all_url ),
-					\esc_html__( 'Show all users.', 'wpvip' )
-				);
-			} else {
-				// Display the original notice when the list is NOT filtered
-				$filter_url = \add_query_arg( 'filter_mfa_disabled', '1', \admin_url( 'users.php' ) );
-				printf(
-					'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+					'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>',
 					sprintf(
-						\_n(
-							'There is %d administrator with MFA disabled.',
-							'There are %d administrators with MFA disabled.',
+						_n(
+							'Showing %d user without MFA enabled.',
+							'Showing %d users without MFA enabled.',
 							$mfa_disabled_count,
 							'wpvip'
 						),
-						\number_format_i18n( $mfa_disabled_count )
+						number_format_i18n( $mfa_disabled_count )
 					),
-					\esc_url( $filter_url ),
-					\esc_html__( 'Filter list to show these users.', 'wpvip' )
+					esc_url( $show_all_url ),
+					esc_html__( 'Show all users.', 'wpvip' )
+				);
+			} else {
+				// Display the original notice when the list is NOT filtered
+				$filter_url = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+				printf(
+					'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+					sprintf(
+						_n(
+							'There is %d user with MFA disabled.',
+							'There are %d users with MFA disabled.',
+							$mfa_disabled_count,
+							'wpvip'
+						),
+						number_format_i18n( $mfa_disabled_count )
+					),
+					esc_url( $filter_url ),
+					esc_html__( 'Filter list to show these users.', 'wpvip' )
 				);
 			}
 		}
@@ -89,7 +95,7 @@ class Highlight_MFA_Users {
 		*/
 	public static function filter_users_by_mfa_status( $query ) {
 		global $pagenow;
-		if ( \is_admin() && 'users.php' === $pagenow && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
+		if ( is_admin() && 'users.php' === $pagenow && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
 			
 			// Ensure we don't break other meta queries
 			$meta_query = $query->get( 'meta_query' );

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -14,7 +14,7 @@ class Highlight_MFA_Users {
 		* Display an admin notice on the Users page showing the count of users with MFA disabled.
 		*/
 	public static function display_mfa_disabled_notice() {
-		if ( ! class_exists( 'Two_Factor_Core' ) ) {
+		if ( ! class_exists( '\Two_Factor_Core' ) ) {
 			return;
 		}
 

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -20,13 +20,13 @@ class Highlight_MFA_Users {
 		}
 
 		// Only show on the main users list table
-		$screen = get_current_screen();
+		$screen = \get_current_screen();
 		if ( ! $screen || 'users' !== $screen->id ) {
 			return;
 		}
 
 
-		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+		$skipped_user_ids = \get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 		if ( ! is_array( $skipped_user_ids ) ) {
 			$skipped_user_ids = [];
 		}
@@ -50,21 +50,36 @@ class Highlight_MFA_Users {
 		}
 
 		if ( $mfa_disabled_count > 0 ) {
-			$filter_url = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
-			printf(
-				'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
-				sprintf(
-					_n(
-						'There is %d administrator with MFA disabled.',
-						'There are %d administrators with MFA disabled.',
-						$mfa_disabled_count,
-						'wpvip'
+			// Check if the filter is currently active
+			$is_filtered = isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'];
+
+			if ( $is_filtered ) {
+				// Display notice for when the list IS filtered
+				$show_all_url = \remove_query_arg( 'filter_mfa_disabled', \admin_url( 'users.php' ) );
+				printf(
+					'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Using notice-info for filtered view
+					\esc_html__( 'Showing administrators without MFA enabled.', 'wpvip' ),
+					\esc_url( $show_all_url ),
+					\esc_html__( 'Show all users.', 'wpvip' )
+				);
+			} else {
+				// Display the original notice when the list is NOT filtered
+				$filter_url = \add_query_arg( 'filter_mfa_disabled', '1', \admin_url( 'users.php' ) );
+				printf(
+					'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+					sprintf(
+						\_n(
+							'There is %d administrator with MFA disabled.',
+							'There are %d administrators with MFA disabled.',
+							$mfa_disabled_count,
+							'wpvip'
+						),
+						\number_format_i18n( $mfa_disabled_count )
 					),
-					number_format_i18n( $mfa_disabled_count )
-				),
-				esc_url( $filter_url ),
-				esc_html__( 'Filter list to show these users.', 'wpvip' )
-			);
+					\esc_url( $filter_url ),
+					\esc_html__( 'Filter list to show these users.', 'wpvip' )
+				);
+			}
 		}
 	}
 
@@ -74,7 +89,7 @@ class Highlight_MFA_Users {
 		*/
 	public static function filter_users_by_mfa_status( $query ) {
 		global $pagenow;
-		if ( is_admin() && 'users.php' === $pagenow && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
+		if ( \is_admin() && 'users.php' === $pagenow && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
 			
 			// Ensure we don't break other meta queries
 			$meta_query = $query->get( 'meta_query' );
@@ -102,18 +117,23 @@ class Highlight_MFA_Users {
 			$query->set( 'role__in', ['administrator'] );
 			$query->set( 'meta_query', $meta_query );
 
-			// Exclude skipped users
-			$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+			// Exclude skipped users AND always exclude User ID 1
+			$skipped_user_ids = \get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 			if ( ! is_array( $skipped_user_ids ) ) {
 				$skipped_user_ids = [];
 			}
-			if ( ! empty( $skipped_user_ids ) ) {
-				$exclude_ids = $query->get( 'exclude' );
-				if ( ! is_array( $exclude_ids ) ) {
-					$exclude_ids = [];
-				}
-				$query->set( 'exclude', array_unique( array_merge( $exclude_ids, $skipped_user_ids ) ) );
+
+			// Get any existing exclusions from the query
+			$exclude_ids = $query->get( 'exclude' );
+			if ( ! is_array( $exclude_ids ) ) {
+				$exclude_ids = [];
 			}
+
+			// Merge existing exclusions, skipped IDs from option, and User ID 1
+			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids, [1] ) );
+
+			// Set the final list of excluded IDs
+			$query->set( 'exclude', $final_exclude_ids );
 		}
 	}
 }

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -2,32 +2,21 @@
 namespace Automattic\VIP\Security\MFAUsers;
 
 class Highlight_MFA_Users {
-	private static $mode;
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
+
 	public static function init() {
-		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-			error_log( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
-			return;
-		}
-
-		$configs             = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
-		$highlight_mfa_users = $configs['highlight_mfa_users'] ?? [];
-		self::$mode          = $highlight_mfa_users['mode'] ?? 'REPORT';
-
-		if ( in_array( self::$mode, array( 'REPORT', 'HIGHLIGHT' ) ) ) {
-			add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
-			add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
-		}
+		// Feature is always active unless specific users are skipped via option.
+		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
+		add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
 	}
 
 	/**
 	 * Display an admin notice on the Users page showing the count of users with MFA disabled.
 	 */
 	public static function display_mfa_disabled_notice() {
-		// Check if the Two Factor plugin is active
 		// TODO: if Two_Factor_Core is disabled, do we display all admin users?
 		if ( ! class_exists( 'Two_Factor_Core' ) ) {
-			return; // Exit if Two Factor plugin isn't active
+			return;
 		}
 
 		// Only show on the main users list table
@@ -44,9 +33,9 @@ class Highlight_MFA_Users {
 
 		// Query for administrator user IDs, excluding skipped ones
 		$args = [
-			'role'    => 'administrator', // Only administrators
+			'role'    => 'administrator',
 			'fields'  => 'ID',
-			'exclude' => $skipped_user_ids,
+			'exclude' => array_merge( $skipped_user_ids, [1] ), // Exclude skipped users AND user ID 1
 			'number'  => -1, // Get all relevant users
 		];
 		$user_query = new \WP_User_Query( $args );

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\VIP\Security\MFAUsers;
 
-class MFA_Users {
+class Highlight_MFA_Users {
 	private static $mode;
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
 	public static function init() {
@@ -71,4 +71,4 @@ class MFA_Users {
 		}
 	}
 }
-MFA_Users::init();
+Highlight_MFA_Users::init();

--- a/modules/highlight-mfa-users/highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/highlight-mfa-users.php
@@ -14,7 +14,6 @@ class Highlight_MFA_Users {
 		* Display an admin notice on the Users page showing the count of users with MFA disabled.
 		*/
 	public static function display_mfa_disabled_notice() {
-		// TODO: if Two_Factor_Core is disabled, do we display all admin users?
 		if ( ! class_exists( 'Two_Factor_Core' ) ) {
 			return;
 		}

--- a/modules/mfa-users/mfa-users.php
+++ b/modules/mfa-users/mfa-users.php
@@ -1,0 +1,74 @@
+<?php
+namespace Automattic\VIP\Security\MFAUsers;
+
+class MFA_Users {
+	private static $mode;
+	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
+	public static function init() {
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			error_log( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
+			return;
+		}
+
+		$configs             = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
+		$highlight_mfa_users = $configs['highlight_mfa_users'] ?? [];
+		self::$mode          = $highlight_mfa_users['mode'] ?? 'REPORT';
+
+		if ( in_array( self::$mode, array( 'REPORT', 'HIGHLIGHT' ) ) ) {
+			add_filter( 'wpmu_users_columns', [ __CLASS__, 'add_mfa_status_column_head' ] );
+			add_filter( 'manage_users_columns', [ __CLASS__, 'add_mfa_status_column_head' ] );
+			add_filter( 'manage_users_custom_column', [ __CLASS__, 'add_mfa_status_column_content' ], 10, 3 );
+		}
+	}
+	
+	public static function add_mfa_status_column_head( $columns ) {
+		$columns['mfa_status'] = __( 'MFA Status', 'wpvip' );
+		return $columns;
+	}
+
+	public static function add_mfa_status_column_content( $output, $column_name, $user_id ) {
+		if ( 'mfa_status' !== $column_name ) {
+			return $output;
+		}
+
+		// Check if user should be skipped via filter
+		/**
+		 * Filters whether to skip the MFA status check for a specific user via code.
+		 * Returning true will prevent the "Enabled" or "Disabled" status from being displayed for this user.
+		 * @param bool $skip    Whether to skip the check. Default false.
+		 * @param int  $user_id The ID of the user being checked.
+		 */
+		$skip_via_filter = apply_filters( 'vip_security_mfa_skip_user_check', false, $user_id );
+
+		if ( $skip_via_filter ) {
+			return $output;
+		}
+
+		// Check if user should be skipped via option
+		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+		if ( ! is_array( $skipped_user_ids ) ) {
+			$skipped_user_ids = [];
+		}
+
+		if ( in_array( $user_id, $skipped_user_ids, true ) ) {
+			return $output;
+		}
+
+		// Proceed with MFA check if not skipped
+		$mfa_enabled = false;
+
+		if ( class_exists( 'Two_Factor_Core' ) && \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
+			$mfa_enabled = true;
+		} else {
+			// $mfa_enabled = get_user_meta( $user_id, 'my_custom_mfa_status_meta_key', true );
+		}
+
+
+		if ( $mfa_enabled ) {
+			return __( 'Enabled', 'wpvip' );
+		} else {
+			return sprintf( '<strong style="color: red;">%s</strong>', __( 'Disabled', 'wpvip' ) );
+		}
+	}
+}
+MFA_Users::init();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -68,18 +68,17 @@ function _disable_core_legacy_widget_registration() {
 }
 
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
-tests_add_filter( 'muplugins_loaded', 'wpcom_enable_two_factor_plugin' );
 tests_add_filter( 'muplugins_loaded', '_remove_init_hook_for_cache_manager' );
 tests_add_filter( 'muplugins_loaded', '_disable_core_legacy_widget_registration' );
 
 // Disable calls to wordpress.org to get translations
-tests_add_filter( 'translations_api', function ( $res ) {
+function _vip_tests_disable_translations_api( $res ) {
 	if ( false === $res ) {
 		$res = [ 'translations' => [] ];
 	}
-
 	return $res;
-} );
+}
+tests_add_filter( 'translations_api', '_vip_tests_disable_translations_api' );
 
 
 require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -194,8 +194,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
             '<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
             sprintf(
                 _n(
-                    'There is %d administrator with MFA disabled.',
-                    'There are %d administrators with MFA disabled.',
+                    'There is %d user with MFA disabled.',
+                    'There are %d users with MFA disabled.',
                     $expected_count,
                     'wpvip'
                 ),
@@ -213,6 +213,40 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
         $output = ob_get_clean();
 
         $this->assertEquals($expected_output, $output);
+       }
+      
+       /**
+        * Test that the admin notice is displayed correctly with the count when the list IS filtered.
+        */
+       public function test_display_mfa_disabled_notice_shows_correct_message_when_filtered() {
+        $this->set_admin_screen_users();
+        $_GET['filter_mfa_disabled'] = '1'; // Activate the filter
+      
+        // We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id)
+        $expected_count = 1;
+        $show_all_url = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
+        $expected_output = sprintf(
+        	'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Notice class is notice-info when filtered
+        	sprintf(
+        		_n(
+        			'Showing %d user without MFA enabled.',
+        			'Showing %d users without MFA enabled.',
+        			$expected_count,
+        			'wpvip'
+        		),
+        		number_format_i18n( $expected_count )
+        	),
+        	esc_url( $show_all_url ),
+        	esc_html__( 'Show all users.', 'wpvip' )
+        );
+      
+        ob_start();
+        Highlight_MFA_Users::display_mfa_disabled_notice();
+        $output = ob_get_clean();
+      
+        $this->assertEquals($expected_output, $output);
+      
+        unset($_GET['filter_mfa_disabled']); // Clean up
     }
 
      /**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -1,0 +1,269 @@
+<?php
+if ( ! class_exists( 'Two_Factor_Core' ) ) {
+    class Two_Factor_Core {
+        /** @var array<int> Stores user IDs that the mock should treat as MFA enabled */
+        public static $mock_enabled_user_ids = [];
+
+        public static function is_user_using_two_factor( $user_id ) {
+            return in_array( (int) $user_id, self::$mock_enabled_user_ids, true );
+        }
+    }
+}
+
+use Automattic\VIP\Security\MFAUsers\Highlight_MFA_Users;
+use WP_User_Query;
+
+class HighlightMFAUsersTest extends WP_UnitTestCase {
+    private $admin_user_mfa_enabled_id;
+    private $admin_user_mfa_disabled_id;
+    private $admin_user_mfa_skipped_id;
+    private $editor_user_id;
+    private $original_get;
+    private $original_current_screen;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        Two_Factor_Core::$mock_enabled_user_ids = [];
+
+        $this->original_get = $_GET;
+        $this->original_current_screen = $GLOBALS['current_screen'] ?? null;
+
+        $this->admin_user_mfa_enabled_id = $this->factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        Two_Factor_Core::$mock_enabled_user_ids[] = $this->admin_user_mfa_enabled_id;
+
+        $this->admin_user_mfa_disabled_id = $this->factory()->user->create([
+            'role' => 'administrator',
+        ]);
+
+        $this->admin_user_mfa_skipped_id = $this->factory()->user->create([
+            'role' => 'administrator',
+        ]);
+        
+        $this->editor_user_id = $this->factory()->user->create([
+            'role' => 'editor',
+        ]);
+
+        // Set skipped users option
+        update_option(Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY, [$this->admin_user_mfa_skipped_id]);
+
+        Highlight_MFA_Users::init();
+    }
+
+    public function tearDown(): void {
+        // Clean up users
+        wp_delete_user($this->admin_user_mfa_enabled_id);
+        wp_delete_user($this->admin_user_mfa_disabled_id);
+        wp_delete_user($this->admin_user_mfa_skipped_id);
+        wp_delete_user($this->editor_user_id);
+
+        // Clean up options
+        delete_option(Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY);
+
+        // No need to restore config state manually as setUp handles it or tests run isolated.
+
+        // Restore original $_GET and screen
+        $_GET = $this->original_get;
+        $GLOBALS['current_screen'] = $this->original_current_screen;
+        unset($GLOBALS['current_screen']); // Ensure it's fully removed if it wasn't set before
+
+        parent::tearDown();
+    }
+
+    /**
+     * Helper to simulate being on the users.php admin page.
+     */
+    private function set_admin_screen_users() {
+        // Set the global $pagenow and $current_screen for the tested function
+        global $pagenow;
+        $pagenow = 'users.php';
+        // Use set_current_screen if available, otherwise manually set the global
+        if ( function_exists( 'set_current_screen' ) ) {
+             set_current_screen('users');
+        } else {
+             // Mock the screen object if the function isn't available in this context
+             $screen = new \stdClass();
+             $screen->id = 'users';
+             $screen->base = 'users';
+             $GLOBALS['current_screen'] = $screen;
+        }
+    }
+
+    /**
+     * Test that the filter correctly identifies and includes only MFA-disabled administrators
+     * when the filter GET parameter is set.
+     */
+    public function test_filter_users_by_mfa_status_applies_filter() {
+        $this->set_admin_screen_users();
+        $_GET['filter_mfa_disabled'] = '1';
+
+        $query = new \WP_User_Query();
+        Highlight_MFA_Users::filter_users_by_mfa_status($query);
+
+        $meta_query = $query->get('meta_query');
+        $role_query = $query->get('role__in');
+        $exclude_query = $query->get('exclude');
+
+        
+        $this->assertIsArray($meta_query);
+        $mfa_meta_clause_found = false;
+        foreach ($meta_query as $clause) {
+            if (isset($clause['relation']) && $clause['relation'] === 'OR' && count($clause) === 4) { // 3 conditions + relation key
+                 $mfa_meta_clause_found = true;
+                 break;
+            }
+        }
+        $this->assertTrue($mfa_meta_clause_found, 'MFA status meta query clause not found.');
+
+
+        $this->assertEquals(['administrator'], $role_query);
+
+        $this->assertIsArray($exclude_query);
+        $this->assertContains($this->admin_user_mfa_skipped_id, $exclude_query);
+
+        unset($_GET['filter_mfa_disabled']);
+    }
+
+    /**
+     * Test that the filter does nothing if the GET parameter is not set.
+     */
+    public function test_filter_users_by_mfa_status_does_nothing_without_param() {
+        $this->set_admin_screen_users();
+        unset($_GET['filter_mfa_disabled']);
+
+        $query = new \WP_User_Query();
+        $original_meta_query = $query->get('meta_query');
+        $original_role_query = $query->get('role__in');
+        $original_exclude_query = $query->get('exclude');
+
+        Highlight_MFA_Users::filter_users_by_mfa_status($query);
+
+        // Assert that the query parameters were not modified
+        $this->assertEquals($original_meta_query, $query->get('meta_query'));
+        $this->assertEquals($original_role_query, $query->get('role__in'));
+        $this->assertEquals($original_exclude_query, $query->get('exclude'));
+    }
+
+     /**
+     * Test that the filter does nothing if not on the users.php page.
+     */
+    public function test_filter_users_by_mfa_status_does_nothing_on_wrong_page() {
+        global $pagenow;
+        $pagenow = 'edit.php';
+         // Use set_current_screen if available, otherwise manually set the global
+        if ( function_exists( 'set_current_screen' ) ) {
+             set_current_screen('edit-post');
+        } else {
+             // Mock the screen object if the function isn't available in this context
+             $screen = new \stdClass();
+             $screen->id = 'edit-post';
+             $screen->base = 'edit';
+             $GLOBALS['current_screen'] = $screen;
+        }
+        $_GET['filter_mfa_disabled'] = '1'; // Set the param
+
+        $query = new \WP_User_Query();
+        $original_meta_query = $query->get('meta_query');
+        $original_role_query = $query->get('role__in');
+        $original_exclude_query = $query->get('exclude');
+
+        Highlight_MFA_Users::filter_users_by_mfa_status($query);
+
+        // Assert that the query parameters were not modified
+        $this->assertEquals($original_meta_query, $query->get('meta_query'));
+        $this->assertEquals($original_role_query, $query->get('role__in'));
+        $this->assertEquals($original_exclude_query, $query->get('exclude'));
+
+        unset($_GET['filter_mfa_disabled']);
+    }
+
+    /**
+     * Test that the admin notice is displayed correctly when MFA-disabled admins exist.
+     */
+    public function test_display_mfa_disabled_notice_shows_when_needed() {
+        $this->set_admin_screen_users();
+        // We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id)
+        // The skipped admin ($this->admin_user_mfa_skipped_id) should be ignored by the notice logic.
+        // The notice logic uses Two_Factor_Core::is_user_using_two_factor which we've mocked.
+        $expected_count = 1; // Only admin_user_mfa_disabled_id should be counted
+        $filter_url = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+        $expected_output = sprintf(
+            '<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+            sprintf(
+                _n(
+                    'There is %d administrator with MFA disabled.',
+                    'There are %d administrators with MFA disabled.',
+                    $expected_count,
+                    'wpvip'
+                ),
+                number_format_i18n( $expected_count )
+            ),
+            esc_url( $filter_url ),
+            esc_html__( 'Filter list to show these users.', 'wpvip' )
+        );
+
+        ob_start();
+        // We need to ensure the action is hooked before calling it directly
+        // In a real scenario, WP would trigger this via do_action('admin_notices')
+        // For isolated testing, we call the method directly after ensuring hooks via init() in setUp.
+        Highlight_MFA_Users::display_mfa_disabled_notice();
+        $output = ob_get_clean();
+
+        $this->assertEquals($expected_output, $output);
+    }
+
+     /**
+     * Test that the admin notice is not displayed on the wrong screen.
+     */
+    public function test_display_mfa_disabled_notice_hides_on_wrong_screen() {
+        // Set screen to something else
+        global $pagenow;
+        $pagenow = 'edit.php';
+         if ( function_exists( 'set_current_screen' ) ) {
+             set_current_screen('edit-post');
+        } else {
+             $screen = new \stdClass(); $screen->id = 'edit-post'; $screen->base = 'edit'; $GLOBALS['current_screen'] = $screen;
+        }
+
+        // Expect no output
+        ob_start();
+        Highlight_MFA_Users::display_mfa_disabled_notice();
+        $output = ob_get_clean();
+        $this->assertEmpty($output);
+    }
+
+    /**
+     * Test that the admin notice is not displayed if all admins have MFA enabled or are skipped.
+     */
+    public function test_display_mfa_disabled_notice_hides_when_no_disabled_admins() {
+        $this->set_admin_screen_users();
+        // Temporarily tell the mock that the MFA-disabled user is enabled for this test
+        Two_Factor_Core::$mock_enabled_user_ids[] = $this->admin_user_mfa_disabled_id;
+        
+
+        // Expect no output
+        ob_start();
+        Highlight_MFA_Users::display_mfa_disabled_notice();
+        $output = ob_get_clean();
+        $this->assertEmpty($output);
+    }
+
+    /**
+     * Test that the init function hooks actions correctly.
+     */
+    public function test_init_hooks_actions_correctly() {
+         remove_all_actions('admin_notices');
+         remove_all_actions('pre_get_users');
+
+         Highlight_MFA_Users::init();
+
+         $this->assertNotFalse(has_action('admin_notices', [Highlight_MFA_Users::class, 'display_mfa_disabled_notice']));
+         $this->assertEquals(10, has_action('admin_notices', [Highlight_MFA_Users::class, 'display_mfa_disabled_notice']));
+
+         $this->assertNotFalse(has_action('pre_get_users', [Highlight_MFA_Users::class, 'filter_users_by_mfa_status']));
+         $this->assertEquals(10, has_action('pre_get_users', [Highlight_MFA_Users::class, 'filter_users_by_mfa_status']));
+    }
+}


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description

Added a notice for administrators to see which users does not have MFA enabled.
- MFA is only required for MFA users.
- Notice is only displayed for Administrators.

<img width="1343" alt="image" src="https://github.com/user-attachments/assets/5453b6dd-83a6-4e09-9760-d8c1644f46a5" />

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
2. `vip dev-env create && vip dev-env start`
3. Add test users
```
vip dev-env shell
wp user generate --count=5 --role=administrator
```
4. Navigate to [wp-admin/users](http://vip-security-boost.vipdev.lndo.site/wp-admin/users.php)
5. Verify you see the notice for users without MFA
6. Try to setup MFA for one user > Notice should update with the correct number
