### PR TITLE
Add badge to display inactive/blocked status in WP Admin user page

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -150,7 +150,7 @@ class Inactive_Users {
 		global $wp_list_table;
 
 		// Make sure we have a list table and it's the users list table
-		if ( ! $wp_list_table || ! is_a( $wp_list_table, 'WP_Users_List_Table' ) ) {
+		if ( ! $wp_list_table || ! ( $wp_list_table instanceof \WP_Users_List_Table ) ) {
 			return;
 		}
 
@@ -180,7 +180,7 @@ class Inactive_Users {
 			);
 
 			// Add the badge to the user_login field (which is what gets displayed in the username column)
-			$user->user_login = $user->user_login . '&nbsp;&nbsp' . $badge;
+			$user->user_login = esc_html( $user->user_login ) . '&nbsp;&nbsp' . $badge;
 		}
 
 		// Update the list table items

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -150,7 +150,11 @@ class Inactive_Users {
 		global $wp_list_table;
 
 		// Make sure we have a list table and it's the users list table
-		if ( ! $wp_list_table || ! ( $wp_list_table instanceof \WP_Users_List_Table ) ) {
+		if ( ! $wp_list_table ) {
+			return;
+		}
+
+		if ( ! ( $wp_list_table instanceof \WP_Users_List_Table ) && ! ( $wp_list_table instanceof \WP_MS_Users_List_Table ) ) {
 			return;
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -180,7 +180,7 @@ class Inactive_Users {
 			);
 
 			// Add the badge to the user_login field (which is what gets displayed in the username column)
-			$user->user_login = esc_html( $user->user_login ) . '&nbsp;&nbsp' . $badge;
+			$user->user_login = esc_html( $user->user_login ) . '&nbsp;&nbsp;' . $badge;
 		}
 
 		// Update the list table items

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -52,6 +52,12 @@ class Inactive_Users {
 			add_filter( 'manage_users_sortable_columns', [ __CLASS__, 'add_last_seen_sortable_column' ] );
 			add_filter( 'manage_users-network_sortable_columns', [ __CLASS__, 'add_last_seen_sortable_column' ] );
 			add_filter( 'users_list_table_query_args', [ __CLASS__, 'last_seen_order_by_query_args' ] );
+
+			// Add badges to username display by modifying the list table items
+			add_action( 'admin_head-users.php', [ __CLASS__, 'modify_users_list_table_items' ] );
+			add_action( 'admin_head-users.php', [ __CLASS__, 'add_username_badge_styles' ] );
+			add_action( 'admin_head-users-network.php', [ __CLASS__, 'modify_users_list_table_items' ] );
+			add_action( 'admin_head-users-network.php', [ __CLASS__, 'add_username_badge_styles' ] );
 		}
 
 		if ( self::is_block_action_enabled() ) {
@@ -138,6 +144,72 @@ class Inactive_Users {
 		}
 
 		return $available;
+	}
+
+	public static function modify_users_list_table_items() {
+		global $wp_list_table;
+
+		// Make sure we have a list table and it's the users list table
+		if ( ! $wp_list_table || ! is_a( $wp_list_table, 'WP_Users_List_Table' ) ) {
+			return;
+		}
+
+		// Get the items from the list table
+		$items = $wp_list_table->items;
+		if ( empty( $items ) ) {
+			return;
+		}
+
+		// Modify each user item to add badge to username
+		foreach ( $items as $user ) {
+			if ( ! self::is_considered_inactive( $user->ID ) ) {
+				continue;
+			}
+
+			// Create the badge
+			$badge_text = self::is_block_action_enabled() ?
+				esc_html__( 'Blocked: Inactivity', 'wpvip' ) :
+				esc_html__( 'Inactive User', 'wpvip' );
+
+			$badge_class = self::is_block_action_enabled() ? 'blocked' : 'inactive';
+
+			$badge = sprintf(
+				'<span class="inactive-user-badge inactive-user-badge--%s">%s</span>',
+				$badge_class,
+				$badge_text
+			);
+
+			// Add the badge to the user_login field (which is what gets displayed in the username column)
+			$user->user_login = $user->user_login . '&nbsp;&nbsp' . $badge;
+		}
+
+		// Update the list table items
+		$wp_list_table->items = $items;
+	}
+
+	public static function add_username_badge_styles() {
+		?>
+		<style type="text/css">
+		.inactive-user-badge {
+			border-radius: 4px;
+			display: inline-block;
+			font-size: 11px;
+			font-weight: 500;
+			margin-bottom: 4px;
+			margin-top: 4px;
+			padding: 2px 8px;
+			vertical-align: middle;
+		}
+		.inactive-user-badge--blocked {
+			background: #d63638;
+			color: white;
+		}
+		.inactive-user-badge--inactive {
+			background: #f0b849;
+			color: #1d2327;
+		}
+		</style>
+		<?php
 	}
 
 	public static function add_last_seen_column_head( $columns ) {

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -18,10 +18,12 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
 			define('VIP_SECURITY_BOOST_CONFIGS', [
-				'inactive_users' => [
-					'mode'                           => 'BLOCK',
-					'considered_inactive_after_days' => 90,
-					'roles'                          => $this->elevated_roles,
+				'module_configs' => [
+					'inactive-users' => [
+						'mode'                           => 'BLOCK',
+						'considered_inactive_after_days' => 90,
+						'roles'                          => $this->elevated_roles,
+					],
 				],
 			]);
 		}
@@ -161,5 +163,121 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertFalse( Inactive_Users::is_considered_inactive( $new_user_id ) );
 
 		wp_delete_user( $new_user_id );
+	}
+
+	/**
+	 * Test that modify_users_list_table_items adds badges to inactive users
+	 */
+	public function test_modify_users_list_table_items_adds_badges() {
+		// Create a mock WP_Users_List_Table
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Create test user objects
+		$inactive_user = new stdClass();
+		$inactive_user->ID = $this->user_id;
+		$inactive_user->user_login = 'testuser';
+
+		$active_user = new stdClass();
+		$active_user->ID = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
+		]);
+		$active_user->user_login = 'activeuser';
+
+		// Set up the list table items
+		$wp_list_table->items = [ $inactive_user, $active_user ];
+
+		// Make the first user inactive
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Call the method
+		Inactive_Users::modify_users_list_table_items();
+
+		// Check that the inactive user has a badge added
+		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
+		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+
+		// Check that the active user doesn't have a badge
+		$this->assertEquals( 'activeuser', $wp_list_table->items[1]->user_login );
+
+		// Clean up
+		wp_delete_user( $active_user->ID );
+	}
+
+	/**
+	 * Test that modify_users_list_table_items shows correct badge text
+	 */
+	public function test_modify_users_list_table_items_badge_text() {
+		// Create a mock WP_Users_List_Table
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Create test user object
+		$inactive_user = new stdClass();
+		$inactive_user->ID = $this->user_id;
+		$inactive_user->user_login = 'testuser';
+
+		$wp_list_table->items = [ $inactive_user ];
+
+		// Make the user inactive
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Test that a badge is added (the specific text depends on the current config)
+		Inactive_Users::modify_users_list_table_items();
+		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
+		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+
+		// Should contain either "Blocked: Inactivity" or "Inactive User"
+		$login_text = $wp_list_table->items[0]->user_login;
+		$this->assertTrue(
+			strpos( $login_text, 'Blocked: Inactivity' ) !== false ||
+			strpos( $login_text, 'Inactive User' ) !== false,
+			'Badge should contain either "Blocked: Inactivity" or "Inactive User"'
+		);
+	}
+
+	/**
+	 * Test that modify_users_list_table_items handles empty or invalid list table
+	 */
+	public function test_modify_users_list_table_items_handles_invalid_input() {
+		global $wp_list_table;
+
+		// Test with no list table
+		$wp_list_table = null;
+		Inactive_Users::modify_users_list_table_items();
+		$this->assertTrue( true ); // Should not crash
+
+		// Test with wrong type of list table
+		$wp_list_table = new stdClass();
+		Inactive_Users::modify_users_list_table_items();
+		$this->assertTrue( true ); // Should not crash
+
+		// Test with empty items
+		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+		$wp_list_table->items = [];
+		Inactive_Users::modify_users_list_table_items();
+		$this->assertTrue( true ); // Should not crash
+	}
+
+	/**
+	 * Test that add_username_badge_styles outputs CSS with correct classes and colors
+	 */
+	public function test_add_username_badge_styles_outputs_css() {
+		ob_start();
+		Inactive_Users::add_username_badge_styles();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '.inactive-user-badge', $output );
+		$this->assertStringContainsString( '.inactive-user-badge--blocked', $output );
+		$this->assertStringContainsString( '.inactive-user-badge--inactive', $output );
+		$this->assertStringContainsString( 'background: #d63638', $output );
+		$this->assertStringContainsString( 'background: #f0b849', $output );
 	}
 }

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -176,12 +176,12 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			->getMock();
 
 		// Create test user objects
-		$inactive_user = new stdClass();
-		$inactive_user->ID = $this->user_id;
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
 		$inactive_user->user_login = 'testuser';
 
-		$active_user = new stdClass();
-		$active_user->ID = $this->factory->user->create([
+		$active_user             = new stdClass();
+		$active_user->ID         = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 day' ) ),
 		]);
@@ -218,8 +218,8 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			->getMock();
 
 		// Create test user object
-		$inactive_user = new stdClass();
-		$inactive_user->ID = $this->user_id;
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
 		$inactive_user->user_login = 'testuser';
 
 		$wp_list_table->items = [ $inactive_user ];
@@ -258,7 +258,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertTrue( true ); // Should not crash
 
 		// Test with empty items
-		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+		$wp_list_table        = $this->getMockBuilder( 'WP_Users_List_Table' )
 			->disableOriginalConstructor()
 			->getMock();
 		$wp_list_table->items = [];

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -267,6 +267,34 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that modify_users_list_table_items works with WP_MS_Users_List_Table for multisite
+	 */
+	public function test_modify_users_list_table_items_works_with_multisite_table() {
+		// Create a mock WP_MS_Users_List_Table
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_MS_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Create test user object
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
+		$inactive_user->user_login = 'testuser';
+
+		$wp_list_table->items = [ $inactive_user ];
+
+		// Make the user inactive
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Call the method
+		Inactive_Users::modify_users_list_table_items();
+
+		// Check that the inactive user has a badge added
+		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
+		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+	}
+
+	/**
 	 * Test that add_username_badge_styles outputs CSS with correct classes and colors
 	 */
 	public function test_add_username_badge_styles_outputs_css() {


### PR DESCRIPTION
## Description

![Screenshot 2025-06-09 at 10 18 00](https://github.com/user-attachments/assets/ba162952-fae9-462e-b45a-4bc414137cef)

![Screenshot 2025-06-09 at 10 18 53](https://github.com/user-attachments/assets/93c0728e-cecb-4ffb-ad8b-13c95388cb09)


This PR implements visual badges for inactive and blocked users in the WordPress admin users list table, addressing Linear issue [PLTFRM-956](https://linear.app/a8c/issue/PLTFRM-956/inactive-users-add-badge-to-display-inactive-blocked-status-to-wp).

The implementation adds badges next to usernames in the users list table to clearly indicate their status:
- **Yellow badge** with "Inactive User" text when blocking is disabled (REPORT mode)
- **Red badge** with "Blocked: Inactivity" text when blocking is enabled (BLOCK mode)

### Technical Implementation

- Added `modify_users_list_table_items()` method that hooks into `admin_head-users.php` and `admin_head-users-network.php` to modify the global `$wp_list_table` object
- Added `add_username_badge_styles()` method to inject CSS styles for the badges
- Badges are only added to users who are considered inactive according to existing logic
- Preserves existing functionality and content while adding visual indicators

## Changelog Description

### Added
- Visual badges in WordPress admin users list table to indicate inactive/blocked user status
- Yellow "Inactive User" badge for inactive users when blocking is disabled
- Red "Blocked: Inactivity" badge for inactive users when blocking is enabled

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Check out this PR
2. Configure the inactive users module in REPORT or BLOCK mode
3. Create test users with administrator roles
4. Set some users as inactive by updating their `wpvip_last_seen` meta to a timestamp older than the configured threshold (default 90 days)
5. Go to `wp-admin` > `Users`
6. Verify that inactive users display the appropriate badge:
   - Yellow "Inactive User" badge in REPORT mode
   - Red "Blocked: Inactivity" badge in BLOCK mode
7. Verify that active users do not display any badge
8. Test on both single-site and network admin user pages