### PR TITLE
[Forced-MFA] Replace capability-based MFA enforcement with role-based approach

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -7,22 +7,22 @@ class Forced_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
 
 	/**
-	 * The capability or capabilities required to force MFA.
+	 * The roles that should have MFA enforced.
 	 *
-	 * @var string|array The capability slug or an array of slugs.
+	 * @var string|array The role slug or an array of role slugs.
 	 */
-	private static $capabilities;
+	private static $roles;
 
 	public static function init() {
 		$forced_mfa_configs = get_module_configs( 'forced-mfa-users' );
 
-		self::$capabilities = $forced_mfa_configs['capabilities'] ?? [];
+		self::$roles = $forced_mfa_configs['roles'] ?? [];
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 	}
 
 	/**
-	* Require 2FA based on capabilities set in config
-	*/
+	 * Require 2FA based on roles set in config
+	 */
 	public static function maybe_enforce_two_factor() {
 		if ( ! is_user_logged_in() ) {
 			return;
@@ -32,33 +32,36 @@ class Forced_MFA_Users {
 			return;
 		}
 
-		$required_capabilities = self::$capabilities;
+		$required_roles = self::$roles;
 
-		if ( empty( $required_capabilities ) ) {
+		if ( empty( $required_roles ) ) {
 			return;
 		}
 
-		if ( is_string( $required_capabilities ) ) {
-			$required_capabilities = [ $required_capabilities ];
+		if ( is_string( $required_roles ) ) {
+			$required_roles = [ $required_roles ];
 		}
 
 		$user_has_two_factor_enforced = false;
 
-		if ( is_array( $required_capabilities ) ) {
-			foreach ( $required_capabilities as $cap ) {
-				// phpcs:ignore WordPress.WP.Capabilities.Undetermined
-				if ( is_string( $cap ) && ! empty( $cap ) && current_user_can( $cap ) ) {
-					$user_has_two_factor_enforced = true;
-					break;
+		if ( is_array( $required_roles ) ) {
+			$user = wp_get_current_user();
+			if ( $user ) {
+				foreach ( $required_roles as $role ) {
+					if ( is_string( $role ) && ! empty( $role ) && in_array( $role, (array) $user->roles, true ) ) {
+						$user_has_two_factor_enforced = true;
+						break;
+					}
 				}
 			}
-		}
 
-		if ( $user_has_two_factor_enforced ) {
-			add_filter( 'wpcom_vip_is_two_factor_forced', function () {
-				return true;
-			}, PHP_INT_MAX );
+			if ( $user_has_two_factor_enforced ) {
+				add_filter( 'wpcom_vip_is_two_factor_forced', function () {
+					return true;
+				}, PHP_INT_MAX );
+			}
 		}
 	}
 }
+
 Forced_MFA_Users::init();

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -44,14 +44,12 @@ class Forced_MFA_Users {
 
 		$user_has_two_factor_enforced = false;
 
-		if ( is_array( $required_roles ) ) {
-			$user = wp_get_current_user();
-			if ( $user ) {
-				foreach ( $required_roles as $role ) {
-					if ( is_string( $role ) && ! empty( $role ) && in_array( $role, (array) $user->roles, true ) ) {
-						$user_has_two_factor_enforced = true;
-						break;
-					}
+		$user = wp_get_current_user();
+		if ( is_array( $required_roles ) && $user ) {
+			foreach ( $required_roles as $role ) {
+				if ( is_string( $role ) && ! empty( $role ) && in_array( $role, (array) $user->roles, true ) ) {
+					$user_has_two_factor_enforced = true;
+					break;
 				}
 			}
 

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -12,16 +12,16 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		// Remove actions/filters added by the class
-		remove_action( 'set_current_user', [ Forced_MFA_Users::class, 'filter_user_capabilities' ] );
+		// Clean up any actions added by the class
 
 		// Reset the static capability property using reflection
 		if ( class_exists( Forced_MFA_Users::class ) ) {
 			try {
 				$reflection = new ReflectionClass( Forced_MFA_Users::class );
-				if ( $reflection->hasProperty( 'capabilities' ) ) {
-					$capabilities_prop = $reflection->getProperty( 'capabilities' );
-					$capabilities_prop->setAccessible( true );
-					$capabilities_prop->setValue( null, null ); // Reset to initial state
+				if ( $reflection->hasProperty( 'roles' ) ) {
+					$roles_prop = $reflection->getProperty( 'roles' );
+					$roles_prop->setAccessible( true );
+					$roles_prop->setValue( null, null ); // Reset to initial state
 				}
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			} catch ( ReflectionException $e ) {
@@ -42,7 +42,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function test_ensure_wpcom_vip_should_force_two_factor_exists() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
+				'forced-mfa-users' => [ 'roles' => 'administrator' ],
 			],
 		] );
 		$this->assertTrue( function_exists( 'wpcom_vip_should_force_two_factor' ) );
@@ -56,7 +56,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
+				'forced-mfa-users' => [ 'roles' => 'administrator' ],
 			],
 		] );
 
@@ -83,14 +83,16 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	 * Helper to set up user and call the filter method.
 	 * Assumes the calling test method has already set up the constant and called init().
 	 */
-	private function setup_user_and_filter( $user_role_or_caps ) {
-		$user_id = self::factory()->user->create( [ 'role' => is_string( $user_role_or_caps ) ? $user_role_or_caps : 'subscriber' ] );
-		if ( is_array( $user_role_or_caps ) ) {
+	private function setup_user_and_filter( $user_role_or_roles ) {
+		$user_id = self::factory()->user->create( [ 'role' => is_string( $user_role_or_roles ) ? $user_role_or_roles : 'subscriber' ] );
+		if ( is_array( $user_role_or_roles ) ) {
 			$user = get_user_by( 'id', $user_id );
 			if ( $user ) { // Check if user creation was successful
-				foreach ( $user_role_or_caps as $cap ) {
-					if ( is_string( $cap ) && ! empty( $cap ) ) { // Add check for valid caps
-						$user->add_cap( $cap );
+				// Remove default role and add the specified roles
+				$user->set_role( '' );
+				foreach ( $user_role_or_roles as $role ) {
+					if ( is_string( $role ) && ! empty( $role ) ) {
+						$user->add_role( $role );
 					}
 				}
 			} else {
@@ -108,133 +110,133 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_maybe_enforce_two_factor_no_capability_set() {
+	public function test_maybe_enforce_two_factor_no_role_set() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => [] ],
+				'forced-mfa-users' => [ 'roles' => [] ],
 			],
 		] );
 		Forced_MFA_Users::init(); // Run init to set the static property
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when no capability is set.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when no role is set.' );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_maybe_enforce_two_factor_single_cap_user_has_cap() {
+	public function test_maybe_enforce_two_factor_single_role_user_has_role() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
-			],
-		] );
-		Forced_MFA_Users::init();
-
-		$this->setup_user_and_filter( 'administrator' ); // Admins have manage_options
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the single required capability.' );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_maybe_enforce_two_factor_single_cap_user_lacks_cap() {
-		define( 'VIP_SECURITY_BOOST_CONFIGS', [
-			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
-			],
-		] );
-		Forced_MFA_Users::init();
-
-		$this->setup_user_and_filter( 'subscriber' ); // Subscribers lack manage_options
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks the single required capability.' );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_maybe_enforce_two_factor_array_cap_user_has_one_cap() {
-		$caps = [ 'edit_posts', 'manage_options' ];
-		define( 'VIP_SECURITY_BOOST_CONFIGS', [
-			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => $caps ],
-			],
-		] );
-		Forced_MFA_Users::init();
-
-		$this->setup_user_and_filter( 'editor' ); // Editors have edit_posts but not manage_options
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_maybe_enforce_two_factor_array_cap_user_lacks_all_caps() {
-		$caps = [ 'manage_options', 'promote_users' ];
-		define( 'VIP_SECURITY_BOOST_CONFIGS', [
-			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => $caps ],
-			],
-		] );
-		Forced_MFA_Users::init();
-
-		$this->setup_user_and_filter( 'editor' ); // Editors lack both capabilities
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks all required capabilities.' );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_maybe_enforce_two_factor_empty_cap_array() {
-		$caps = [];
-		define( 'VIP_SECURITY_BOOST_CONFIGS', [
-			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => $caps ],
+				'forced-mfa-users' => [ 'roles' => 'administrator' ],
 			],
 		] );
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true with an empty capability array.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the single required role.' );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_maybe_enforce_two_factor_invalid_cap_types_in_array_user_has_valid_cap() {
-		$caps = [ 'edit_posts', null, '', 5 ]; // Mix of valid and invalid
+	public function test_maybe_enforce_two_factor_single_role_user_lacks_role() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => $caps ],
+				'forced-mfa-users' => [ 'roles' => 'administrator' ],
 			],
 		] );
 		Forced_MFA_Users::init();
 
-		$this->setup_user_and_filter( 'editor' ); // Has edit_posts
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true if user has at least one valid capability in a mixed array.' );
+		$this->setup_user_and_filter( 'subscriber' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks the single required role.' );
 	}
 
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_maybe_enforce_two_factor_invalid_cap_types_in_array_only_invalid() {
-		$caps = [ null, '', 5 ]; // Only invalid types
+	public function test_maybe_enforce_two_factor_array_role_user_has_one_role() {
+		$roles = [ 'administrator', 'editor' ];
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 'capabilities' => $caps ],
+				'forced-mfa-users' => [ 'roles' => $roles ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		$this->setup_user_and_filter( 'editor' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required roles.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_array_role_user_lacks_all_roles() {
+		$roles = [ 'administrator', 'editor' ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'roles' => $roles ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		$this->setup_user_and_filter( 'author' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks all required roles.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_empty_role_array() {
+		$roles = [];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'roles' => $roles ],
 			],
 		] );
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if only invalid capability types are provided.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true with an empty role array.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_invalid_role_types_in_array_user_has_valid_role() {
+		$roles = [ 'editor', 123, [], new stdClass() ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'roles' => $roles ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		$this->setup_user_and_filter( 'editor' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has a valid role even if other array items are invalid.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_invalid_role_types_in_array_only_invalid() {
+		$roles = [ 123, [], new stdClass() ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'roles' => $roles ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		$this->setup_user_and_filter( 'administrator' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when all roles in array are invalid types.' );
 	}
 
 	/**

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -85,20 +85,6 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	 */
 	private function setup_user_and_filter( $user_role_or_roles ) {
 		$user_id = self::factory()->user->create( [ 'role' => is_string( $user_role_or_roles ) ? $user_role_or_roles : 'subscriber' ] );
-		if ( is_array( $user_role_or_roles ) ) {
-			$user = get_user_by( 'id', $user_id );
-			if ( $user ) { // Check if user creation was successful
-				// Remove default role and add the specified roles
-				$user->set_role( '' );
-				foreach ( $user_role_or_roles as $role ) {
-					if ( is_string( $role ) && ! empty( $role ) ) {
-						$user->add_role( $role );
-					}
-				}
-			} else {
-				$this->fail( 'Failed to create user for testing.' );
-			}
-		}
 		wp_set_current_user( $user_id );
 
 		// Manually trigger the action hook's callback for testing isolation

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -12,7 +12,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 	public function tearDown(): void {
 		// Remove actions/filters added by the class
-		// Clean up any actions added by the class
+		remove_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] );
 
 		// Reset the static capability property using reflection
 		if ( class_exists( Forced_MFA_Users::class ) ) {


### PR DESCRIPTION
## Description
Continuing the work on moving towards using roles instead of capabilities, in this case we're changing the logic of the Forced MFA plugin so that it uses roles.


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. `vip dev-env create && vip dev-env start`
3.  Update `vip-security-boost.php` and add this for testing
```
add_filter( 'wpcom_vip_is_two_factor_local_testing', '__return_true' );
```
4. Add test users and note their username/passwords.
```
for role in administrator editor author; do
  rand=$((RANDOM % 90 + 10))
  username="test${role}${rand}"
  email="${username}@example.local"
  echo "Creating user: $username"
  vip dev-env exec --slug=vip-security-boost -- wp user create "$username" "$email" --role="$role"
done
```
7. Set `force-mfa-user` config to `['administrator','editor']` 
8. Login as `author` > verify that MFA is required banner is NOT displayed
9. Login as `editor` > verify that MFA is required banner is displayed
10. Login as `administrator` > verify that MFA is required banner is displayed