### PR TITLE
Fix config parsing since configs serialized from the k8s ConfigMap can be a string

### DIFF
--- a/modules/inactive-users/inactive-users.php
+++ b/modules/inactive-users/inactive-users.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\VIP\Security\InactiveUsers;
 
+use function Automattic\VIP\Security\Utils\get_module_configs;
 use Automattic\VIP\Utils\Context;
 
 class Inactive_Users {
@@ -22,13 +23,7 @@ class Inactive_Users {
 	private $application_password_authentication_error;
 	
 	public static function init() {
-		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-			return;
-		}
-	
-		$configs               = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
-		$module_configs        = $configs[ 'module_configs' ] ?? [];
-		$inactive_user_configs = $module_configs[ 'inactive-users' ] ?? [];
+		$inactive_user_configs = get_module_configs( 'inactive-users' );
 
 		self::$mode                           = $inactive_user_configs[ 'mode' ] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs[ 'considered_inactive_after_days' ] ?? 90;

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -1,19 +1,13 @@
 <?php
 namespace Automattic\VIP\Security\XmlRpc;
 
+use function Automattic\VIP\Security\Utils\get_module_configs;
+
 class Xml_Rpc {
 	private static $mode = 'DISABLE';
 
 	public static function init() {
-		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-			trigger_error( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
-			return;
-		}
-
-		$configs        = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
-		$module_configs = $configs[ 'module_configs' ] ?? [];
-		$xmlrpc_configs = $module_configs['xml-rpc'] ?? [];
+		$xmlrpc_configs = get_module_configs( 'xml-rpc' );
 		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'DISABLE' );
 
 		if ( vip_is_jetpack_request() ) {

--- a/modules/xml-rpc/xml-rpc.php
+++ b/modules/xml-rpc/xml-rpc.php
@@ -4,11 +4,11 @@ namespace Automattic\VIP\Security\XmlRpc;
 use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Xml_Rpc {
-	private static $mode = 'DISABLE';
+	private static $mode = 'RESTRICT';
 
 	public static function init() {
 		$xmlrpc_configs = get_module_configs( 'xml-rpc' );
-		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'DISABLE' );
+		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'RESTRICT' );
 
 		if ( vip_is_jetpack_request() ) {
 			// Jetpack is allowed to use XML-RPC.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../utils/configs.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -21,29 +21,27 @@ function get_module_configs( $module_name ) {
     $configs = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 
     if ( ! is_array( $configs ) || ! isset( $configs[ 'module_configs' ] ) ) {
-        trigger_error( 'Invalid structure in VIP_SECURITY_BOOST_CONFIGS: \'module_configs\' key not found or constant is not an array.', E_USER_WARNING );
         return [];
     }
+
     $module_configs = $configs[ 'module_configs' ];
+    $current_module_config = [];
 
-    if ( ! is_array( $module_configs ) || ! isset( $module_configs[ $module_name ] ) ) {
-        trigger_error( 'Module configuration not found for module: ' . $module_name, E_USER_NOTICE );
-        return [];
-    }
+    if ( is_array( $module_configs ) && isset( $module_configs[ $module_name ] ) ) {
+        $current_module_config = $module_configs[ $module_name ];
 
-    $current_module_config = $module_configs[ $module_name ];
+        if ( is_string( $current_module_config ) ) {
+            $decoded_config = json_decode( $current_module_config, true );
 
-    if ( is_string( $current_module_config ) ) {
-        $decoded_config = json_decode( $current_module_config, true );
-
-        if ( is_null( $decoded_config ) && json_last_error() !== JSON_ERROR_NONE ) {
-            trigger_error(
-                'Failed to decode JSON configuration for module: ' . $module_name . '. Error (' . json_last_error() . '): ' . json_last_error_msg(),
-                E_USER_WARNING
-            );
-            return [];
+            if ( is_null( $decoded_config ) && json_last_error() !== JSON_ERROR_NONE ) {
+                trigger_error(
+                    'Failed to decode JSON configuration for module: ' . $module_name . '. Error (' . json_last_error() . '): ' . json_last_error_msg(),
+                    E_USER_WARNING
+                );
+                return [];
+            }
+            $current_module_config = $decoded_config;
         }
-        $current_module_config = $decoded_config;
     }
 
     if ( ! is_array( $current_module_config ) ) {

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -1,0 +1,37 @@
+<?php
+namespace Automattic\VIP\Security\Utils;
+
+/**
+ * Get the module configs for a given module name.
+ *
+ * @param string $module_name The name of the module to get the configs for.
+ * @return array The module configs.
+ */
+function get_module_configs( $module_name ) {
+    if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+        trigger_error( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
+        return [];
+    }
+
+    $configs = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
+
+    if ( ! isset( $configs[ 'module_configs' ] ) ) {
+        trigger_error( 'module_configs not found in VIP_SECURITY_BOOST_CONFIGS' );
+        return [];
+    }
+    $module_configs = $configs[ 'module_configs' ];
+
+    if ( ! isset( $module_configs[ $module_name ] ) ) {
+        trigger_error( 'module_configs not found for ' . $module_name );
+        return [];
+    }
+
+    $current_module_config = $module_configs[ $module_name ];
+
+    // if configs is a string, convert it to an array
+    if ( is_string( $current_module_config ) ) {
+        $current_module_config = json_decode( $current_module_config, true );
+    }
+
+    return $current_module_config;
+}

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -4,33 +4,54 @@ namespace Automattic\VIP\Security\Utils;
 /**
  * Get the module configs for a given module name.
  *
+ * Attempts to retrieve configuration for a specific security module.
+ * Configuration is expected to be stored within the VIP_SECURITY_BOOST_CONFIGS constant.
+ * Handles cases where the configuration might be stored as a JSON string.
+ *
  * @param string $module_name The name of the module to get the configs for.
- * @return array The module configs.
+ * @return array The module configs. Returns an empty array if configs are not found,
+ * not defined, or if JSON parsing fails.
  */
 function get_module_configs( $module_name ) {
     if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-        trigger_error( 'VIP_SECURITY_BOOST_CONFIGS not defined' );
+        trigger_error( 'VIP_SECURITY_BOOST_CONFIGS is not defined.', E_USER_WARNING );
         return [];
     }
 
     $configs = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 
-    if ( ! isset( $configs[ 'module_configs' ] ) ) {
-        trigger_error( 'module_configs not found in VIP_SECURITY_BOOST_CONFIGS' );
+    if ( ! is_array( $configs ) || ! isset( $configs[ 'module_configs' ] ) ) {
+        trigger_error( 'Invalid structure in VIP_SECURITY_BOOST_CONFIGS: \'module_configs\' key not found or constant is not an array.', E_USER_WARNING );
         return [];
     }
     $module_configs = $configs[ 'module_configs' ];
 
-    if ( ! isset( $module_configs[ $module_name ] ) ) {
-        trigger_error( 'module_configs not found for ' . $module_name );
+    if ( ! is_array( $module_configs ) || ! isset( $module_configs[ $module_name ] ) ) {
+        trigger_error( 'Module configuration not found for module: ' . $module_name, E_USER_NOTICE );
         return [];
     }
 
     $current_module_config = $module_configs[ $module_name ];
 
-    // if configs is a string, convert it to an array
     if ( is_string( $current_module_config ) ) {
-        $current_module_config = json_decode( $current_module_config, true );
+        $decoded_config = json_decode( $current_module_config, true );
+
+        if ( is_null( $decoded_config ) && json_last_error() !== JSON_ERROR_NONE ) {
+            trigger_error(
+                'Failed to decode JSON configuration for module: ' . $module_name . '. Error (' . json_last_error() . '): ' . json_last_error_msg(),
+                E_USER_WARNING
+            );
+            return [];
+        }
+        $current_module_config = $decoded_config;
+    }
+
+    if ( ! is_array( $current_module_config ) ) {
+        trigger_error(
+            'Module configuration for ' . $module_name . ' resolved to a non-array type after processing. Returning empty array.',
+            E_USER_NOTICE
+        );
+        return [];
     }
 
     return $current_module_config;

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -14,6 +14,7 @@
  * @package vip-security-boost
  */
 
+require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/class-integration.php';
 
 use Automattic\VIP\Integrations\IntegrationsSingleton;


### PR DESCRIPTION
## Description

Testing on the live site revealed that when configs are serialized into PHP - to be loaded by the integrations API in mu-plugins - they are serialized like so:

```php
<?php return array('type' => 'security-boost', 'org' => array('status' => 'enabled'), 'env' => array('status' => 'enabled', 'config' => array('enabled_modules' => 'inactive-users,xml-rpc', 'module_configs' => '{"xml-rpc":{"mode":"RESTRICT"}}', 'version' => 'latest'))); 
```

which means module configs are actually a serialized JSON string. This PR handles that by parsing the JSON string when that happens.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
