### PR TITLE
[PLTFRM-913] Ignores specific users

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -27,6 +27,10 @@ class Forced_MFA_Users {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
+		// don't enforce 2FA if the user is already excluded by VIP mu-plugins logic
+		if ( function_exists( 'wpcom_vip_should_force_two_factor' ) && ! wpcom_vip_should_force_two_factor() ) {
+			return;
+		}
 
 		$required_capabilities = self::$capabilities;
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -28,11 +28,6 @@ class Forced_MFA_Users {
 			return;
 		}
 
-		// Exclude User ID 1
-		if ( 1 === get_current_user_id() ) {
-			return;
-		}
-
 		$required_capabilities = self::$capabilities;
 
 		if ( empty( $required_capabilities ) ) {

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -7,9 +7,9 @@ class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
 
 	/**
-	 * The capabilities used to highlight users without MFA.
+	 * The roles used to highlight users without MFA.
 	 *
-	 * @var array An array of capability slugs.
+	 * @var array An array of role slugs.
 	 */
 	private static $roles;
 
@@ -50,12 +50,18 @@ class Highlight_MFA_Users {
 			$skipped_user_ids = [];
 		}
 
+		// Exclude the wpcomvip user from the list
+		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+		if ( false !== $wpcomvip ) {
+			$skipped_user_ids[] = $wpcomvip->ID;
+		}
+
 		// Query for user IDs with the configured roles, excluding skipped ones
 		$args       = [
 			'role__in' => self::$roles,
 			'fields'   => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'  => array_merge( $skipped_user_ids, [ 1 ] ),
+			'exclude'  => $skipped_user_ids,
 			'number'   => -1, // Get all relevant users
 		];
 		$user_query = new \WP_User_Query( $args );
@@ -148,19 +154,25 @@ class Highlight_MFA_Users {
 			$query->set( 'role__in', self::$roles ); // Set the configured roles
 			$query->set( 'meta_query', $meta_query );
 
-			// Exclude skipped users AND always exclude User ID 1
+			// Exclude skipped users AND always exclude User wpcomvip
 			$skipped_user_ids = \get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 			if ( ! is_array( $skipped_user_ids ) ) {
 				$skipped_user_ids = [];
 			}
+
+			// Exclude the wpcomvip user from the list
+			$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+			if ( false !== $wpcomvip ) {
+				$skipped_user_ids[] = $wpcomvip->ID;
+			}
+
 			// Get any existing exclusions from the query
 			$exclude_ids = $query->get( 'exclude' );
 			if ( ! is_array( $exclude_ids ) ) {
 				$exclude_ids = [];
 			}
-
-			// Merge existing exclusions, skipped IDs from option, and User ID 1
-			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids, [ 1 ] ) );
+			// Merge existing exclusions, skipped IDs from option
+			$final_exclude_ids = array_unique( array_merge( $exclude_ids, $skipped_user_ids ) );
 
 			// Set the final list of excluded IDs
 			$query->set( 'exclude', $final_exclude_ids );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -55,7 +55,6 @@ class Highlight_MFA_Users {
 		if ( false !== $wpcomvip ) {
 			$skipped_user_ids[] = $wpcomvip->ID;
 		}
-
 		// Query for user IDs with the configured roles, excluding skipped ones
 		$args       = [
 			'role__in' => self::$roles,

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -3,6 +3,12 @@
 use Automattic\VIP\Security\MFAUsers\Forced_MFA_Users;
 
 class Test_Forced_MFA_Users extends WP_UnitTestCase {
+	public function setUp(): void {
+		parent::setUp();
+		add_action( 'wpcom_vip_is_two_factor_local_testing', '__return_true' ); // Tell the two-factor plugin we're in local testing
+		// Loads the Two_Factor_Core class (required for the wpcom_vip_should_force_two_factor to work)
+		require_once WPVIP_MU_PLUGIN_DIR . '/shared-plugins/two-factor/two-factor.php';
+	}
 	public function tearDown(): void {
 		// Remove actions/filters added by the class
 		remove_action( 'set_current_user', [ Forced_MFA_Users::class, 'filter_user_capabilities' ] );
@@ -215,4 +221,4 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		$this->setup_user_and_filter( 'administrator' );
 		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if only invalid capability types are provided.' );
 	}
-} 
+}

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -236,4 +236,23 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		$this->setup_user_and_filter( 'administrator' );
 		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if only invalid capability types are provided.' );
 	}
+
+	/**
+	 * We want to test that under a normal condition, if a user has the required capability, the filter returns false because
+	 * wpcom_vip_should_force_two_factor returns false.
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_user_if_wpcom_vip_should_force_two_factor_returns_false() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'capabilities' => 'edit_posts' ],
+			],
+		] );
+		Forced_MFA_Users::init();
+		add_filter( 'wpcom_vip_is_user_using_two_factor', '__return_true' ); // we're using this to change the behavior of the wpcom_vip_should_force_two_factor to return false.
+
+		$this->setup_user_and_filter( 'administrator' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_should_force_two_factor returns false even if the user has the required capability.' );
+	}
 }

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -9,6 +9,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		// Loads the Two_Factor_Core class (required for the wpcom_vip_should_force_two_factor to work)
 		require_once WPVIP_MU_PLUGIN_DIR . '/shared-plugins/two-factor/two-factor.php';
 	}
+
 	public function tearDown(): void {
 		// Remove actions/filters added by the class
 		remove_action( 'set_current_user', [ Forced_MFA_Users::class, 'filter_user_capabilities' ] );
@@ -31,6 +32,20 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		// Reset current user
 		wp_set_current_user( 0 );
 		parent::tearDown();
+	}
+
+	/**
+	 * This is a dependance for our project. While we should not break the site if this function is missing, we should at least warn if it is missing.
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_ensure_wpcom_vip_should_force_two_factor_exists() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
+			],
+		] );
+		$this->assertTrue( function_exists( 'wpcom_vip_should_force_two_factor' ) );
 	}
 
 	/**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -16,6 +16,7 @@ use WP_User_Query;
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class HighlightMFAUsersTest extends WP_UnitTestCase {
 	private $admin_user_mfa_enabled_id;
+	private $admin_wpcomvip_ignored_id; // wpcomvip user should be ignored
 	private $admin_user_mfa_disabled_id;
 	private $admin_user_mfa_skipped_id;
 	private $editor_user_id;
@@ -37,6 +38,12 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		]);
 
 		Two_Factor_Core::$mock_enabled_user_ids[] = $this->admin_user_mfa_enabled_id;
+
+
+		$this->admin_wpcomvip_ignored_id = $this->factory()->user->create([
+			'role'       => 'administrator',
+			'user_login' => 'wpcomvip',
+		]);
 
 		$this->admin_user_mfa_disabled_id = $this->factory()->user->create([
 			'role' => 'administrator',
@@ -66,6 +73,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		wp_delete_user( $this->admin_user_mfa_disabled_id );
 		wp_delete_user( $this->admin_user_mfa_skipped_id );
 		wp_delete_user( $this->editor_user_id );
+		wp_delete_user( $this->subscriber_user_id );
+		wp_delete_user( $this->admin_wpcomvip_ignored_id );
 
 		// Clean up options
 		delete_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY );
@@ -128,6 +137,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $exclude_query );
 		$this->assertContains( $this->admin_user_mfa_skipped_id, $exclude_query );
+		$this->assertContains( $this->admin_wpcomvip_ignored_id, $exclude_query );
 
 		unset( $_GET['filter_mfa_disabled'] );
 	}
@@ -190,12 +200,12 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_display_mfa_disabled_notice_shows_when_needed() {
 		$this->set_admin_screen_users();
-		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id)
+		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id) and the default superadmin with ID 1
 		// The skipped admin ($this->admin_user_mfa_skipped_id) should be ignored by the notice logic.
 		// The subscriber ($this->subscriber_user_id) should not be included in the notice.
 		// The notice logic uses Two_Factor_Core::is_user_using_two_factor which we've mocked.
 		// Only admin_user_mfa_disabled_id should be counted (editor doesn't have administrator role)
-		$expected_count  = 2;
+		$expected_count  = 3;
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
@@ -230,8 +240,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->set_admin_screen_users();
 		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
 
-		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id)
-		$expected_count  = 2;
+		// We have one MFA-disabled admin ($this->admin_user_mfa_disabled_id) and one editor ($this->editor_user_id), plus the default superadmin with ID 1
+		$expected_count  = 3;
 		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Notice class is notice-info when filtered
@@ -289,6 +299,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Temporarily tell the mock that the MFA-disabled user is enabled for this test
 		Two_Factor_Core::$mock_enabled_user_ids[] = $this->admin_user_mfa_disabled_id;
 		Two_Factor_Core::$mock_enabled_user_ids[] = $this->editor_user_id;
+		Two_Factor_Core::$mock_enabled_user_ids[] = 1; // skipping default user 1 just to see if the notice is hidden
 
 		// Expect no output
 		ob_start();


### PR DESCRIPTION
## Description
This PRs introduces changes to support ignoring some users specific to the VIP Platform and to better rely on the functions already provided by the https://github.com/Automattic/vip-go-mu-plugins repo in terms of excluding users from 2FA.

The changes impact two modules
* Enforce MFA
* Highlight MFA

For both module we stopped excluding userId 1, since that user might not be the right one to exclude, and instead rely on the `wpcom_vip_should_force_two_factor` [function offered by vip-go-mu-plugins](https://github.com/Automattic/vip-go-mu-plugins/blob/a3d7fb7cd62f4a5f3dd81b2c832d26eabd96c01e/two-factor.php#L23) (Enforce MFA), or excluding the `wpcomvip` user itself (Highlight MFA)

Note: there is no specific user-exclusion locally for the enforce MFA part, relying on the `wpcom_vip_should_force_two_factor` means that locally we won't enforce 2FA, whereas 2FA will be enforce in production sites just like it is now.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Check out PR & ensure the module is active on your site
- `vip dev-env create && vip dev-env start`
- create the wpcomvip user `vip dev-env exec --slug=vip-security-boost -- wp user create wpcomvip test@example.local --role=administrator`
- Going into the [wp-admin/users](http://vip-security-boost.vipdev.lndo.site/wp-admin/users.php) and check that the filtered user list doesn't include `wpcomvip`