### PR TITLE
[Highlight MFA]  Use roles instead of capabilities

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -11,21 +11,20 @@ class Highlight_MFA_Users {
 	 *
 	 * @var array An array of capability slugs.
 	 */
-	private static $capabilities;
+	private static $roles;
 
 	public static function init() {
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = get_module_configs( 'highlight-mfa-users' );
-		self::$capabilities    = $highlight_mfa_configs['capabilities'] ?? [ 'edit_posts' ]; // Default to edit_posts if not configured
+		self::$roles           = $highlight_mfa_configs['roles'] ?? [ 'administrator' ]; // Default to administrator if not configured
 
-		if ( ! is_array( self::$capabilities ) ) {
-			self::$capabilities = [ self::$capabilities ];
+		if ( ! is_array( self::$roles ) ) {
+			self::$roles = [ self::$roles ];
 		}
-		self::$capabilities = array_filter( self::$capabilities );
-
-		// If after filtering, the array is empty, default back to edit_posts
-		if ( empty( self::$capabilities ) ) {
-			self::$capabilities = [ 'edit_posts' ];
+		self::$roles = array_filter( self::$roles );
+		// If after filtering, the array is empty, default back to administrator
+		if ( empty( self::$roles ) ) {
+			self::$roles = [ 'administrator' ];
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
@@ -51,13 +50,13 @@ class Highlight_MFA_Users {
 			$skipped_user_ids = [];
 		}
 
-		// Query for user IDs with the configured capabilities, excluding skipped ones
+		// Query for user IDs with the configured roles, excluding skipped ones
 		$args       = [
-			'capability__in' => self::$capabilities,
-			'fields'         => 'ID',
+			'role__in' => self::$roles,
+			'fields'   => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'        => array_merge( $skipped_user_ids, [ 1 ] ),
-			'number'         => -1, // Get all relevant users
+			'exclude'  => array_merge( $skipped_user_ids, [ 1 ] ),
+			'number'   => -1, // Get all relevant users
 		];
 		$user_query = new \WP_User_Query( $args );
 		$user_ids   = $user_query->get_results();
@@ -145,7 +144,9 @@ class Highlight_MFA_Users {
 					'compare' => '=',
 				],
 			];
-			$query->set( 'capability__in', self::$capabilities ); // Set the configured capabilities
+
+			$query->set( 'role__in', self::$roles ); // Set the configured roles
+			error_log( 'Roles: ' . print_r( self::$roles, true ) );
 			$query->set( 'meta_query', $meta_query );
 
 			// Exclude skipped users AND always exclude User ID 1
@@ -153,12 +154,13 @@ class Highlight_MFA_Users {
 			if ( ! is_array( $skipped_user_ids ) ) {
 				$skipped_user_ids = [];
 			}
-
+			error_log( 'Skipped user IDs: ' . print_r( $skipped_user_ids, true ) );
 			// Get any existing exclusions from the query
 			$exclude_ids = $query->get( 'exclude' );
 			if ( ! is_array( $exclude_ids ) ) {
 				$exclude_ids = [];
 			}
+			error_log( 'Exclude IDs: ' . print_r( $exclude_ids, true ) );
 
 			// Merge existing exclusions, skipped IDs from option, and User ID 1
 			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids, [ 1 ] ) );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -146,7 +146,6 @@ class Highlight_MFA_Users {
 			];
 
 			$query->set( 'role__in', self::$roles ); // Set the configured roles
-			error_log( 'Roles: ' . print_r( self::$roles, true ) );
 			$query->set( 'meta_query', $meta_query );
 
 			// Exclude skipped users AND always exclude User ID 1
@@ -154,13 +153,11 @@ class Highlight_MFA_Users {
 			if ( ! is_array( $skipped_user_ids ) ) {
 				$skipped_user_ids = [];
 			}
-			error_log( 'Skipped user IDs: ' . print_r( $skipped_user_ids, true ) );
 			// Get any existing exclusions from the query
 			$exclude_ids = $query->get( 'exclude' );
 			if ( ! is_array( $exclude_ids ) ) {
 				$exclude_ids = [];
 			}
-			error_log( 'Exclude IDs: ' . print_r( $exclude_ids, true ) );
 
 			// Merge existing exclusions, skipped IDs from option, and User ID 1
 			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids, [ 1 ] ) );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -16,15 +16,15 @@ class Highlight_MFA_Users {
 	public static function init() {
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = get_module_configs( 'highlight-mfa-users' );
-		self::$roles           = $highlight_mfa_configs['roles'] ?? [ 'administrator' ]; // Default to administrator if not configured
+		self::$roles           = $highlight_mfa_configs['roles'] ?? [ 'administrator', 'editor' ]; // Default to administrator and editor if not configured
 
 		if ( ! is_array( self::$roles ) ) {
 			self::$roles = [ self::$roles ];
 		}
 		self::$roles = array_filter( self::$roles );
-		// If after filtering, the array is empty, default back to administrator
+		// If after filtering, the array is empty, default back to administrator and editor
 		if ( empty( self::$roles ) ) {
-			self::$roles = [ 'administrator' ];
+			self::$roles = [ 'administrator', 'editor' ];
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -45,7 +45,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->admin_user_mfa_skipped_id = $this->factory()->user->create([
 			'role' => 'administrator',
 		]);
-		
+
 		$this->editor_user_id = $this->factory()->user->create([
 			'role' => 'editor',
 		]);
@@ -110,9 +110,9 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$query = new \WP_User_Query();
 		Highlight_MFA_Users::filter_users_by_mfa_status( $query );
 
-		$meta_query      = $query->get( 'meta_query' );
-		$roles_in_query  = $query->get( 'role__in' );
-		$exclude_query   = $query->get( 'exclude' );
+		$meta_query     = $query->get( 'meta_query' );
+		$roles_in_query = $query->get( 'role__in' );
+		$exclude_query  = $query->get( 'exclude' );
 
 		$this->assertIsArray( $meta_query );
 		$mfa_meta_clause_found = false;
@@ -222,14 +222,14 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_output, $output );
 	}
-	  
+
 		/**
 		* Test that the admin notice is displayed correctly with the count when the list IS filtered.
 		*/
 	public function test_display_mfa_disabled_notice_shows_correct_message_when_filtered() {
 		$this->set_admin_screen_users();
 		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
-	  
+
 		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id)
 		$expected_count  = 2;
 		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
@@ -248,13 +248,13 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 			esc_url( $show_all_url ),
 			esc_html__( 'Show all users.', 'wpvip' )
 		);
-	  
+
 		ob_start();
 		Highlight_MFA_Users::display_mfa_disabled_notice();
 		$output = ob_get_clean();
-	  
+
 		$this->assertEquals( $expected_output, $output );
-	  
+
 		unset( $_GET['filter_mfa_disabled'] ); // Clean up
 	}
 

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -19,6 +19,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	private $admin_user_mfa_disabled_id;
 	private $admin_user_mfa_skipped_id;
 	private $editor_user_id;
+	private $subscriber_user_id;
 	private $original_get;
 	private $original_current_screen;
 
@@ -109,11 +110,10 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$query = new \WP_User_Query();
 		Highlight_MFA_Users::filter_users_by_mfa_status( $query );
 
-		$meta_query          = $query->get( 'meta_query' );
-		$capability_in_query = $query->get( 'capability__in' );
-		$exclude_query       = $query->get( 'exclude' );
+		$meta_query      = $query->get( 'meta_query' );
+		$roles_in_query  = $query->get( 'role__in' );
+		$exclude_query   = $query->get( 'exclude' );
 
-		
 		$this->assertIsArray( $meta_query );
 		$mfa_meta_clause_found = false;
 		foreach ( $meta_query as $clause ) {
@@ -124,8 +124,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		}
 		$this->assertTrue( $mfa_meta_clause_found, 'MFA status meta query clause not found.' );
 
-
-		$this->assertEquals( [ 'edit_posts' ], $capability_in_query );
+		$this->assertEquals( [ 'administrator' ], $roles_in_query );
 
 		$this->assertIsArray( $exclude_query );
 		$this->assertContains( $this->admin_user_mfa_skipped_id, $exclude_query );
@@ -195,7 +194,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// The skipped admin ($this->admin_user_mfa_skipped_id) should be ignored by the notice logic.
 		// The subscriber ($this->subscriber_user_id) should not be included in the notice.
 		// The notice logic uses Two_Factor_Core::is_user_using_two_factor which we've mocked.
-		$expected_count  = 2; // Only admin_user_mfa_disabled_id should be counted
+		// Only admin_user_mfa_disabled_id should be counted (editor doesn't have administrator role)
+		$expected_count  = 1;
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -124,7 +124,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		}
 		$this->assertTrue( $mfa_meta_clause_found, 'MFA status meta query clause not found.' );
 
-		$this->assertEquals( [ 'administrator' ], $roles_in_query );
+		$this->assertEquals( [ 'administrator', 'editor' ], $roles_in_query );
 
 		$this->assertIsArray( $exclude_query );
 		$this->assertContains( $this->admin_user_mfa_skipped_id, $exclude_query );
@@ -195,7 +195,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// The subscriber ($this->subscriber_user_id) should not be included in the notice.
 		// The notice logic uses Two_Factor_Core::is_user_using_two_factor which we've mocked.
 		// Only admin_user_mfa_disabled_id should be counted (editor doesn't have administrator role)
-		$expected_count  = 1;
+		$expected_count  = 2;
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',


### PR DESCRIPTION
## Description

In this PR, we're moving away from capabilities, and then using roles instead to highlight the users who need MFA:

![CleanShot 2025-05-26 at 15 10 06@2x](https://github.com/user-attachments/assets/09d19cf4-9670-41a7-90ec-b60ed4d8d5c1)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Check out PR & ensure the module is active on your site
- `vip dev-env create && vip dev-env start`
- Generate users
```
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=administrator
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=editor
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=author
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=contributor
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=subscriber
```
- play with the config of the module, using 
```
"highlight-mfa-users": {
        "roles": ["administrator","editor","author"]
      }
```
- Navigate to [wp-admin/users](http://vip-security-boost.vipdev.lndo.site/wp-admin/users.php) and verify that the count matches the module config. Click the filter link in the notice and ensure the filtered users are the one with the selected roles.