### PR TITLE
[PLTFRM-892] Add sorting for role column

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -5,6 +5,7 @@ use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
+	const ROLE_COLUMN_KEY              = 'role';
 
 	/**
 	 * The capabilities used to highlight users without MFA.
@@ -30,6 +31,21 @@ class Highlight_MFA_Users {
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
 		add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
+		
+		// Add column for role
+		// Single site or main site admin users page
+		add_filter( 'manage_users_columns', [ __CLASS__, 'add_columns' ] );
+		// Network admin users page
+		add_filter( 'wpmu_users_columns', [ __CLASS__, 'add_columns' ] );
+		// Add content to the role column
+		add_filter( 'manage_users_custom_column', [ __CLASS__, 'manage_columns' ], 10, 3 );
+		
+		// Make columns sortable
+		add_filter( 'manage_users_sortable_columns', [ __CLASS__, 'make_columns_sortable' ] );
+		add_filter( 'manage_users-network_sortable_columns', [ __CLASS__, 'make_columns_sortable' ] );
+		
+		// Handle sorting
+		add_filter( 'users_list_table_query_args', [ __CLASS__, 'sort_columns' ] );
 	}
 
 	/**
@@ -54,7 +70,6 @@ class Highlight_MFA_Users {
 		// Query for user IDs with the configured capabilities, excluding skipped ones
 		$args       = [
 			'capability__in' => self::$capabilities,
-			'fields'         => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
 			'exclude'        => array_merge( $skipped_user_ids, [ 1 ] ),
 			'number'         => -1, // Get all relevant users
@@ -166,6 +181,89 @@ class Highlight_MFA_Users {
 			// Set the final list of excluded IDs
 			$query->set( 'exclude', $final_exclude_ids );
 		}
+	}
+
+	/**
+	 * Add Role column to the users table.
+	 *
+	 * @param array $columns The existing columns.
+	 * @return array The modified columns.
+	 */
+	public static function add_columns( $columns ) {
+		$new_columns = [];
+		
+		foreach ( $columns as $key => $title ) {
+			// Add role column if it doesn't exist
+			if ( 'name' === $key ) {
+				$new_columns[ $key ]                  = $title;
+				$new_columns[ self::ROLE_COLUMN_KEY ] = __( 'Role', 'wpvip' );
+			} else {
+				$new_columns[ $key ] = $title;
+			}
+		}
+		
+		return $new_columns;
+	}
+
+	/**
+	 * Manage the content of the custom columns.
+	 *
+	 * @param string $output      The output for the column.
+	 * @param string $column_name The name of the column.
+	 * @param int    $user_id     The ID of the user.
+	 * @return string The content for the column.
+	 */
+	public static function manage_columns( $output, $column_name, $user_id ) {
+		switch ( $column_name ) {
+			case self::ROLE_COLUMN_KEY:
+				$user = get_userdata( $user_id );
+				if ( $user ) {
+					$roles = array_map( function ( $role ) {
+						return translate_user_role( wp_roles()->roles[ $role ]['name'] );
+					}, $user->roles );
+					return esc_html( implode( ', ', $roles ) );
+				}
+				return '';
+		}
+		
+		return $output;
+	}
+
+	/**
+	 * Make the custom columns sortable.
+	 *
+	 * @param array $columns The sortable columns.
+	 * @return array The modified sortable columns.
+	 */
+	public static function make_columns_sortable( $columns ) {
+		$columns[ self::ROLE_COLUMN_KEY ] = self::ROLE_COLUMN_KEY;
+		return $columns;
+	}
+
+	/**
+	 * Handle the sorting of custom columns.
+	 *
+	 * @param array $args The query arguments.
+	 * @return array The modified query arguments.
+	 */
+	public static function sort_columns( $args ) {
+		if ( ! isset( $args['orderby'] ) ) {
+			return $args;
+		}
+
+		// The 'order' GET parameter is already handled by WP_Users_List_Table
+		// and applied to $args['order'] before this filter.
+		switch ( $args['orderby'] ) {
+			case self::ROLE_COLUMN_KEY:
+				// Sort by role using WP_User_Query arguments
+				global $wpdb;
+				$args['meta_key'] = $wpdb->prefix . 'capabilities';
+				$args['orderby']  = 'meta_value';
+				// $args['order'] (ASC/DESC) is already set by WP_Users_List_Table
+				break;
+		}
+		
+		return $args;
 	}
 }
 Highlight_MFA_Users::init();

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -8,9 +8,9 @@ class Highlight_MFA_Users {
 	const ROLE_COLUMN_KEY              = 'role';
 
 	/**
-	 * The capabilities used to highlight users without MFA.
+	 * The roles used to highlight users without MFA.
 	 *
-	 * @var array An array of capability slugs.
+	 * @var array An array of role slugs.
 	 */
 	private static $roles;
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -71,8 +71,8 @@ class Highlight_MFA_Users {
 		$args       = [
 			'capability__in' => self::$capabilities,
 			'fields'         => 'ID',
-			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'        => array_merge( $skipped_user_ids, [ 1 ] ),
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users
+			'exclude'        => array_merge( $skipped_user_ids ),
 			'number'         => -1, // Get all relevant users
 		];
 		$user_query = new \WP_User_Query( $args );
@@ -177,7 +177,7 @@ class Highlight_MFA_Users {
 			}
 
 			// Merge existing exclusions, skipped IDs from option, and User ID 1
-			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids, [ 1 ] ) );
+			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids ) );
 
 			// Set the final list of excluded IDs
 			$query->set( 'exclude', $final_exclude_ids );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -70,6 +70,7 @@ class Highlight_MFA_Users {
 		// Query for user IDs with the configured capabilities, excluding skipped ones
 		$args       = [
 			'capability__in' => self::$capabilities,
+			'fields'         => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
 			'exclude'        => array_merge( $skipped_user_ids, [ 1 ] ),
 			'number'         => -1, // Get all relevant users

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -71,7 +71,7 @@ class Highlight_MFA_Users {
 			'role__in' => self::$roles,
 			'fields'   => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'  => array_merge( $skipped_user_ids, [ 1 ] ),
+			'exclude'  => array_merge( $skipped_user_ids ),
 			'number'   => -1, // Get all relevant users
 		];
 		$user_query = new \WP_User_Query( $args );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -70,7 +70,7 @@ class Highlight_MFA_Users {
 		$args       = [
 			'role__in' => self::$roles,
 			'fields'   => 'ID',
-			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small known set of users
 			'exclude'  => array_merge( $skipped_user_ids ),
 			'number'   => -1, // Get all relevant users
 		];

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -195,7 +195,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// The subscriber ($this->subscriber_user_id) should not be included in the notice.
 		// The notice logic uses Two_Factor_Core::is_user_using_two_factor which we've mocked.
 		// Only admin_user_mfa_disabled_id should be counted (editor doesn't have administrator role)
-		$expected_count  = 2;
+		$expected_count  = 3;
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
@@ -231,7 +231,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
 
 		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id)
-		$expected_count  = 2;
+		// In the filtered view, User ID 1 is excluded from the notice count by the main plugin logic.
+		$expected_count  = 3;
 		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Notice class is notice-info when filtered
@@ -289,6 +290,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Temporarily tell the mock that the MFA-disabled user is enabled for this test
 		Two_Factor_Core::$mock_enabled_user_ids[] = $this->admin_user_mfa_disabled_id;
 		Two_Factor_Core::$mock_enabled_user_ids[] = $this->editor_user_id;
+		Two_Factor_Core::$mock_enabled_user_ids[] = 1; // Also ensure User ID 1 is treated as MFA enabled
 
 		// Expect no output
 		ob_start();

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -319,12 +319,16 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 * Test that the role column is added to the users table.
 	 */
 	public function test_role_column_is_added() {
-		$columns = Highlight_MFA_Users::add_columns( [ 'username' => 'Username', 'name' => 'Name', 'email' => 'Email' ] );
+		$columns = Highlight_MFA_Users::add_columns( [
+			'username' => 'Username',
+			'name'     => 'Name',
+			'email'    => 'Email',
+		] );
 		$this->assertArrayHasKey( Highlight_MFA_Users::ROLE_COLUMN_KEY, $columns );
 		$this->assertEquals( __( 'Role', 'wpvip' ), $columns[ Highlight_MFA_Users::ROLE_COLUMN_KEY ] );
 
 		// Test positioning after 'name'
-		$keys = array_keys( $columns );
+		$keys     = array_keys( $columns );
 		$name_pos = array_search( 'name', $keys, true );
 		$role_pos = array_search( Highlight_MFA_Users::ROLE_COLUMN_KEY, $keys, true );
 		$this->assertNotFalse( $name_pos );
@@ -336,7 +340,10 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 * Test that the role column is made sortable.
 	 */
 	public function test_role_column_is_made_sortable() {
-		$sortable_columns = Highlight_MFA_Users::make_columns_sortable( [ 'username' => 'username', 'email' => 'email' ] );
+		$sortable_columns = Highlight_MFA_Users::make_columns_sortable( [
+			'username' => 'username',
+			'email'    => 'email',
+		] );
 		$this->assertArrayHasKey( Highlight_MFA_Users::ROLE_COLUMN_KEY, $sortable_columns );
 		$this->assertEquals( Highlight_MFA_Users::ROLE_COLUMN_KEY, $sortable_columns[ Highlight_MFA_Users::ROLE_COLUMN_KEY ] );
 	}
@@ -345,10 +352,10 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 * Test content of the role column.
 	 */
 	public function test_manage_columns_for_role_column() {
-		$admin_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
-		$editor_user_id = $this->factory()->user->create( [ 'role' => 'editor' ] );
+		$admin_user_id      = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$editor_user_id     = $this->factory()->user->create( [ 'role' => 'editor' ] );
 		$multi_role_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
-		$user = new WP_User( $multi_role_user_id );
+		$user               = new WP_User( $multi_role_user_id );
 		$user->add_role( 'editor' );
 
 		$output_admin = Highlight_MFA_Users::manage_columns( '', Highlight_MFA_Users::ROLE_COLUMN_KEY, $admin_user_id );
@@ -360,7 +367,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$output_multi = Highlight_MFA_Users::manage_columns( '', Highlight_MFA_Users::ROLE_COLUMN_KEY, $multi_role_user_id );
 		// Order might vary, so check for both
 		$expected_roles = [ translate_user_role( 'Administrator' ), translate_user_role( 'Editor' ) ];
-		$actual_roles = array_map( 'trim', explode( ',', $output_multi ) );
+		$actual_roles   = array_map( 'trim', explode( ',', $output_multi ) );
 		sort( $expected_roles );
 		sort( $actual_roles );
 		$this->assertEquals( $expected_roles, $actual_roles );
@@ -379,7 +386,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_sort_columns_by_role_asc() {
 		global $wpdb;
-		$args = [
+		$args        = [
 			'orderby' => Highlight_MFA_Users::ROLE_COLUMN_KEY,
 			'order'   => 'asc',
 		];
@@ -395,7 +402,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_sort_columns_by_role_desc() {
 		global $wpdb;
-		$args = [
+		$args        = [
 			'orderby' => Highlight_MFA_Users::ROLE_COLUMN_KEY,
 			'order'   => 'desc',
 		];
@@ -410,13 +417,13 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 * Test that sorting logic does not interfere with other orderby parameters.
 	 */
 	public function test_sort_columns_does_nothing_for_other_orderby() {
-		$args = [
-			'orderby' => 'username',
-			'order'   => 'asc',
+		$args          = [
+			'orderby'  => 'username',
+			'order'    => 'asc',
 			'meta_key' => 'some_other_key', // To ensure it's not overwritten
 		];
 		$original_args = $args; // Make a copy for comparison
-		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+		$sorted_args   = Highlight_MFA_Users::sort_columns( $args );
 
 		$this->assertEquals( $original_args, $sorted_args, "Query args were modified for an unrelated 'orderby' parameter." );
 	}
@@ -425,11 +432,11 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 * Test that sorting logic does nothing if orderby is not set.
 	 */
 	public function test_sort_columns_does_nothing_if_orderby_not_set() {
-		$args = [
-			'order'   => 'asc',
+		$args          = [
+			'order' => 'asc',
 		];
 		$original_args = $args;
-		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+		$sorted_args   = Highlight_MFA_Users::sort_columns( $args );
 		$this->assertEquals( $original_args, $sorted_args );
 	}
 }

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -314,4 +314,122 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertNotFalse( has_action( 'pre_get_users', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status' ] ) );
 		$this->assertEquals( 10, has_action( 'pre_get_users', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status' ] ) );
 	}
+
+	/**
+	 * Test that the role column is added to the users table.
+	 */
+	public function test_role_column_is_added() {
+		$columns = Highlight_MFA_Users::add_columns( [ 'username' => 'Username', 'name' => 'Name', 'email' => 'Email' ] );
+		$this->assertArrayHasKey( Highlight_MFA_Users::ROLE_COLUMN_KEY, $columns );
+		$this->assertEquals( __( 'Role', 'wpvip' ), $columns[ Highlight_MFA_Users::ROLE_COLUMN_KEY ] );
+
+		// Test positioning after 'name'
+		$keys = array_keys( $columns );
+		$name_pos = array_search( 'name', $keys, true );
+		$role_pos = array_search( Highlight_MFA_Users::ROLE_COLUMN_KEY, $keys, true );
+		$this->assertNotFalse( $name_pos );
+		$this->assertNotFalse( $role_pos );
+		$this->assertEquals( $name_pos + 1, $role_pos );
+	}
+
+	/**
+	 * Test that the role column is made sortable.
+	 */
+	public function test_role_column_is_made_sortable() {
+		$sortable_columns = Highlight_MFA_Users::make_columns_sortable( [ 'username' => 'username', 'email' => 'email' ] );
+		$this->assertArrayHasKey( Highlight_MFA_Users::ROLE_COLUMN_KEY, $sortable_columns );
+		$this->assertEquals( Highlight_MFA_Users::ROLE_COLUMN_KEY, $sortable_columns[ Highlight_MFA_Users::ROLE_COLUMN_KEY ] );
+	}
+
+	/**
+	 * Test content of the role column.
+	 */
+	public function test_manage_columns_for_role_column() {
+		$admin_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$editor_user_id = $this->factory()->user->create( [ 'role' => 'editor' ] );
+		$multi_role_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$user = new WP_User( $multi_role_user_id );
+		$user->add_role( 'editor' );
+
+		$output_admin = Highlight_MFA_Users::manage_columns( '', Highlight_MFA_Users::ROLE_COLUMN_KEY, $admin_user_id );
+		$this->assertEquals( translate_user_role( 'Administrator' ), $output_admin );
+
+		$output_editor = Highlight_MFA_Users::manage_columns( '', Highlight_MFA_Users::ROLE_COLUMN_KEY, $editor_user_id );
+		$this->assertEquals( translate_user_role( 'Editor' ), $output_editor );
+		
+		$output_multi = Highlight_MFA_Users::manage_columns( '', Highlight_MFA_Users::ROLE_COLUMN_KEY, $multi_role_user_id );
+		// Order might vary, so check for both
+		$expected_roles = [ translate_user_role( 'Administrator' ), translate_user_role( 'Editor' ) ];
+		$actual_roles = array_map( 'trim', explode( ',', $output_multi ) );
+		sort( $expected_roles );
+		sort( $actual_roles );
+		$this->assertEquals( $expected_roles, $actual_roles );
+		
+		// Test with a different column name
+		$output_other_column = Highlight_MFA_Users::manage_columns( 'initial_output', 'other_column', $admin_user_id );
+		$this->assertEquals( 'initial_output', $output_other_column );
+
+		wp_delete_user( $admin_user_id );
+		wp_delete_user( $editor_user_id );
+		wp_delete_user( $multi_role_user_id );
+	}
+
+	/**
+	 * Test sorting by role in ascending order.
+	 */
+	public function test_sort_columns_by_role_asc() {
+		global $wpdb;
+		$args = [
+			'orderby' => Highlight_MFA_Users::ROLE_COLUMN_KEY,
+			'order'   => 'asc',
+		];
+		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+
+		$this->assertEquals( $wpdb->prefix . 'capabilities', $sorted_args['meta_key'] );
+		$this->assertEquals( 'meta_value', $sorted_args['orderby'] );
+		$this->assertEquals( 'asc', $sorted_args['order'] );
+	}
+
+	/**
+	 * Test sorting by role in descending order.
+	 */
+	public function test_sort_columns_by_role_desc() {
+		global $wpdb;
+		$args = [
+			'orderby' => Highlight_MFA_Users::ROLE_COLUMN_KEY,
+			'order'   => 'desc',
+		];
+		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+
+		$this->assertEquals( $wpdb->prefix . 'capabilities', $sorted_args['meta_key'] );
+		$this->assertEquals( 'meta_value', $sorted_args['orderby'] );
+		$this->assertEquals( 'desc', $sorted_args['order'] );
+	}
+
+	/**
+	 * Test that sorting logic does not interfere with other orderby parameters.
+	 */
+	public function test_sort_columns_does_nothing_for_other_orderby() {
+		$args = [
+			'orderby' => 'username',
+			'order'   => 'asc',
+			'meta_key' => 'some_other_key', // To ensure it's not overwritten
+		];
+		$original_args = $args; // Make a copy for comparison
+		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+
+		$this->assertEquals( $original_args, $sorted_args, "Query args were modified for an unrelated 'orderby' parameter." );
+	}
+
+	/**
+	 * Test that sorting logic does nothing if orderby is not set.
+	 */
+	public function test_sort_columns_does_nothing_if_orderby_not_set() {
+		$args = [
+			'order'   => 'asc',
+		];
+		$original_args = $args;
+		$sorted_args = Highlight_MFA_Users::sort_columns( $args );
+		$this->assertEquals( $original_args, $sorted_args );
+	}
 }


### PR DESCRIPTION
## Description

This PR adds a sortable 'Role' column to the Users list table (for both single site and network admin views), allowing users to be sorted by their assigned roles.

![image](https://github.com/user-attachments/assets/3a3597d6-950d-456b-818d-7a8b269147e9)

How sorting works: Users are sorted by their serialized `wp_capabilities` meta value. While this doesn't produce alphabetical role ordering, it effectively **groups** all users with the same role together:

administrator → a:1:{s:13:"administrator";b:1;}
author → a:1:{s:6:"author";b:1;}
contributor → a:1:{s:11:"contributor";b:1;}
editor → a:1:{s:6:"editor";b:1;}
subscriber → a:1:{s:10:"subscriber";b:1;}

Why this approach?

- It leverages WordPress's existing role storage without requiring new database fields
- It's performant even on sites with many users
- It achieves the primary goal of grouping users by role

PS: Users with multiple roles will sort based on their full serialized capabilities string, which may produce less predictable ordering.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
Start local GOOP

1. Check out PR.
2. Enable `highlight-mfa-users` in GOOP and add roles ['administrator', 'author', 'editor']. Follow steps from [here](https://github.com/Automattic/vip-go-api/pull/6211), just replace `capabilities` with `roles`
3. `vip dev-env create && vip dev-env start`
4. Add users with different roles
```
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=administrator
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=author
vip dev-env exec --slug=vip-security-boost -- wp user generate --count=1 --role=editor
```
5. Verify that you can sort the Role column
