### PR TITLE
Add log2logstash error and debug logging

### DIFF
--- a/class-loader.php
+++ b/class-loader.php
@@ -2,6 +2,7 @@
 namespace Automattic\VIP\Security;
 
 class Loader {
+	const LOG_FEATURE_NAME = 'security-boost:module-loader';
 	public static function init() {
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
 			throw new \Exception( 'VIP_SECURITY_BOOST_CONFIGS is not defined.' );
@@ -30,7 +31,7 @@ class Loader {
 				\Automattic\VIP\Logstash\log2logstash(
 					[
 						'severity' => 'error',
-						'feature'  => 'security-boost:module-loader',
+						'feature'  => self::LOG_FEATURE_NAME,
 						'message'  => 'Module not found: ' . $module,
 					]
 				);

--- a/class-loader.php
+++ b/class-loader.php
@@ -1,8 +1,10 @@
 <?php
 namespace Automattic\VIP\Security;
 
+use Automattic\VIP\Security\Constants;
+
 class Loader {
-	const LOG_FEATURE_NAME = 'security-boost:module-loader';
+	const LOG_FEATURE_NAME = 'sb_module_loader';
 	public static function init() {
 		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
 			throw new \Exception( 'VIP_SECURITY_BOOST_CONFIGS is not defined.' );
@@ -31,6 +33,7 @@ class Loader {
 				\Automattic\VIP\Logstash\log2logstash(
 					[
 						'severity' => 'error',
+						'plugin'   => Constants::LOG_PLUGIN_NAME,
 						'feature'  => self::LOG_FEATURE_NAME,
 						'message'  => 'Module not found: ' . $module,
 					]

--- a/class-loader.php
+++ b/class-loader.php
@@ -27,6 +27,13 @@ class Loader {
 			} else {
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error( 'Module not found: ' . esc_html( $module ), E_USER_WARNING );
+				\Automattic\VIP\Logstash\log2logstash(
+					[
+						'severity' => 'error',
+						'feature'  => 'security-boost:module-loader',
+						'message'  => 'Module not found: ' . $module,
+					]
+				);
 			}
 		}
 	}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -10,6 +10,8 @@ class Inactive_Users {
 	private static $mode;
 	public static $release_date;
 
+	const LOG_FEATURE_NAME = 'security-boost:inactive-users';
+
 	const LAST_SEEN_META_KEY                               = 'wpvip_last_seen';
 	const LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY = 'wpvip_last_seen_ignore_inactivity_check_until';
 	const LAST_SEEN_CACHE_GROUP                            = 'wpvip_last_seen';
@@ -104,7 +106,7 @@ class Inactive_Users {
 			\Automattic\VIP\Logstash\log2logstash(
 				[
 					'severity' => 'debug',
-					'feature'  => 'security-boost:inactive-users:authenticate',
+					'feature'  => self::LOG_FEATURE_NAME,
 					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, login was blocked.',
 				]
 			);
@@ -142,7 +144,7 @@ class Inactive_Users {
 			\Automattic\VIP\Logstash\log2logstash(
 				[
 					'severity' => 'debug',
-					'feature'  => 'security-boost:inactive-users:application-password-authentication',
+					'feature'  => self::LOG_FEATURE_NAME,
 					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, application password authentication was blocked.',
 				]
 			);

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -101,6 +101,13 @@ class Inactive_Users {
 		}
 
 		if ( $user->ID && self::is_considered_inactive( $user->ID ) ) {
+			\Automattic\VIP\Logstash\log2logstash(
+				[
+					'severity' => 'debug',
+					'feature'  => 'security-boost:inactive-users:authenticate',
+					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, login was blocked.',
+				]
+			);
 			if ( Context::is_xmlrpc_api() ) {
 				add_filter('xmlrpc_login_error', function () {
 					return new \IXR_Error( 403, __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ) );
@@ -132,6 +139,13 @@ class Inactive_Users {
 		}
 
 		if ( self::is_considered_inactive( $user->ID ) ) {
+			\Automattic\VIP\Logstash\log2logstash(
+				[
+					'severity' => 'debug',
+					'feature'  => 'security-boost:inactive-users:application-password-authentication',
+					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, application password authentication was blocked.',
+				]
+			);
 			self::$application_password_authentication_error = new \WP_Error( 'inactive_account', __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ), array( 'status' => 403 ) );
 
 			return false;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -2,6 +2,7 @@
 namespace Automattic\VIP\Security\InactiveUsers;
 
 use Automattic\VIP\Utils\Context;
+use Automattic\VIP\Security\Constants;
 use function Automattic\VIP\Security\Utils\get_module_configs;
 
 class Inactive_Users {
@@ -10,7 +11,7 @@ class Inactive_Users {
 	private static $mode;
 	public static $release_date;
 
-	const LOG_FEATURE_NAME = 'security-boost:inactive-users';
+	const LOG_FEATURE_NAME = 'sb_inactive_users';
 
 	const LAST_SEEN_META_KEY                               = 'wpvip_last_seen';
 	const LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY = 'wpvip_last_seen_ignore_inactivity_check_until';
@@ -107,6 +108,7 @@ class Inactive_Users {
 				[
 					'severity' => 'debug',
 					'feature'  => self::LOG_FEATURE_NAME,
+					'plugin'   => Constants::LOG_PLUGIN_NAME,
 					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, login was blocked.',
 				]
 			);
@@ -145,6 +147,7 @@ class Inactive_Users {
 				[
 					'severity' => 'debug',
 					'feature'  => self::LOG_FEATURE_NAME,
+					'plugin'   => Constants::LOG_PLUGIN_NAME,
 					'message'  => 'User ' . $user->user_login . ' is flagged as inactive, application password authentication was blocked.',
 				]
 			);

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -18,29 +18,46 @@ class Notify_Privileged_Activity {
 	 * @param int $user_id The ID of the newly registered user.
 	 */
 	public static function notify_admin_user_creation( $user_id ) {
-		$user = get_userdata( $user_id );
-		if ( ! $user ) {
-			return;
-		}
-
-		if ( in_array( 'administrator', (array) $user->roles, true ) ) {
-			$admin_email = get_option( 'admin_email' );
-
-			if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {
+		try {
+			$user = get_userdata( $user_id );
+			if ( ! $user ) {
 				return;
 			}
 
-			/* Translators: %s: Site name. */
-			$subject = sprintf( __( '[%s] New Administrator User Created', 'wpvip' ),
-				get_bloginfo( 'name' )
-			);
+			if ( in_array( 'administrator', (array) $user->roles, true ) ) {
+				$admin_email = get_option( 'admin_email' );
 
-			Email::send( $user_id, $admin_email, $subject, 'privileged-user-created', [
-				'user_login' => $user->user_login,
-				'user_email' => $user->user_email,
-				'user_role'  => 'Administrator',
-				'admin_url'  => admin_url(),
-			] );
+				if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {
+					return;
+				}
+
+				/* Translators: %s: Site name. */
+				$subject = sprintf( __( '[%s] New Administrator User Created', 'wpvip' ),
+					get_bloginfo( 'name' )
+				);
+
+				\Automattic\VIP\Logstash\log2logstash(
+					[
+						'severity' => 'debug',
+						'feature'  => 'security-boost:notify-privileged-activity',
+						'message'  => 'New administrator user created: ' . $user->user_login,
+					]
+				);
+				Email::send( $user_id, $admin_email, $subject, 'privileged-user-created', [
+					'user_login' => $user->user_login,
+					'user_email' => $user->user_email,
+					'user_role'  => 'Administrator',
+					'admin_url'  => admin_url(),
+				] );
+			}
+		} catch ( \Exception $e ) {
+			\Automattic\VIP\Logstash\log2logstash(
+				[
+					'severity' => 'error',
+					'feature'  => 'security-boost:notify-privileged-activity',
+					'message'  => 'Failed to notify admin user creation: ' . $e->getMessage(),
+				]
+			);
 		}
 	}
 }

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Security\PrivilegedActivityNotifier;
 use Automattic\VIP\Security\Email\Email;
 
 class Notify_Privileged_Activity {
+	const LOG_FEATURE_NAME = 'security-boost:notify-privileged-activity';
 	public static function init() {
 		if ( is_multisite() ) {
 			add_action( 'add_user_to_blog', [ __CLASS__, 'notify_admin_user_creation' ] );
@@ -39,7 +40,7 @@ class Notify_Privileged_Activity {
 				\Automattic\VIP\Logstash\log2logstash(
 					[
 						'severity' => 'debug',
-						'feature'  => 'security-boost:notify-privileged-activity',
+						'feature'  => self::LOG_FEATURE_NAME,
 						'message'  => 'New administrator user created: ' . $user->user_login,
 					]
 				);
@@ -54,7 +55,7 @@ class Notify_Privileged_Activity {
 			\Automattic\VIP\Logstash\log2logstash(
 				[
 					'severity' => 'error',
-					'feature'  => 'security-boost:notify-privileged-activity',
+					'feature'  => self::LOG_FEATURE_NAME,
 					'message'  => 'Failed to notify admin user creation: ' . $e->getMessage(),
 				]
 			);

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -2,9 +2,10 @@
 namespace Automattic\VIP\Security\PrivilegedActivityNotifier;
 
 use Automattic\VIP\Security\Email\Email;
+use Automattic\VIP\Security\Constants;
 
 class Notify_Privileged_Activity {
-	const LOG_FEATURE_NAME = 'security-boost:notify-privileged-activity';
+	const LOG_FEATURE_NAME = 'sb_notify_privileged_activity';
 	public static function init() {
 		if ( is_multisite() ) {
 			add_action( 'add_user_to_blog', [ __CLASS__, 'notify_admin_user_creation' ] );
@@ -41,6 +42,7 @@ class Notify_Privileged_Activity {
 					[
 						'severity' => 'debug',
 						'feature'  => self::LOG_FEATURE_NAME,
+						'plugin'   => Constants::LOG_PLUGIN_NAME,
 						'message'  => 'New administrator user created: ' . $user->user_login,
 					]
 				);
@@ -56,6 +58,7 @@ class Notify_Privileged_Activity {
 				[
 					'severity' => 'error',
 					'feature'  => self::LOG_FEATURE_NAME,
+					'plugin'   => Constants::LOG_PLUGIN_NAME,
 					'message'  => 'Failed to notify admin user creation: ' . $e->getMessage(),
 				]
 			);

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -12,7 +12,7 @@ use function Automattic\VIP\Security\Utils\get_module_configs;
  * - 1-13: Number of days the session should last. WordPress default is 14 days, so we're allowing users to choose a number below it.
  */
 class Session_Control {
-
+	const LOG_FEATURE_NAME     = 'security-boost:session-control';
 	public const DEFAULT_VALUE = 'default';
 	/**
 	 * Session expiration time in days
@@ -41,7 +41,7 @@ class Session_Control {
 				\Automattic\VIP\Logstash\log2logstash(
 					[
 						'severity' => 'warning',
-						'feature'  => 'security-boost:session-control',
+						'feature'  => self::LOG_FEATURE_NAME,
 						'message'  => 'Invalid session expiration days. Must be an integer. Reverting to default.',
 					]
 				);
@@ -56,7 +56,7 @@ class Session_Control {
 				\Automattic\VIP\Logstash\log2logstash(
 					[
 						'severity' => 'warning',
-						'feature'  => 'security-boost:session-control',
+						'feature'  => self::LOG_FEATURE_NAME,
 						'message'  => 'Invalid session expiration days. Must be between 1 and 13. Reverting to default.',
 					]
 				);

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\VIP\Security\SessionControl;
 
+use Automattic\VIP\Security\Constants;
 use function Automattic\VIP\Security\Utils\get_module_configs;
+
 /**
  * Session Control module for VIP Security Boost
  *
@@ -12,7 +14,7 @@ use function Automattic\VIP\Security\Utils\get_module_configs;
  * - 1-13: Number of days the session should last. WordPress default is 14 days, so we're allowing users to choose a number below it.
  */
 class Session_Control {
-	const LOG_FEATURE_NAME     = 'security-boost:session-control';
+	const LOG_FEATURE_NAME     = 'sb_session_control';
 	public const DEFAULT_VALUE = 'default';
 	/**
 	 * Session expiration time in days
@@ -42,6 +44,7 @@ class Session_Control {
 					[
 						'severity' => 'warning',
 						'feature'  => self::LOG_FEATURE_NAME,
+						'plugin'   => Constants::LOG_PLUGIN_NAME,
 						'message'  => 'Invalid session expiration days. Must be an integer. Reverting to default.',
 					]
 				);
@@ -57,6 +60,7 @@ class Session_Control {
 					[
 						'severity' => 'warning',
 						'feature'  => self::LOG_FEATURE_NAME,
+						'plugin'   => Constants::LOG_PLUGIN_NAME,
 						'message'  => 'Invalid session expiration days. Must be between 1 and 13. Reverting to default.',
 					]
 				);

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -38,6 +38,13 @@ class Session_Control {
 			// Validate the expiration days value (must be between 1 and 13)
 			// check if it's valid int
 			if ( ! is_numeric( $expiration_days_value ) ) {
+				\Automattic\VIP\Logstash\log2logstash(
+					[
+						'severity' => 'warning',
+						'feature'  => 'security-boost:session-control',
+						'message'  => 'Invalid session expiration days. Must be an integer. Reverting to default.',
+					]
+				);
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error( 'Invalid session expiration days. Must be an integer. Reverting to default.', E_USER_WARNING );
 				return;
@@ -45,6 +52,14 @@ class Session_Control {
 			$expiration_days = intval( $expiration_days_value );
 
 			if ( $expiration_days < 1 || $expiration_days > 13 ) {
+
+				\Automattic\VIP\Logstash\log2logstash(
+					[
+						'severity' => 'warning',
+						'feature'  => 'security-boost:session-control',
+						'message'  => 'Invalid session expiration days. Must be between 1 and 13. Reverting to default.',
+					]
+				);
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error( 'Invalid session expiration days. Must be between 1 and 13. Reverting to default.', E_USER_WARNING );
 				return;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../utils/configs.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
+require_once __DIR__ . '/../utils/class-constants.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/utils/class-constants.php
+++ b/utils/class-constants.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Automattic\VIP\Security;
+
+class Constants {
+	const LOG_PLUGIN_NAME = 'vip-security-boost';
+}

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -17,6 +17,7 @@ declare(strict_types = 1);
 
 require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/email/email.php';
+require_once __DIR__ . '/utils/class-constants.php';
 
 use function Automattic\VIP\Security\Utils\load_integration_configs_from_headers;
 use function Automattic\VIP\Security\Utils\load_integration_configs_from_url;

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Plugin Name: WordPress VIP Security Boost
  * Plugin URI: https://github.com/Automattic/vip-security-boost-integration
@@ -32,7 +32,7 @@ if ( $is_local_env ) {
 	if ( ! defined( 'VIP_GO_APP_ID' ) || ! constant( 'VIP_GO_APP_ID' ) ) {
 		define( 'VIP_GO_APP_ID', 101 );
 	}
-	
+
 	// Check headers for integration test configs
 	if ( isset( $_SERVER['HTTP_X_INTEGRATION_TEST'] ) ) {
 		// Load the integration configurations from the headers


### PR DESCRIPTION
## Description

To make sure we can track issues when they arise, and to help with debugging, we're adding some `log2logstash` logs into the plugin.

I didn't want to abuse the logging because, depending on the situation, they might raise more noise and would be unhelpful. Therefore I've added logs in these areas which should be low-noise and helpful when debugging.

We can iterate it further once we get extra feedback.

Logs I've added
* [module-loader] Module not found
* [session-control] Wrong configs
* [inactive-users] Login blocked
* [notify-privileged-activity] Mail sent / error when sending email

While logging I'm also passing the `plugin: 'vip-security-boost'` to make filtering easier at the logstash level

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- If you have a blocked inactive user you can test this out by trying to login and then run `vip dev-env shell -- cat /app/log/debug.log` to see if there's a debug log similar to
- 
```
Automattic\VIP\Logstash\Logger: {
    "site_id": 1,
    "blog_id": 1,
    "http_host": "vip-security-boost.vipdev.lndo.site",
    "severity": "debug",
    "feature": "a8c_vip_sb_inactive_users",
    "message": "User <username> is flagged as inactive, login was blocked.",
    "user_id": 0,
    "extra": "[]",
    "timestamp": "2025-06-10 10:48:51",
    "index": "log2logstash",
    "http_user_agent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/136.0.0.0 Safari\/537.36",
    "file": "\/wp\/wp-content\/plugins\/vip-security-boost\/modules\/inactive-users\/class-inactive-users.php",
    "line": "107",
    "plugin": "vip-security-boost"
}
```