### PR TITLE
Add XML-RPC module to allow disabling XML-RPC for a site

### DIFF
--- a/.wpvip/vip-dev-env.yml.ejs
+++ b/.wpvip/vip-dev-env.yml.ejs
@@ -2,7 +2,7 @@ configuration-version: 1
 slug: vip-security-boost
 title: VIP Security Boost
 php: 8.2
-wordpress: 6.7
+wordpress: 6.8
 app-code: image
 mu-plugins: image
 multisite: true

--- a/.wpvip/vip-dev-env.yml.ejs
+++ b/.wpvip/vip-dev-env.yml.ejs
@@ -6,7 +6,7 @@ wordpress: 6.8
 app-code: image
 mu-plugins: image
 multisite: true
-phpmyadmin: false
+phpmyadmin: true
 elasticsearch: false
 xdebug: true
 mailpit: false

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,11 @@
 	},
 	"require-dev": {
 		"automattic/vipwpcs": "^3",
+		"guzzlehttp/guzzle": "^7.9",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^9",
-		"yoast/phpunit-polyfills": "3.0.0",
-		"wp-phpunit/wp-phpunit": "^6.5"
+		"wp-phpunit/wp-phpunit": "^6.5",
+		"yoast/phpunit-polyfills": "3.0.0"
 	},
 	"autoload-dev": {
 		"classmap": [
@@ -31,6 +32,7 @@
 		"lint": "./vendor/bin/phpcs --standard=.phpcs.xml.dist",
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
 		"phpcs": "./vendor/bin/phpcs",
-		"test": "./bin/test.sh --php 8.2 --wp 6.5"
+		"test": "./bin/test.sh --php 8.2 --wp 6.5",
+		"test:integration": "./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "494fa388f50041001a9ff5f5829cb980",
+	"content-hash": "f2cdaf76c645b0cf40164c8a3a03f5b9",
 	"packages": [],
 	"packages-dev": [
 		{
@@ -911,6 +911,331 @@
 				}
 			],
 			"time": "2024-08-06T10:04:20+00:00"
+		},
+		{
+			"name": "guzzlehttp/guzzle",
+			"version": "7.9.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/guzzle/guzzle.git",
+				"reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+				"reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+				"shasum": ""
+			},
+			"require": {
+				"ext-json": "*",
+				"guzzlehttp/promises": "^1.5.3 || ^2.0.3",
+				"guzzlehttp/psr7": "^2.7.0",
+				"php": "^7.2.5 || ^8.0",
+				"psr/http-client": "^1.0",
+				"symfony/deprecation-contracts": "^2.2 || ^3.0"
+			},
+			"provide": {
+				"psr/http-client-implementation": "1.0"
+			},
+			"require-dev": {
+				"bamarni/composer-bin-plugin": "^1.8.2",
+				"ext-curl": "*",
+				"guzzle/client-integration-tests": "3.0.2",
+				"php-http/message-factory": "^1.1",
+				"phpunit/phpunit": "^8.5.39 || ^9.6.20",
+				"psr/log": "^1.1 || ^2.0 || ^3.0"
+			},
+			"suggest": {
+				"ext-curl": "Required for CURL handler support",
+				"ext-intl": "Required for Internationalized Domain Name (IDN) support",
+				"psr/log": "Required for using the Log middleware"
+			},
+			"type": "library",
+			"extra": {
+				"bamarni-bin": {
+					"bin-links": true,
+					"forward-command": false
+				}
+			},
+			"autoload": {
+				"files": [
+					"src/functions_include.php"
+				],
+				"psr-4": {
+					"GuzzleHttp\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Graham Campbell",
+					"email": "hello@gjcampbell.co.uk",
+					"homepage": "https://github.com/GrahamCampbell"
+				},
+				{
+					"name": "Michael Dowling",
+					"email": "mtdowling@gmail.com",
+					"homepage": "https://github.com/mtdowling"
+				},
+				{
+					"name": "Jeremy Lindblom",
+					"email": "jeremeamia@gmail.com",
+					"homepage": "https://github.com/jeremeamia"
+				},
+				{
+					"name": "George Mponos",
+					"email": "gmponos@gmail.com",
+					"homepage": "https://github.com/gmponos"
+				},
+				{
+					"name": "Tobias Nyholm",
+					"email": "tobias.nyholm@gmail.com",
+					"homepage": "https://github.com/Nyholm"
+				},
+				{
+					"name": "Márk Sági-Kazár",
+					"email": "mark.sagikazar@gmail.com",
+					"homepage": "https://github.com/sagikazarmark"
+				},
+				{
+					"name": "Tobias Schultze",
+					"email": "webmaster@tubo-world.de",
+					"homepage": "https://github.com/Tobion"
+				}
+			],
+			"description": "Guzzle is a PHP HTTP client library",
+			"keywords": [
+				"client",
+				"curl",
+				"framework",
+				"http",
+				"http client",
+				"psr-18",
+				"psr-7",
+				"rest",
+				"web service"
+			],
+			"support": {
+				"issues": "https://github.com/guzzle/guzzle/issues",
+				"source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/GrahamCampbell",
+					"type": "github"
+				},
+				{
+					"url": "https://github.com/Nyholm",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+					"type": "tidelift"
+				}
+			],
+			"time": "2025-03-27T13:37:11+00:00"
+		},
+		{
+			"name": "guzzlehttp/promises",
+			"version": "2.2.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/guzzle/promises.git",
+				"reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+				"reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2.5 || ^8.0"
+			},
+			"require-dev": {
+				"bamarni/composer-bin-plugin": "^1.8.2",
+				"phpunit/phpunit": "^8.5.39 || ^9.6.20"
+			},
+			"type": "library",
+			"extra": {
+				"bamarni-bin": {
+					"bin-links": true,
+					"forward-command": false
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"GuzzleHttp\\Promise\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Graham Campbell",
+					"email": "hello@gjcampbell.co.uk",
+					"homepage": "https://github.com/GrahamCampbell"
+				},
+				{
+					"name": "Michael Dowling",
+					"email": "mtdowling@gmail.com",
+					"homepage": "https://github.com/mtdowling"
+				},
+				{
+					"name": "Tobias Nyholm",
+					"email": "tobias.nyholm@gmail.com",
+					"homepage": "https://github.com/Nyholm"
+				},
+				{
+					"name": "Tobias Schultze",
+					"email": "webmaster@tubo-world.de",
+					"homepage": "https://github.com/Tobion"
+				}
+			],
+			"description": "Guzzle promises library",
+			"keywords": [
+				"promise"
+			],
+			"support": {
+				"issues": "https://github.com/guzzle/promises/issues",
+				"source": "https://github.com/guzzle/promises/tree/2.2.0"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/GrahamCampbell",
+					"type": "github"
+				},
+				{
+					"url": "https://github.com/Nyholm",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+					"type": "tidelift"
+				}
+			],
+			"time": "2025-03-27T13:27:01+00:00"
+		},
+		{
+			"name": "guzzlehttp/psr7",
+			"version": "2.7.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/guzzle/psr7.git",
+				"reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+				"reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2.5 || ^8.0",
+				"psr/http-factory": "^1.0",
+				"psr/http-message": "^1.1 || ^2.0",
+				"ralouphie/getallheaders": "^3.0"
+			},
+			"provide": {
+				"psr/http-factory-implementation": "1.0",
+				"psr/http-message-implementation": "1.0"
+			},
+			"require-dev": {
+				"bamarni/composer-bin-plugin": "^1.8.2",
+				"http-interop/http-factory-tests": "0.9.0",
+				"phpunit/phpunit": "^8.5.39 || ^9.6.20"
+			},
+			"suggest": {
+				"laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+			},
+			"type": "library",
+			"extra": {
+				"bamarni-bin": {
+					"bin-links": true,
+					"forward-command": false
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"GuzzleHttp\\Psr7\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Graham Campbell",
+					"email": "hello@gjcampbell.co.uk",
+					"homepage": "https://github.com/GrahamCampbell"
+				},
+				{
+					"name": "Michael Dowling",
+					"email": "mtdowling@gmail.com",
+					"homepage": "https://github.com/mtdowling"
+				},
+				{
+					"name": "George Mponos",
+					"email": "gmponos@gmail.com",
+					"homepage": "https://github.com/gmponos"
+				},
+				{
+					"name": "Tobias Nyholm",
+					"email": "tobias.nyholm@gmail.com",
+					"homepage": "https://github.com/Nyholm"
+				},
+				{
+					"name": "Márk Sági-Kazár",
+					"email": "mark.sagikazar@gmail.com",
+					"homepage": "https://github.com/sagikazarmark"
+				},
+				{
+					"name": "Tobias Schultze",
+					"email": "webmaster@tubo-world.de",
+					"homepage": "https://github.com/Tobion"
+				},
+				{
+					"name": "Márk Sági-Kazár",
+					"email": "mark.sagikazar@gmail.com",
+					"homepage": "https://sagikazarmark.hu"
+				}
+			],
+			"description": "PSR-7 message implementation that also provides common utility methods",
+			"keywords": [
+				"http",
+				"message",
+				"psr-7",
+				"request",
+				"response",
+				"stream",
+				"uri",
+				"url"
+			],
+			"support": {
+				"issues": "https://github.com/guzzle/psr7/issues",
+				"source": "https://github.com/guzzle/psr7/tree/2.7.1"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/GrahamCampbell",
+					"type": "github"
+				},
+				{
+					"url": "https://github.com/Nyholm",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+					"type": "tidelift"
+				}
+			],
+			"time": "2025-03-27T12:30:47+00:00"
 		},
 		{
 			"name": "myclabs/deep-copy",
@@ -2325,6 +2650,166 @@
 			"time": "2021-11-05T16:47:00+00:00"
 		},
 		{
+			"name": "psr/http-client",
+			"version": "1.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-fig/http-client.git",
+				"reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+				"reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.0 || ^8.0",
+				"psr/http-message": "^1.0 || ^2.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Psr\\Http\\Client\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "PHP-FIG",
+					"homepage": "https://www.php-fig.org/"
+				}
+			],
+			"description": "Common interface for HTTP clients",
+			"homepage": "https://github.com/php-fig/http-client",
+			"keywords": [
+				"http",
+				"http-client",
+				"psr",
+				"psr-18"
+			],
+			"support": {
+				"source": "https://github.com/php-fig/http-client"
+			},
+			"time": "2023-09-23T14:17:50+00:00"
+		},
+		{
+			"name": "psr/http-factory",
+			"version": "1.1.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-fig/http-factory.git",
+				"reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+				"reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.1",
+				"psr/http-message": "^1.0 || ^2.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Psr\\Http\\Message\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "PHP-FIG",
+					"homepage": "https://www.php-fig.org/"
+				}
+			],
+			"description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+			"keywords": [
+				"factory",
+				"http",
+				"message",
+				"psr",
+				"psr-17",
+				"psr-7",
+				"request",
+				"response"
+			],
+			"support": {
+				"source": "https://github.com/php-fig/http-factory"
+			},
+			"time": "2024-04-15T12:06:14+00:00"
+		},
+		{
+			"name": "psr/http-message",
+			"version": "2.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-fig/http-message.git",
+				"reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+				"reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2 || ^8.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Psr\\Http\\Message\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "PHP-FIG",
+					"homepage": "https://www.php-fig.org/"
+				}
+			],
+			"description": "Common interface for HTTP messages",
+			"homepage": "https://github.com/php-fig/http-message",
+			"keywords": [
+				"http",
+				"http-message",
+				"psr",
+				"psr-7",
+				"request",
+				"response"
+			],
+			"support": {
+				"source": "https://github.com/php-fig/http-message/tree/2.0"
+			},
+			"time": "2023-04-04T09:54:51+00:00"
+		},
+		{
 			"name": "psr/log",
 			"version": "3.0.2",
 			"source": {
@@ -2373,6 +2858,50 @@
 				"source": "https://github.com/php-fig/log/tree/3.0.2"
 			},
 			"time": "2024-09-11T13:17:53+00:00"
+		},
+		{
+			"name": "ralouphie/getallheaders",
+			"version": "3.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/ralouphie/getallheaders.git",
+				"reference": "120b605dfeb996808c31b6477290a714d356e822"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+				"reference": "120b605dfeb996808c31b6477290a714d356e822",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.6"
+			},
+			"require-dev": {
+				"php-coveralls/php-coveralls": "^2.1",
+				"phpunit/phpunit": "^5 || ^6.5"
+			},
+			"type": "library",
+			"autoload": {
+				"files": [
+					"src/getallheaders.php"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Ralph Khattar",
+					"email": "ralph.khattar@gmail.com"
+				}
+			],
+			"description": "A polyfill for getallheaders.",
+			"support": {
+				"issues": "https://github.com/ralouphie/getallheaders/issues",
+				"source": "https://github.com/ralouphie/getallheaders/tree/develop"
+			},
+			"time": "2019-03-08T08:55:37+00:00"
 		},
 		{
 			"name": "sebastian/cli-parser",

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -15,6 +15,12 @@ class Xml_Rpc {
 		$xmlrpc_configs = $module_configs['xml-rpc'] ?? [];
 		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'DISABLE' );
 
+		if ( vip_is_jetpack_request() ) {
+			// Jetpack is allowed to use XML-RPC.
+			error_log( 'Allowing Jetpack to use XML-RPC' );
+			return;
+		}
+
 		switch ( self::$mode ) {
 			case 'DISABLE':
 				// Completely disable XML-RPC.

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -1,0 +1,30 @@
+<?php
+namespace Automattic\VIP\Security\XmlRpc;
+
+class Xml_Rpc {
+	private static $disabled;
+
+	public static function init() {
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			error_log( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
+			return;
+		}
+
+		$configs        = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
+		$xmlrpc_configs = $configs['xml-rpc'] ?? [];
+		self::$disabled = $xmlrpc_configs['disabled'] ?? false;
+
+		if ( self::$disabled ) {
+			self::disable_xml_rpc();
+		}
+	}
+
+	/**
+	 * Disable XML-RPC by returning false to the xmlrpc_enabled filter.
+	 */
+	private static function disable_xml_rpc() {
+		add_filter( 'xmlrpc_enabled', '__return_false', PHP_INT_MAX );
+	}
+}
+
+Xml_Rpc::init();

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -2,7 +2,7 @@
 namespace Automattic\VIP\Security\XmlRpc;
 
 class Xml_Rpc {
-	private static $disabled;
+	private static $mode = 'DISABLE';
 
 	public static function init() {
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
@@ -13,10 +13,19 @@ class Xml_Rpc {
 		$configs        = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 		$module_configs = $configs[ 'module_configs' ] ?? [];
 		$xmlrpc_configs = $module_configs['xml-rpc'] ?? [];
-		self::$disabled = $xmlrpc_configs['disabled'] ?? false;
+		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'DISABLE' );
 
-		if ( self::$disabled ) {
-			self::disable_xml_rpc();
+		switch ( self::$mode ) {
+			case 'RESTRICT':
+				// Restrict XML-RPC to only allow Application Passwords.
+				self::restrict_xmlrpc();
+				break;
+
+			case 'DISABLE':
+			default:
+				// Completely disable XML-RPC.
+				self::disable_xml_rpc();
+				break;
 		}
 	}
 
@@ -46,6 +55,29 @@ class Xml_Rpc {
 			header('HTTP/1.1 403 Forbidden');
 			exit('Access to XML-RPC is disabled on this site.');
 		});
+	}
+
+	/**
+	 * Restrict XML-RPC
+	 */
+	public static function restrict_xmlrpc() {
+		// Only act during XML-RPC requests.
+		if ( self::is_xmlrpc_request() ) {
+			// Remove the filters responsible for username/password and email/password authentication.
+			// Priority 20 must match the priority used when they were added.
+			// See https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L500-L503
+			remove_filter( 'authenticate', 'wp_authenticate_username_password', 20 );
+			remove_filter( 'authenticate', 'wp_authenticate_email_password', 20 );
+		}
+	}
+
+	/**
+	 * Check if the current request is an XML-RPC request.
+	 *
+	 * @return bool True if the request is an XML-RPC request, false otherwise.
+	 */
+	private static function is_xmlrpc_request() {
+		return defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
 	}
 }
 

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -16,15 +16,15 @@ class Xml_Rpc {
 		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'DISABLE' );
 
 		switch ( self::$mode ) {
-			case 'RESTRICT':
-				// Restrict XML-RPC to only allow Application Passwords.
-				self::restrict_xmlrpc();
-				break;
-
 			case 'DISABLE':
-			default:
 				// Completely disable XML-RPC.
 				self::disable_xml_rpc();
+				break;
+
+			case 'RESTRICT':
+			default:
+				// Restrict XML-RPC to only allow Application Passwords.
+				self::restrict_xmlrpc();
 				break;
 		}
 	}

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -6,7 +6,8 @@ class Xml_Rpc {
 
 	public static function init() {
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-			error_log( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
 			return;
 		}
 
@@ -17,7 +18,6 @@ class Xml_Rpc {
 
 		if ( vip_is_jetpack_request() ) {
 			// Jetpack is allowed to use XML-RPC.
-			error_log( 'Allowing Jetpack to use XML-RPC' );
 			return;
 		}
 
@@ -60,6 +60,7 @@ class Xml_Rpc {
 		add_filter('wp_xmlrpc_server_class', function( $class ) {
 			header('HTTP/1.1 403 Forbidden');
 			exit('Access to XML-RPC is disabled on this site.');
+			return $class;
 		});
 	}
 

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -11,7 +11,8 @@ class Xml_Rpc {
 		}
 
 		$configs        = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
-		$xmlrpc_configs = $configs['xml-rpc'] ?? [];
+		$module_configs = $configs[ 'module_configs' ] ?? [];
+		$xmlrpc_configs = $module_configs['xml-rpc'] ?? [];
 		self::$disabled = $xmlrpc_configs['disabled'] ?? false;
 
 		if ( self::$disabled ) {
@@ -20,10 +21,31 @@ class Xml_Rpc {
 	}
 
 	/**
-	 * Disable XML-RPC by returning false to the xmlrpc_enabled filter.
+	 * Disable XML-RPC
 	 */
-	private static function disable_xml_rpc() {
+	public static function disable_xml_rpc() {
+		// Disable XML-RPC methods that require authentication.
 		add_filter( 'xmlrpc_enabled', '__return_false', PHP_INT_MAX );
+
+		// Remove the “Really Simple Discovery” link from the header.
+		remove_action( 'wp_head', 'rsd_link' );
+
+		// Remove the X-Pingback HTTP header.
+		add_filter( 'wp_headers', function( $headers ) {
+			if ( isset( $headers['X-Pingback'] ) ) {
+				unset( $headers['X-Pingback'] );
+			}
+			return $headers;
+		}, PHP_INT_MAX, 1 );
+
+		// Return an empty array for all XML-RPC methods.
+		add_filter( 'xmlrpc_methods', '__return_empty_array', PHP_INT_MAX );
+
+		// Disable XML-RPC completely by returning a 403 Forbidden header.
+		add_filter('wp_xmlrpc_server_class', function( $class ) {
+			header('HTTP/1.1 403 Forbidden');
+			exit('Access to XML-RPC is disabled on this site.');
+		});
 	}
 }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,7 +25,6 @@
 			<directory>bin</directory>
 			<directory>mu_plugins</directory>
 			<directory>docs</directory>
-			<directory>modules</directory>
 			<directory>vendor</directory>
 			<directory>vip-config</directory>
 		</exclude>

--- a/tests/integration/XmlRpcTest.php
+++ b/tests/integration/XmlRpcTest.php
@@ -5,6 +5,11 @@ namespace Tests\Integration;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Client;
 
+$client = new Client([
+    'base_uri' => 'http://vip-security-boost.vipdev.lndo.site',
+    'http_errors' => false,
+]);
+
 class XmlRpcTest extends TestCase
 {
     /**
@@ -14,7 +19,8 @@ class XmlRpcTest extends TestCase
      */
     public function testXmlRpcReturns403WhenDisabled(): void
     {
-        $url = 'http://vip-security-boost.vipdev.lndo.site/xmlrpc.php';
+        global $client;
+        $url = '/xmlrpc.php';
 
         $xmlPayload = <<<XML
         <?xml version="1.0"?>
@@ -24,26 +30,8 @@ class XmlRpcTest extends TestCase
             </methodCall>
         XML;
 
-        $headers = [
-            'X-Integration-Test' => 'true',
-            'X-Integration-Test-Configs' => json_encode(
-                array(
-                    'enabled_modules' => [ 'xml-rpc' ],
-                    'module_configs' => array(
-                        'xml-rpc' => array(
-                            'mode' => 'DISABLE',
-                        ),
-                    ),
-                )
-            ),
-        ];
-
-        $client = new Client([
-            'headers' => $headers,
-            'http_errors' => false,
-            'timeout' => 10.0,
-        ]);
         $response = $client->request('POST', $url, [
+            'headers' => $this->build_request_headers( 'DISABLE' ),
             'body' => $xmlPayload,
         ]);
 
@@ -51,6 +39,263 @@ class XmlRpcTest extends TestCase
             403,
             $response->getStatusCode(),
             "Expected HTTP status code 403 Forbidden, but received {$response->getStatusCode()}."
+        );
+    }
+
+    /**
+     * Test that accessing XML-RPC endpoint returns 200 OK when module is disabled.
+     *
+     * @return void
+     */
+    public function testXmlRpcReturns200WhenModuleDisabled(): void
+    {
+        global $client;
+        $url = '/xmlrpc.php';
+
+        $xmlPayload = <<<XML
+        <?xml version="1.0"?>
+        <methodCall>
+            <methodName>system.listMethods</methodName>
+            <params></params>
+        </methodCall>
+        XML;
+
+        $response = $client->request('POST', $url, [
+            'headers' => array( [
+                'X-Integration-Test' => 'true',
+                'X-Integration-Test-Configs' => $this->encode_config_header(
+                    array(
+                        'enabled_modules' => [],
+                    )
+                ),
+            ] ),
+            'body' => $xmlPayload,
+        ]);
+
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+            "Expected HTTP status code 200 OK, but received {$response->getStatusCode()}."
+        );
+    }
+
+    /**
+     * Test that login/password fails when mode is RESTRICT
+     *
+     * @return void
+     */
+    public function testXmlRpcAuthFailsWithUsernameAndPasswordWhenModeIsRestrict(): void
+    {
+        global $client;
+        $url = '/xmlrpc.php';
+        $username = 'vipgo';
+        $password = 'password';
+
+        $xmlPayload = <<<XML
+        <?xml version="1.0"?>
+        <methodCall>
+            <methodName>wp.getUsersBlogs</methodName>
+            <params>
+                <param><value><string>{$username}</string></value></param>
+                <param><value><string>{$password}</string></value></param>
+            </params>
+        </methodCall>
+        XML;
+
+        $response = $client->request('POST', $url, [
+            'auth' => [ $username, $password ],
+            'headers' => $this->build_request_headers( 'RESTRICT' ),
+            'body' => $xmlPayload,
+        ]);
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+            <methodResponse>
+                <fault>
+                    <value>
+                        <struct>
+                            <member>
+                                <name>faultCode</name>
+                                <value><int>403</int></value>
+                            </member>
+                            <member>
+                                <name>faultString</name>
+                                <value><string>Incorrect username or password.</string></value>
+                            </member>
+                        </struct>
+                    </value>
+                </fault>
+            </methodResponse>
+            XML,
+            $response->getBody()->getContents()
+        );
+    }
+
+    public function testXmlRpcAuthWorksWithEmailAndPasswordWhenModuleIsDisabled(): void
+    {
+        global $client;
+        $url = '/xmlrpc.php';
+        $username = 'vipgo';
+        $password = 'password';
+
+        $xmlPayload = <<<XML
+        <?xml version="1.0"?>
+        <methodCall>
+            <methodName>wp.getUsersBlogs</methodName>
+            <params>
+                <param><value><string>{$username}</string></value></param>
+                <param><value><string>{$password}</string></value></param>
+            </params>
+        </methodCall>
+        XML;
+
+        $response = $client->request('POST', $url, [
+            'headers' => array( [
+                'X-Integration-Test' => 'true',
+                'X-Integration-Test-Configs' => $this->encode_config_header(
+                    array(
+                        'enabled_modules' => [],
+                    )
+                ),
+            ] ),
+            'body' => $xmlPayload,
+        ]);
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+            <methodResponse>
+                <params>
+                    <param>
+                        <value>
+                            <array>
+                                <data>
+                                    <value>
+                                        <struct>
+                                            <member><name>isAdmin</name><value><boolean>1</boolean></value></member>
+                                            <member><name>isPrimary</name><value><boolean>1</boolean></value></member>
+                                            <member><name>url</name><value><string>http://vip-security-boost.vipdev.lndo.site/</string></value></member>
+                                            <member><name>blogid</name><value><string>1</string></value></member>
+                                            <member><name>blogName</name><value><string>VIP Security Boost</string></value></member>
+                                            <member><name>xmlrpc</name><value><string>http://vip-security-boost.vipdev.lndo.site/xmlrpc.php</string></value></member>
+                                        </struct>
+                                    </value>
+                                </data>
+                            </array>    
+                        </value>
+                    </param>
+                </params>
+            </methodResponse>
+            XML,
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * Test that application password login works when mode is RESTRICT
+     *
+     * @return void
+     */
+    public function testXmlRpcAuthSucceedsWithApplicationPasswordWhenModeIsRestrict(): void
+    {
+        global $client;
+        $url = '/xmlrpc.php';
+        $username = 'vipgo';
+        $application_password = $this->generate_application_password();
+
+        $this->assertNotEmpty($application_password, 'Application password should not be empty.');
+
+        $xmlPayload = <<<XML
+        <?xml version="1.0"?>
+        <methodCall>
+            <methodName>wp.getUsersBlogs</methodName>
+            <params>
+                <param><value><string>{$username}</string></value></param>
+                <param><value><string>{$application_password}</string></value></param>
+            </params>
+        </methodCall>
+        XML;
+
+        $response = $client->request('POST', $url, [
+            'headers' => $this->build_request_headers( 'RESTRICT' ),
+            'body' => $xmlPayload,
+            'auth' => [ $username, $application_password ],
+        ]);
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+            <methodResponse>
+                <params>
+                    <param>
+                        <value>
+                            <array>
+                                <data>
+                                    <value>
+                                        <struct>
+                                            <member><name>isAdmin</name><value><boolean>1</boolean></value></member>
+                                            <member><name>isPrimary</name><value><boolean>1</boolean></value></member>
+                                            <member><name>url</name><value><string>http://vip-security-boost.vipdev.lndo.site/</string></value></member>
+                                            <member><name>blogid</name><value><string>1</string></value></member>
+                                            <member><name>blogName</name><value><string>VIP Security Boost</string></value></member>
+                                            <member><name>xmlrpc</name><value><string>http://vip-security-boost.vipdev.lndo.site/xmlrpc.php</string></value></member>
+                                        </struct>
+                                    </value>
+                                </data>
+                            </array>
+                        </value>
+                    </param>
+                </params>
+            </methodResponse>
+            XML,
+            $response->getBody()->getContents()
+        );
+    }
+
+    /**
+     * Generate an application password for the user 'vipgo'.
+     *
+     * @return string The generated application password.
+     */
+    protected function generate_application_password(): string
+    {
+        // Create the application password
+        $command = "vip dev-env exec -- wp user application-password create vipgo 'My PHPUnit App' --porcelain";
+        $cliOutput = shell_exec($command);
+        $trimmedOutput = trim($cliOutput);
+        $lines = explode("\n", $trimmedOutput);
+        $application_password = end($lines);
+        $application_password = trim($application_password);
+
+        return $application_password;
+    }
+
+    /**
+     * Encode the config header.
+     *
+     * @param array $configs The configs to encode.
+     * @return string The encoded configs.
+     */
+    protected function encode_config_header(array $configs): string
+    {
+        return base64_encode(json_encode($configs));
+    }
+
+    /**
+     * Build the request headers.
+     *
+     * @param string $mode The mode to set.
+     * @return array The request headers.
+     */
+    protected function build_request_headers( $mode ): array
+    {
+        return array(
+            'Content-Type' => 'text/xml',
+            'X-Integration-Test' => 'true',
+            'X-Integration-Test-Configs' => $this->encode_config_header(
+                array(
+                    'enabled_modules' => [ 'xml-rpc' ],
+                    'module_configs' => [ 'xml-rpc' => [ 'mode' => $mode ] ],
+                )
+            ),
         );
     }
 }

--- a/tests/integration/XmlRpcTest.php
+++ b/tests/integration/XmlRpcTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Client;
+
+class XmlRpcTest extends TestCase
+{
+    /**
+     * Test that accessing XML-RPC endpoint returns 403 Forbidden when disabled.
+     *
+     * @return void
+     */
+    public function testXmlRpcReturns403WhenDisabled(): void
+    {
+        $url = 'http://vip-security-boost.vipdev.lndo.site/xmlrpc.php';
+
+        $xmlPayload = <<<XML
+        <?xml version="1.0"?>
+            <methodCall>
+                <methodName>system.listMethods</methodName>
+                <params></params>
+            </methodCall>
+        XML;
+
+        $headers = [
+            'X-Integration-Test' => 'true',
+            'X-Integration-Test-Configs' => json_encode(
+                array(
+                    'enabled_modules' => [ 'xml-rpc' ],
+                    'module_configs' => array(
+                        'xml-rpc' => array(
+                            'mode' => 'DISABLE',
+                        ),
+                    ),
+                )
+            ),
+        ];
+
+        $client = new Client([
+            'headers' => $headers,
+            'http_errors' => false,
+            'timeout' => 10.0,
+        ]);
+        $response = $client->request('POST', $url, [
+            'body' => $xmlPayload,
+        ]);
+
+        $this->assertEquals(
+            403,
+            $response->getStatusCode(),
+            "Expected HTTP status code 403 Forbidden, but received {$response->getStatusCode()}."
+        );
+    }
+}

--- a/tests/integration/bootstrap.php
+++ b/tests/integration/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+require_once __DIR__ . '/../class-speedup-isolated-wp-tests.php';

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -3,10 +3,19 @@
 namespace Automattic\VIP\Security\Utils;
 
 function load_integration_configs_from_url() {
+    if ( defined( 'WP_CLI' ) && constant( 'WP_CLI' ) ) {
+        return;
+    }
+
     $config_api_url = vip_get_env_var( 'VIP_CONFIG_API_URL', getenv( 'VIP_CONFIG_API_URL' ) );
-    $endpoint       = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', $config_api_url, constant( 'VIP_GO_APP_ID' ) );
-    $api_error      = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );
-    $response       = vip_safe_wp_remote_get( $endpoint, $api_error, 5, 5, 5, array() );
+
+    if ( ! $config_api_url ) {
+        return;
+    }
+
+    $endpoint  = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', $config_api_url, constant( 'VIP_GO_APP_ID' ) );
+    $api_error = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );
+    $response  = vip_safe_wp_remote_get( $endpoint, $api_error, 5, 5, 5, array() );
 
     if ( is_wp_error( $response ) ) {
         error_log( 'Error: ' . $response->get_error_message() );
@@ -28,6 +37,6 @@ function load_integration_configs_from_url() {
 }
 
 function load_integration_configs_from_headers() {
-    $configs = json_decode( $_SERVER['HTTP_X_INTEGRATION_TEST_CONFIGS'], true );
+    $configs = json_decode( base64_decode( $_SERVER['HTTP_X_INTEGRATION_TEST_CONFIGS'] ), true );
     define( 'VIP_SECURITY_BOOST_CONFIGS', $configs );
 }

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -2,10 +2,11 @@
 
 namespace Automattic\VIP\Security\Utils;
 
-function load_integration_configs() {
-    $endpoint  = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', constant( 'VIP_CONFIG_API_URL' ), constant( 'VIP_GO_APP_ID' ) );
-    $api_error = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );
-    $response  = vip_safe_wp_remote_get( $endpoint, $api_error, 5, 5, 5, array() );
+function load_integration_configs_from_url() {
+    $config_api_url = vip_get_env_var( 'VIP_CONFIG_API_URL', getenv( 'VIP_CONFIG_API_URL' ) );
+    $endpoint       = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', $config_api_url, constant( 'VIP_GO_APP_ID' ) );
+    $api_error      = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );
+    $response       = vip_safe_wp_remote_get( $endpoint, $api_error, 5, 5, 5, array() );
 
     if ( is_wp_error( $response ) ) {
         error_log( 'Error: ' . $response->get_error_message() );
@@ -24,4 +25,9 @@ function load_integration_configs() {
     if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
         define( 'VIP_SECURITY_BOOST_CONFIGS', $body['data']['config'] );
     }
+}
+
+function load_integration_configs_from_headers() {
+    $configs = json_decode( $_SERVER['HTTP_X_INTEGRATION_TEST_CONFIGS'], true );
+    define( 'VIP_SECURITY_BOOST_CONFIGS', $configs );
 }

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -19,7 +19,8 @@ require_once __DIR__ . '/class-integration.php';
 use Automattic\VIP\Integrations\IntegrationsSingleton;
 use Automattic\VIP\Security\Integration;
 
-use function Automattic\VIP\Security\Utils\load_integration_configs;
+use function Automattic\VIP\Security\Utils\load_integration_configs_from_headers;
+use function Automattic\VIP\Security\Utils\load_integration_configs_from_url;
 
 /**
  * Local environment specific configurations.
@@ -34,8 +35,6 @@ if ( $is_local_env ) {
 		define( 'VIP_GO_APP_ID', 101 );
 	}
     
-    define( 'VIP_CONFIG_API_URL', vip_get_env_var( 'VIP_CONFIG_API_URL', getenv( 'VIP_CONFIG_API_URL' ) ) );
-	
     /**
      * Register and activate the integration.
      */
@@ -44,8 +43,14 @@ if ( $is_local_env ) {
     IntegrationsSingleton::instance()->register( $integration );
     IntegrationsSingleton::instance()->activate_platform_integrations();
 
-    // Load the integration configurations from the CONFIG API
-    load_integration_configs();
+    // Check headers for integration test configs
+    if ( isset( $_SERVER['HTTP_X_INTEGRATION_TEST'] ) ) {
+        // Load the integration configurations from the headers
+        load_integration_configs_from_headers();
+    } else {
+        // Load the integration configurations from the CONFIG API
+        load_integration_configs_from_url();
+    }
 
     // Load the integration
     $integration->load();


### PR DESCRIPTION
## Description

Add XML-RPC module to allow disabling XML-RPC for a site. Right now it will only disable it when the `disabled` configuration is explicitly set to `false`.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

### On DISABLE mode

```bash
curl -i --data '<?xml version="1.0"?>
<methodCall>
  <methodName>system.listMethods</methodName>
  <params></params>
</methodCall>' http://vip-security-boost.vipdev.lndo.site/xmlrpc.php
```

should return 

```
HTTP/1.1 403 Forbidden
Content-Type: text/html; charset=UTF-8
Date: Thu, 10 Apr 2025 18:29:51 GMT
Server: nginx/1.27.4
X-Powered-By: PHP/8.2.28
Transfer-Encoding: chunked

Access to XML-RPC is disabled on this site.
````

### On RESTRICT mode

```bash
curl -i \
  -H 'Content-Type: text/xml' \
  -u 'YOUR_WP_USERNAME:YOUR_APPLICATION_PASSWORD' \
  --data '<?xml version="1.0"?>
<methodCall>
  <methodName>wp.getUsersBlogs</methodName>
  <params>
    <param><value><string>vipgo</string></value></param>
    <param><value><string>password</string></value></param>
  </params>
</methodCall>' \
  http://vip-security-boost.vipdev.lndo.site/xmlrpc.php
```

```
HTTP/1.1 200 OK
Content-Type: text/xml; charset=UTF-8
Date: Thu, 10 Apr 2025 19:01:22 +0000
Server: nginx/1.27.4
X-Powered-By: PHP/8.2.28
X-Xmlrpc-Error-Code: 403
Transfer-Encoding: chunked

<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>403</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>Incorrect username or password.</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```

With application passwords

```bash
WP_USERNAME="vipgo"
APP_PASSWORD="yG3K tiWU huae TzPg gj8V wVV8"

curl -i \
  -H 'Content-Type: text/xml' \
  -u "${WP_USERNAME}:${APP_PASSWORD}" \
  --data '<?xml version="1.0"?>
<methodCall>
  <methodName>wp.getUsersBlogs</methodName>
  <params>
    <param><value><string>'"${WP_USERNAME}"'</string></value></param>
    <param><value><string>'"${APP_PASSWORD}"'</string></value></param>
  </params>
</methodCall>' \
  "http://vip-security-boost.vipdev.lndo.site/xmlrpc.php"
```

```
HTTP/1.1 200 OK
Content-Type: text/xml; charset=UTF-8
Date: Thu, 10 Apr 2025 19:10:51 +0000
Server: nginx/1.27.4
X-Powered-By: PHP/8.2.28
Transfer-Encoding: chunked

<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>400</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>Insufficient arguments passed to this XML-RPC method.</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```

## Running Integration Tests

```bash
composer test:integration

The "composer/package-versions-deprecated" plugin was not loaded as it is not listed in allow-plugins and is not required by the root package anymore.
> ./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/
PHPUnit 9.6.22 by Sebastian Bergmann and contributors.

.....                                                               5 / 5 (100%)

Time: 00:02.490, Memory: 6.00 MB

OK (5 tests, 6 assertions)
```