### PR TITLE
Fix email notification when adding privileged users on multisites

### DIFF
--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -31,13 +31,6 @@ class Notify_Privileged_Activity {
 				get_bloginfo( 'name' )
 			);
 
-			$message = sprintf(
-				/* Translators: %1$s is the username, %2$s is the user email. */
-				__( 'A new user with administrator privileges has been created:\nUsername: %1$s\nEmail: %2$s', 'wpvip' ),
-				$user->user_login,
-				$user->user_email
-			);
-
 			Email::send( $user_id, $admin_email, $subject, 'privileged-user-created', [
 				'user_login' => $user->user_login,
 				'user_email' => $user->user_email,

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -5,7 +5,11 @@ use Automattic\VIP\Security\Email\Email;
 
 class Notify_Privileged_Activity {
 	public static function init() {
-		add_action( 'user_register', [ __CLASS__, 'notify_admin_user_creation' ] );
+		if ( is_multisite() ) {
+			add_action( 'add_user_to_blog', [ __CLASS__, 'notify_admin_user_creation' ] );
+		} else {
+			add_action( 'user_register', [ __CLASS__, 'notify_admin_user_creation' ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

This pull request introduces changes to the `Notify_Privileged_Activity` class to improve how notifications are handled for new privileged user creation in both multisite and single-site WordPress environments. The most significant updates include adding multisite compatibility and streamlining the email notification logic.

### Multisite Compatibility:

* Updated the `init` method to add a new action hook, `add_user_to_blog`, for multisite environments, ensuring that admin notifications are triggered when a privileged user is added to a blog. The existing `user_register` action is retained for single-site environments.

### Notification Logic Simplification:

* Removed the inline construction of the email message string in the `notify_admin_user_creation` method. Instead, the method now directly uses the `Email::send` function with a template (`privileged-user-created`) and user data, simplifying the logic and improving maintainability.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Open wp-admin
2. Go to the user management
3. Add a new user with role `Administrator
4. Check your mailpit inbox at: http://vip-security-boost-mailpit.vipdev.lndo.site/
5. Verify that you received an email with subject `local - [VIP Security Boost] New Administrator User Created`

**Do the above for both single site and multisite**:

### Changing from multisite to single site and vice versa

1. Open `.wpvip/vip-dev-env.yml.ejs` 
6. Change `multisite: true` -> `multisite: false`
7. `vip dev-env destroy`
8. `vip dev-env create`
9. ⚠️ Destroying your environment will erase your `.env` file (The one containing your `VIP_CONFIG_API_URL` config). Remember to add it back