### PR TITLE
Improve Higlight-MFA Module notice to specify the affected roles

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -67,6 +67,7 @@ class Highlight_MFA_Users {
 		$configured_roles_for_comparison = self::$roles;
 		\sort( $configured_roles_for_comparison ); // Use global sort
 
+		// unordered array check with ==
 		$is_default_config = ( self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS === $configured_roles_for_comparison || empty( $configured_roles_for_comparison ) );
 
 		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -4,8 +4,9 @@ namespace Automattic\VIP\Security\MFAUsers;
 use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Highlight_MFA_Users {
-	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
-	const ROLE_COLUMN_KEY              = 'role';
+	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
+	const ROLE_COLUMN_KEY                 = 'role';
+	const DEFAULT_ADMIN_EDITOR_ROLE_SLUGS = [ 'administrator', 'editor' ];
 
 	/**
 	 * The roles used to highlight users without MFA.
@@ -17,7 +18,7 @@ class Highlight_MFA_Users {
 	public static function init() {
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = get_module_configs( 'highlight-mfa-users' );
-		self::$roles           = $highlight_mfa_configs['roles'] ?? [ 'administrator', 'editor' ]; // Default to administrator and editor if not configured
+		self::$roles           = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS; // Default to administrator and editor if not configured
 
 		if ( ! is_array( self::$roles ) ) {
 			self::$roles = [ self::$roles ];
@@ -25,7 +26,7 @@ class Highlight_MFA_Users {
 		self::$roles = array_filter( self::$roles );
 		// If after filtering, the array is empty, default back to administrator and editor
 		if ( empty( self::$roles ) ) {
-			self::$roles = [ 'administrator', 'editor' ];
+			self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
@@ -61,6 +62,13 @@ class Highlight_MFA_Users {
 			return;
 		}
 
+		// Determine notice text based on role configuration
+		// self::$roles is already an array and populated from init().
+		$configured_roles_for_comparison = self::$roles;
+		\sort( $configured_roles_for_comparison ); // Use global sort
+
+		$is_default_config = ( self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS === $configured_roles_for_comparison || empty( $configured_roles_for_comparison ) );
+
 		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
 		if ( ! is_array( $skipped_user_ids ) ) {
 			$skipped_user_ids = [];
@@ -95,43 +103,102 @@ class Highlight_MFA_Users {
 			$is_filtered = isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'];
 
 			if ( $is_filtered ) {
-				// Display notice for when the list IS filtered
-				$show_all_url = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
+				// Display info notice for when the list IS filtered
+				$show_all_url        = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
+				$notice_message_text = self::get_missing_mfa_notice_message_text( $mfa_disabled_count, $is_default_config );
+
 				printf(
 					'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>',
-					esc_html( sprintf(
-						/* Translators: %d is the number of users without 2FA enabled being shown in the filtered list. */
-						_n(
-							'Showing %d user without Two-Factor Authentication enabled.',
-							'Showing %d users without Two-Factor Authentication enabled.',
-							$mfa_disabled_count,
-							'wpvip'
-						),
-						number_format_i18n( $mfa_disabled_count )
-					) ),
+					esc_html( $notice_message_text ),
 					esc_url( $show_all_url ),
 					esc_html__( 'Show all users.', 'wpvip' )
 				);
 			} else {
 				// Display the original notice when the list is NOT filtered
-				$filter_url = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+				$filter_url          = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+				$notice_message_text = self::get_filtering_mfa_info_message_text( $mfa_disabled_count, $is_default_config );
+
 				printf(
 					'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
-					esc_html( sprintf(
-						/* Translators: %d is the number of users without 2FA enabled. */
-						_n(
-							'There is %d user with Two-Factor Authentication disabled.',
-							'There are %d users with Two-Factor Authentication disabled.',
-							$mfa_disabled_count,
-							'wpvip'
-						),
-						number_format_i18n( $mfa_disabled_count )
-					) ),
+					esc_html( $notice_message_text ),
 					esc_url( $filter_url ),
 					esc_html__( 'Filter list to show these users.', 'wpvip' )
 				);
 			}
 		}
+	}
+
+	/**
+	 * Get the notice message text for when users with missing MFA are shown.
+	 *
+	 * @param int $mfa_disabled_count The number of users with missing MFA.
+	 * @param bool $is_default_config Whether the default roles are being used.
+	 * @return string The notice message text.
+	 */
+	protected static function get_missing_mfa_notice_message_text( $mfa_disabled_count, $is_default_config ) {
+		$notice_message_text = '';
+		if ( $is_default_config ) {
+			// Default roles: Administrator, Editor
+			$notice_message_text = sprintf(
+				/* Translators: %d is the number of users with Administrator or Editor roles without 2FA enabled being shown. */
+				_n(
+					'Showing %d user with Administrator or Editor roles without Two-Factor Authentication enabled.',
+					'Showing %d users with Administrator or Editor roles without Two-Factor Authentication enabled.',
+					$mfa_disabled_count,
+					'wpvip'
+				),
+				number_format_i18n( $mfa_disabled_count )
+			);
+		} else {
+			// Custom roles
+			$notice_message_text = sprintf(
+				/* Translators: %d is the number of users with high-privileges without 2FA enabled being shown. */
+				_n(
+					'Showing %d user with high-privileges without Two-Factor Authentication enabled.',
+					'Showing %d users with high-privileges without Two-Factor Authentication enabled.',
+					$mfa_disabled_count,
+					'wpvip'
+				),
+				number_format_i18n( $mfa_disabled_count )
+			);
+		}
+
+		return $notice_message_text;
+	}
+
+	/**
+	 * Get the notice message text for when users with missing MFA are filtered.
+	 *
+	 * @param int $mfa_disabled_count The number of users with missing MFA.
+	 * @param bool $is_default_config Whether the default roles are being used.
+	 * @return string The notice message text.
+	 */
+	protected static function get_filtering_mfa_info_message_text( $mfa_disabled_count, $is_default_config ) {
+		$notice_message_text = '';
+		if ( $is_default_config ) {
+			$notice_message_text = sprintf(
+					/* Translators: %d is the number of users with Administrator or Editor roles and 2FA disabled. */
+				_n(
+					'There is %d user with Administrator or Editor roles with Two-Factor Authentication disabled.',
+					'There are %d users with Administrator or Editor roles with Two-Factor Authentication disabled.',
+					$mfa_disabled_count,
+					'wpvip'
+				),
+				number_format_i18n( $mfa_disabled_count )
+			);
+		} else {
+			$notice_message_text = sprintf(
+				/* Translators: %d is the number of high-privilege users with 2FA disabled. */
+				_n(
+					'There is %d user with high-privileges with Two-Factor Authentication disabled.',
+					'There are %d users with high-privileges with Two-Factor Authentication disabled.',
+					$mfa_disabled_count,
+					'wpvip'
+				),
+				number_format_i18n( $mfa_disabled_count )
+			);
+		}
+		return $notice_message_text;
 	}
 
 	/**

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -178,7 +178,7 @@ class Highlight_MFA_Users {
 		$notice_message_text = '';
 		if ( $is_default_config ) {
 			$notice_message_text = sprintf(
-					/* Translators: %d is the number of users with Administrator or Editor roles and 2FA disabled. */
+				/* Translators: %d is the number of users with Administrator or Editor roles and 2FA disabled. */
 				_n(
 					'There is %d user with Administrator or Editor roles with Two-Factor Authentication disabled.',
 					'There are %d users with Administrator or Editor roles with Two-Factor Authentication disabled.',

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -212,8 +212,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 			sprintf(
 				// translators: %d: Number of users.
 				_n(
-					'There is %d user with Two-Factor Authentication disabled.',
-					'There are %d users with Two-Factor Authentication disabled.',
+					'There is %d user with Administrator or Editor roles with Two-Factor Authentication disabled.',
+					'There are %d users with Administrator or Editor roles with Two-Factor Authentication disabled.',
 					$expected_count,
 					'wpvip'
 				),
@@ -248,8 +248,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 			sprintf(
 				// translators: %d: Number of users.
 				_n(
-					'Showing %d user without Two-Factor Authentication enabled.',
-					'Showing %d users without Two-Factor Authentication enabled.',
+					'Showing %d user with Administrator or Editor roles without Two-Factor Authentication enabled.',
+					'Showing %d users with Administrator or Editor roles without Two-Factor Authentication enabled.',
 					$expected_count,
 					'wpvip'
 				),
@@ -306,6 +306,107 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		Highlight_MFA_Users::display_mfa_disabled_notice();
 		$output = ob_get_clean();
 		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that the admin notice (filtered view) displays correctly for custom high-privilege roles.
+	 */
+	public function test_display_mfa_disabled_notice_shows_correct_filtered_message_for_custom_roles() {
+		$this->set_admin_screen_users();
+		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
+
+		// Set custom roles using reflection
+		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
+		$roles_property   = $reflection_class->getProperty( 'roles' );
+		$roles_property->setAccessible( true );
+		$custom_roles = [ 'author', 'contributor' ];
+		$roles_property->setValue( null, $custom_roles );
+
+		// Create users with custom roles
+		$author_user_id      = $this->factory()->user->create( [ 'role' => 'author' ] );
+		$contributor_user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
+
+		// Existing users (admin_user_mfa_disabled_id, editor_user_id, user ID 1) should not be counted
+		// as 'administrator' and 'editor' are not in $custom_roles for this test.
+
+		$expected_count  = 2; // The author and contributor created above.
+		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
+		$expected_output = sprintf(
+			'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>',
+			sprintf(
+				// translators: %d: Number of users.
+				_n(
+					'Showing %d user with high-privileges without Two-Factor Authentication enabled.',
+					'Showing %d users with high-privileges without Two-Factor Authentication enabled.',
+					$expected_count,
+					'wpvip'
+				),
+				number_format_i18n( $expected_count )
+			),
+			esc_url( $show_all_url ),
+			esc_html__( 'Show all users.', 'wpvip' )
+		);
+
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertEquals( $expected_output, $output );
+
+		unset( $_GET['filter_mfa_disabled'] ); // Clean up
+	}
+
+	/**
+	 * Test that the admin notice displays correctly for custom high-privilege roles.
+	 */
+	public function test_display_mfa_disabled_notice_shows_for_custom_roles() {
+		$this->set_admin_screen_users();
+
+		// Set custom roles using reflection
+		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
+		$roles_property   = $reflection_class->getProperty( 'roles' );
+		$roles_property->setAccessible( true );
+		// Highlight_MFA_Users::init() in setUp already set roles to default.
+		// We are overriding them here for this specific test.
+		$custom_roles = [ 'author', 'contributor' ];
+		$roles_property->setValue( null, $custom_roles );
+
+		// Create users with custom roles
+		$author_user_id = $this->factory()->user->create( [ 'role' => 'author' ] );
+		// Ensure this user is MFA disabled (default for mock unless added to Two_Factor_Core::$mock_enabled_user_ids)
+
+		$contributor_user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
+		// Ensure this user is MFA disabled
+
+		// Existing users (admin_user_mfa_disabled_id, editor_user_id, user ID 1) should not be counted
+		// as 'administrator' and 'editor' are not in $custom_roles for this test.
+
+		$expected_count  = 2; // The author and contributor created above.
+		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+		$expected_output = sprintf(
+			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+			sprintf(
+				// translators: %d: Number of users.
+				_n(
+					'There is %d user with high-privileges with Two-Factor Authentication disabled.',
+					'There are %d users with high-privileges with Two-Factor Authentication disabled.',
+					$expected_count,
+					'wpvip'
+				),
+				number_format_i18n( $expected_count )
+			),
+			esc_url( $filter_url ),
+			esc_html__( 'Filter list to show these users.', 'wpvip' )
+		);
+
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output = ob_get_clean();
+
+		$this->assertEquals( $expected_output, $output );
+
+		// No need to explicitly clean up $author_user_id, $contributor_user_id as WP_UnitTestCase handles factory users.
+		// No need to restore Highlight_MFA_Users::$roles as the next test's setUp() will call init() again.
 	}
 
 	/**


### PR DESCRIPTION
## Description

When using the default config, the Highlight MFA module will create a notice saying that there are users without MFA.
That was considered too broad and would not represent the actual config which is based on the administrators and editors who do not have MFA active. 

In this PR we're introducing a change in the messaging so that whenever we're using the default config, we're exposing the fact that administrators and editors are the one affected by this notice.
At the same time if the module is set up to use a different set of roles, we will also support those by having a more generic yet less broad definition which uses the term "high privileges" to indicate that the affected users are relevant when managing the site.

![CleanShot 2025-06-06 at 16 44 09@2x](https://github.com/user-attachments/assets/ac726266-3c8e-4d10-b04b-2e1736a6c841)
![CleanShot 2025-06-06 at 16 44 26@2x](https://github.com/user-attachments/assets/417992ad-a690-4d43-8cf6-7c206fec1dc8)

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test


1. Check out PR.
1. Go to `wp-admin` > `Users` list and check the two new messages, click on the filter link and check that the message is consistent.