### PR TITLE
Fix parsing of json configs. We were trying to decode the wrong level of configs

### DIFF
--- a/tests/phpunit/test-configs.php
+++ b/tests/phpunit/test-configs.php
@@ -1,0 +1,66 @@
+<?php
+
+use WP_UnitTestCase;
+use function Automattic\VIP\Security\Utils\get_module_configs;
+
+class ConfigsTest extends WP_UnitTestCase {
+    public function setUp(): void {
+        parent::setUp();
+        
+        if (!defined('VIP_SECURITY_BOOST_CONFIGS')) {
+            define('VIP_SECURITY_BOOST_CONFIGS', [
+                'module_configs' => '{"inactive_users":{"mode":"BLOCK","considered_inactive_after_days":90}}'
+            ]);
+        }
+    }
+    
+    public function tearDown(): void {
+        parent::tearDown();
+    }
+
+    /**
+     * Test that parsing module_configs string returns the correct array
+     */
+    public function test_parsing_module_configs_string_returns_array() {
+        $configs = [
+            'module_configs' => '{"inactive_users":{"mode":"BLOCK","considered_inactive_after_days":90}}'
+        ];
+        $module_configs = get_module_configs( 'inactive_users', $configs );
+
+        $this->assertIsArray( $module_configs );
+        $this->assertEquals( 'BLOCK', $module_configs['mode'] );
+        $this->assertEquals( 90, $module_configs['considered_inactive_after_days'] );
+    }
+
+    /**
+     * Test that parsing a broken json string returns an empty array
+     */
+    public function test_parsing_broken_json_string_returns_empty_array() {
+        $configs = [
+            'module_configs' => '{////}'
+        ];
+        $module_configs = get_module_configs( 'inactive_users', $configs );
+
+        $this->assertIsArray( $module_configs );
+        $this->assertEquals( [], $module_configs );
+    }
+
+    /**
+     * Test that parsing module_configs string returns the correct array
+     */
+    public function test_parsing_module_configs_array_returns_array() {
+        $configs = [
+            'module_configs' => [
+                'inactive_users' => [
+                    'mode' => 'BLOCK',
+                    'considered_inactive_after_days' => 90
+                ]
+            ]
+        ];
+        $module_configs = get_module_configs( 'inactive_users', $configs );
+
+        $this->assertIsArray( $module_configs );
+        $this->assertEquals( 'BLOCK', $module_configs['mode'] );
+        $this->assertEquals( 90, $module_configs['considered_inactive_after_days'] );
+    }
+}

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -12,13 +12,10 @@ namespace Automattic\VIP\Security\Utils;
  * @return array The module configs. Returns an empty array if configs are not found,
  * not defined, or if JSON parsing fails.
  */
-function get_module_configs( $module_name ) {
-    if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-        trigger_error( 'VIP_SECURITY_BOOST_CONFIGS is not defined.', E_USER_WARNING );
-        return [];
+function get_module_configs( $module_name, $configs = false ) {
+    if ( $configs === false ) {
+        $configs = get_all_module_configs();
     }
-
-    $configs = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 
     if ( ! is_array( $configs ) || ! isset( $configs[ 'module_configs' ] ) ) {
         return [];
@@ -27,30 +24,35 @@ function get_module_configs( $module_name ) {
     $module_configs = $configs[ 'module_configs' ];
     $current_module_config = [];
 
-    if ( is_array( $module_configs ) && isset( $module_configs[ $module_name ] ) ) {
-        $current_module_config = $module_configs[ $module_name ];
+    if ( is_string( $module_configs ) ) {
+        $module_configs = json_decode( $module_configs, true );
 
-        if ( is_string( $current_module_config ) ) {
-            $decoded_config = json_decode( $current_module_config, true );
-
-            if ( is_null( $decoded_config ) && json_last_error() !== JSON_ERROR_NONE ) {
-                trigger_error(
-                    'Failed to decode JSON configuration for module: ' . $module_name . '. Error (' . json_last_error() . '): ' . json_last_error_msg(),
-                    E_USER_WARNING
-                );
-                return [];
-            }
-            $current_module_config = $decoded_config;
+        if ( is_null( $module_configs ) && json_last_error() !== JSON_ERROR_NONE ) {
+            error_log(
+                '[Security Boost] Failed to decode module configs. Error (' . json_last_error() . '): ' . json_last_error_msg()
+            );
+            return [];
         }
     }
 
+    if ( is_array( $module_configs ) && isset( $module_configs[ $module_name ] ) ) {
+        $current_module_config = $module_configs[ $module_name ];        
+    }
+
     if ( ! is_array( $current_module_config ) ) {
-        trigger_error(
-            'Module configuration for ' . $module_name . ' resolved to a non-array type after processing. Returning empty array.',
-            E_USER_NOTICE
+        error_log(
+            '[Security Boost] Module configuration for ' . $module_name . ' resolved to a non-array type after processing. Returning empty array.'
         );
         return [];
     }
 
     return $current_module_config;
+}
+
+function get_all_module_configs() {
+    if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+        trigger_error( '[Security Boost] VIP_SECURITY_BOOST_CONFIGS is not defined.', E_USER_WARNING );
+        return [];
+    }
+    return constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 }


### PR DESCRIPTION
## Description

This is a follow-up on https://github.com/Automattic/vip-security-boost/pull/11 since I implemented incorrectly there. We need to decode `module_configs`.

Also, added unit tests to make sure the behavior is the expected now

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

composer test