### PR TITLE
Allow configuring which capabilities will be blocked after inactivity period

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -21,7 +21,7 @@ class Inactive_Users {
 	 *
 	 * @var \WP_Error|null
 	 */
-	private $application_password_authentication_error;
+	private static $application_password_authentication_error;
 	
 	public static function init() {
 		$inactive_user_configs = get_module_configs( 'inactive-users' );

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -5,8 +5,9 @@ use Automattic\VIP\Utils\Context;
 use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Inactive_Users {
-	private static $mode;
 	private static $considered_inactive_after_days;
+	private static $elevated_capabilities;
+	private static $mode;
 	public static $release_date;
 
 	const LAST_SEEN_META_KEY                               = 'wpvip_last_seen';
@@ -25,9 +26,24 @@ class Inactive_Users {
 	public static function init() {
 		$inactive_user_configs = get_module_configs( 'inactive-users' );
 
+		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
-		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
+		self::$elevated_capabilities          = $inactive_user_configs['elevated_capabilities'] ?? [
+			'edit_posts',
+			'delete_posts',
+			'publish_posts',
+			'edit_pages',
+			'delete_pages',
+			'publish_pages',
+			'edit_others_posts',
+			'edit_others_pages',
+			'manage_options',
+			'edit_users',
+			'promote_users',
+			'activate_plugins',
+			'manage_network',
+		];
 
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );
@@ -371,7 +387,7 @@ class Inactive_Users {
 		 *
 		 * @param array $skip_users The list of user IDs to skip.
 		 */
-		$skip_users = apply_filters( 'vip_security_last_seen_skip_users', array() );
+		$skip_users = apply_filters( 'vip_security_boost_skip_inactive_users', array() );
 		if ( in_array( $user_id, $skip_users, true ) ) {
 			return false;
 		}
@@ -394,21 +410,7 @@ class Inactive_Users {
 		 *
 		 * @param array $elevated_capabilities The elevated capabilities.
 		 */
-		$elevated_capabilities = apply_filters( 'vip_security_last_seen_elevated_capabilities', [
-			'edit_posts',
-			'delete_posts',
-			'publish_posts',
-			'edit_pages',
-			'delete_pages',
-			'publish_pages',
-			'edit_others_posts',
-			'edit_others_pages',
-			'manage_options',
-			'edit_users',
-			'promote_users',
-			'activate_plugins',
-			'manage_network',
-		] );
+		$elevated_capabilities = apply_filters( 'vip_security_boost_inactive_users_elevated_capabilities', self::$elevated_capabilities );
 
 		// Prevent infinite loops inside user_can() due to other security logic.
 		if ( is_automattician( $user->ID ) ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -29,7 +29,7 @@ class Inactive_Users {
 		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
-		self::$elevated_capabilities          = $inactive_user_configs['elevated_capabilities'] ?? [
+		self::$elevated_capabilities          = $inactive_user_configs['capability'] ?? [
 			'edit_posts',
 			'delete_posts',
 			'publish_posts',

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -29,7 +29,7 @@ class Inactive_Users {
 		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
-		self::$elevated_capabilities          = $inactive_user_configs['capability'] ?? [
+		self::$elevated_capabilities          = $inactive_user_configs['capabilities'] ?? [
 			'edit_posts',
 			'delete_posts',
 			'publish_posts',


### PR DESCRIPTION
## Description

Allow configuring which capabilities will be blocked after inactivity period

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Create an Editor and an Author user
1. Open PhpMyAdmin: http://vip-security-boost-pma.vipdev.lndo.site/
1. Edit their `user_registered` column to a date in the past that's more than 90 days
1. Edit the `wpvip_last_seen_release_date_timestamp` option on the `wp_option` table to a date prior to the register dates of the users above
1. You might need to restart the dev-env for those changes to take effect
1 Configure the `inactive-users` module to block users with the `publish_pages` capability:

```
"module_configs": {
  "inactive-users": {
    "mode": "BLOCK",
    "considered_inactive_after_days": 90,
    "capability": [
      "publish_pages"
    ]
  }
}
```

Make sure only the Editor user is considered inactive:

![Screenshot 2025-04-23 at 15 44 55](https://github.com/user-attachments/assets/e1894662-48a1-4c6b-a787-6b732a760587)
