### PR TITLE
Show the MFA notice only for users with `manage_options` capabilities

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -55,6 +55,11 @@ class Highlight_MFA_Users {
 			return;
 		}
 
+		// Only show the notice to admins
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		// Only show on the main users list table
 		$screen = get_current_screen();
 		if ( ! $screen || 'users' !== $screen->id ) {

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -197,7 +197,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 
 	/**
-	 * Test that the admin notice is displayed correctly when MFA-disabled admins exist.
+	 * Test that the admin notice is not displayed when we're an editor
 	 */
 	public function test_display_mfa_disabled_notice_does_not_show_when_not_admin() {
 		$this->set_admin_screen_users();

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -63,7 +63,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		// Set skipped users option
 		update_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY, [ $this->admin_user_mfa_skipped_id ] );
-
+		wp_set_current_user( $this->admin_user_mfa_enabled_id );
 		Highlight_MFA_Users::init();
 	}
 
@@ -85,7 +85,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$_GET                      = $this->original_get;
 		$GLOBALS['current_screen'] = $this->original_current_screen;
 		unset( $GLOBALS['current_screen'] ); // Ensure it's fully removed if it wasn't set before
-
+		wp_set_current_user( 0 );
 		parent::tearDown();
 	}
 
@@ -193,6 +193,25 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertEquals( $original_exclude_query, $query->get( 'exclude' ) );
 
 		unset( $_GET['filter_mfa_disabled'] );
+	}
+
+
+	/**
+	 * Test that the admin notice is displayed correctly when MFA-disabled admins exist.
+	 */
+	public function test_display_mfa_disabled_notice_does_not_show_when_not_admin() {
+		$this->set_admin_screen_users();
+		// Set a non-admin user
+		wp_set_current_user( $this->editor_user_id );
+
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertEquals( '', $output );
+
+		// Reset current user
+		wp_set_current_user( 0 );
 	}
 
 	/**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -209,9 +209,6 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertEquals( '', $output );
-
-		// Reset current user
-		wp_set_current_user( 0 );
 	}
 
 	/**


### PR DESCRIPTION
## Description

Currently, the Highlight MFA module is displaying the notice for every user landing on the user list. 
This could create confusion because that's not something that every user (think subscribers) can act upon.

This PR changes the logic so that we will show the notice only if the logged in user has `manage_options` capabilities.

## Changelog Description

### Added
- MFA Notice is now only displayed for users with `manage_options` capabilities ("admins")


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Log in as admin and go to the user list, ensure you see the notice (if you have users without MFA)
3. Log in as editor and the notice shouldn't be there anymore.