### PR TITLE
[PLTFRM-762]: migrate from capabilities to roles in inactive users

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -403,7 +403,8 @@ class Inactive_Users {
 			return true;
 		}
 
-		if ( array_intersect( $elevated_roles, (array) $user->roles ) ) {
+		// Ensure $user->roles is defined and is an array before using it.
+		if ( isset( $user->roles ) && is_array( $user->roles ) && array_intersect( $elevated_roles, $user->roles ) ) {
 			return true;
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -29,7 +29,7 @@ class Inactive_Users {
 		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
-		self::$elevated_roles                 = $inactive_user_configs['roles'] ?? [ 'editor' ];
+		self::$elevated_roles                 = $inactive_user_configs['roles'] ?? [ 'administrator' ];
 
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -6,7 +6,7 @@ use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Inactive_Users {
 	private static $considered_inactive_after_days;
-	private static $elevated_capabilities;
+	private static $elevated_roles;
 	private static $mode;
 	public static $release_date;
 
@@ -22,28 +22,14 @@ class Inactive_Users {
 	 * @var \WP_Error|null
 	 */
 	private static $application_password_authentication_error;
-	
+
 	public static function init() {
 		$inactive_user_configs = get_module_configs( 'inactive-users' );
 
 		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
-		self::$elevated_capabilities          = $inactive_user_configs['capabilities'] ?? [
-			'edit_posts',
-			'delete_posts',
-			'publish_posts',
-			'edit_pages',
-			'delete_pages',
-			'publish_pages',
-			'edit_others_posts',
-			'edit_others_pages',
-			'manage_options',
-			'edit_users',
-			'promote_users',
-			'activate_plugins',
-			'manage_network',
-		];
+		self::$elevated_roles                 = $inactive_user_configs['roles'] ?? [ 'editor' ];
 
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );
@@ -332,7 +318,7 @@ class Inactive_Users {
 			throw new \Exception( 'User not found' );
 		}
 
-		if ( ! self::user_with_elevated_capabilities( $user ) ) {
+		if ( ! self::user_with_elevated_roles( $user ) ) {
 			return;
 		}
 
@@ -401,28 +387,24 @@ class Inactive_Users {
 			return false;
 		}
 
-		return self::user_with_elevated_capabilities( $user );
+		return self::user_with_elevated_roles( $user );
 	}
 
-	private static function user_with_elevated_capabilities( $user ) {
+	private static function user_with_elevated_roles( $user ) {
 		/**
-		 * Filters the last seen elevated capabilities that are used to determine if the last seen should be checked.
+		 * Filters the last seen elevated roles that are used to determine if the last seen should be checked.
 		 *
-		 * @param array $elevated_capabilities The elevated capabilities.
+		 * @param array $elevated_roles The elevated roles.
 		 */
-		$elevated_capabilities = apply_filters( 'vip_security_boost_inactive_users_elevated_capabilities', self::$elevated_capabilities );
+		$elevated_roles = apply_filters( 'vip_security_boost_inactive_users_elevated_roles', self::$elevated_roles );
 
 		// Prevent infinite loops inside user_can() due to other security logic.
 		if ( is_automattician( $user->ID ) ) {
 			return true;
 		}
 
-		// TODO: Add a list of capabilities to check.
-		foreach ( $elevated_capabilities as $elevated_capability ) {
-			// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- $elevated_capability is defined earlier and contains a valid capability
-			if ( user_can( $user->ID, $elevated_capability ) ) {
-				return true;
-			}
+		if ( array_intersect( $elevated_roles, (array) $user->roles ) ) {
+			return true;
 		}
 
 		return false;

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -130,6 +130,8 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-91 days' ) ),
 		]);
 
+		update_user_meta( $new_user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
 		// Add all roles to the new user that are not currently elevated.
 		global $wp_roles;
 		$role_names = array_values( array_diff( array_keys( $wp_roles->roles ), $this->elevated_roles ) );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -127,7 +127,6 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		// Create a new user with a registration date that should be blocked if it has an elevated role. Starts with no role.
 		$new_user_id = $this->factory->user->create([
-			'role'            => '',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-91 days' ) ),
 		]);
 

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -5,13 +5,14 @@ use WP_UnitTestCase;
 
 class InactiveUsersTest extends WP_UnitTestCase {
 	private $user_id;
+	private $elevated_roles = [ 'administrator' ];
 
 	public function setUp(): void {
 		parent::setUp();
 
 		// Create a test user with elevated roles and an old registration date
 		$this->user_id = $this->factory->user->create([
-			'role'            => 'editor',
+			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
 
@@ -20,6 +21,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 				'inactive_users' => [
 					'mode'                           => 'BLOCK',
 					'considered_inactive_after_days' => 90,
+					'roles'                          => $this->elevated_roles,
 				],
 			]);
 		}
@@ -116,6 +118,33 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'inactive_account', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that authentication for users with non elevated roles are not blocked.
+	 */
+	public function test_authenticate_does_not_block_nonelevated_roles() {
+
+		// Create a new user with a registration date that should be blocked if it has an elevated role. Starts with no role.
+		$new_user_id = $this->factory->user->create([
+			'role'            => '',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-91 days' ) ),
+		]);
+
+		// Add all roles to the new user that are not currently elevated.
+		global $wp_roles;
+		$role_names = array_values( array_diff( array_keys( $wp_roles->roles ), $this->elevated_roles ) );
+		$new_user   = new WP_User( $new_user_id );
+
+		foreach ( $role_names as $role_key ) {
+			$new_user->add_role( $role_key );
+		}
+
+		$result = Inactive_Users::authenticate( $new_user );
+
+		$this->assertNotInstanceOf( 'WP_Error', $result );
+
+		wp_delete_user( $new_user_id );
 	}
 
 	/**

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -5,16 +5,16 @@ use WP_UnitTestCase;
 
 class InactiveUsersTest extends WP_UnitTestCase {
 	private $user_id;
-	
+
 	public function setUp(): void {
 		parent::setUp();
-		
-		// Create a test user with elevated capabilities and an old registration date
+
+		// Create a test user with elevated roles and an old registration date
 		$this->user_id = $this->factory->user->create([
 			'role'            => 'editor',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
-		
+
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
 			define('VIP_SECURITY_BOOST_CONFIGS', [
 				'inactive_users' => [
@@ -23,10 +23,10 @@ class InactiveUsersTest extends WP_UnitTestCase {
 				],
 			]);
 		}
-		
+
 		Inactive_Users::init();
 	}
-	
+
 	public function tearDown(): void {
 		wp_delete_user( $this->user_id );
 		parent::tearDown();
@@ -41,9 +41,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			'email'    => 'Email',
 			'role'     => 'Role',
 		];
-		
+
 		$result = Inactive_Users::add_last_seen_column_head( $initial_columns );
-		
+
 		$this->assertArrayHasKey( 'last_seen', $result );
 		$this->assertEquals( __( 'Last seen', 'wpvip' ), $result['last_seen'] );
 		$this->assertEquals( count( $initial_columns ) + 1, count( $result ) );
@@ -54,9 +54,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_record_activity() {
 		$result = Inactive_Users::record_activity( $this->user_id );
-		
+
 		$last_seen = get_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, true );
-		
+
 		$this->assertNotEmpty( $last_seen );
 		$this->assertTrue( is_numeric( $last_seen ) );
 		$this->assertLessThanOrEqual( time(), $last_seen );
@@ -69,7 +69,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Set last seen to 91 days ago (beyond the 90-day threshold)
 		$old_timestamp = strtotime( '-91 days' );
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, $old_timestamp );
-		
+
 		$this->assertTrue( Inactive_Users::is_considered_inactive( $this->user_id ) );
 	}
 
@@ -80,7 +80,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Set last seen to yesterday
 		$recent_timestamp = strtotime( '-1 day' );
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, $recent_timestamp );
-		
+
 		$this->assertFalse( Inactive_Users::is_considered_inactive( $this->user_id ) );
 	}
 
@@ -89,15 +89,15 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_ignore_inactivity_check_for_user() {
 		Inactive_Users::init(); // Re-initialize with test config
-   
+
 		// Set user as inactive
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
-		
+
 		// Ignore inactivity check
 		Inactive_Users::ignore_inactivity_check_for_user( $this->user_id );
-	  
+
 		$this->assertFalse( Inactive_Users::is_considered_inactive( $this->user_id ) );
-	  
+
 		// Verify the ignore until timestamp was set
 		$ignore_until = get_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY, true );
 		$this->assertNotEmpty( $ignore_until );
@@ -110,10 +110,10 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	public function test_authenticate_blocks_inactive_users() {
 		// Set user as inactive
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
-		
+
 		$user   = new WP_User( $this->user_id );
 		$result = Inactive_Users::authenticate( $user );
-		
+
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'inactive_account', $result->get_error_code() );
 	}
@@ -127,9 +127,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			'role'            => 'editor',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
 		]);
-		
+
 		$this->assertFalse( Inactive_Users::is_considered_inactive( $new_user_id ) );
-		
+
 		wp_delete_user( $new_user_id );
 	}
 }


### PR DESCRIPTION
## Description
Migrate inactive users from using capabilities into using roles.

Example of this plugin working locally using a vip dev enviroment.
<img width="958" alt="Screenshot 2025-05-29 at 3 33 48 PM" src="https://github.com/user-attachments/assets/c5a968bd-46ae-4f29-8f93-3df4edaa695f" />


## Changelog Description

### Changed
- modified inactive users module to use roles instead of capabilities
- updated test descriptions


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Check out PR & ensure the module is active on your site
- `vip dev-env create && vip dev-env start`
- create the wpcomvip user `vip dev-env exec --slug=vip-security-boost -- wp user create wpcomvip test@example.local --role=administrator`
- Using phpmyadmin, update the `wpvip_last_seen` meta for the user within the `wp_usermeta` table to be > 90 days from current timestamp.
- Check if the user has been blocked in wp-admin dashboard