### PR TITLE
fix [PLTFRM-963]: inactive users that are not blocked shown as blocked

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -168,20 +168,7 @@ class Inactive_Users {
 		isset( $_GET['last_seen_filter_nonce'] ) &&
 		wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' )
 		) {
-			$included_roles = self::$elevated_roles;
-
-			if ( ! is_array( $included_roles ) || empty( $included_roles ) ) {
-				// Skip adding the OR clause if no elevated roles are defined
-				return $vars;
-			}
-			$role_queries = [];
-			foreach ( $included_roles as $role ) {
-				$role_queries[] = [
-					'key'     => $GLOBALS['wpdb']->get_blog_prefix() . 'capabilities',
-					'value'   => '"' . $role . '"',
-					'compare' => 'LIKE',
-				];
-			}
+			$vars['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
 
       // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$vars['meta_query'] = [
@@ -192,14 +179,7 @@ class Inactive_Users {
 					'type'    => 'NUMERIC',
 					'compare' => '<',
 				],
-				[
-					'relation' => 'OR',
-					...$role_queries,
-				],
 			];
-
-			// ensure no conflict with top-level meta args
-			unset( $vars['meta_key'], $vars['meta_value'], $vars['meta_type'], $vars['meta_compare'] );
 		}
 
 		return $vars;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -160,17 +160,47 @@ class Inactive_Users {
 		return $vars;
 	}
 
+
 	public static function last_seen_blocked_users_filter_query_args( $vars ) {
-		if ( isset( $_GET['last_seen_filter'] ) && 'blocked' === $_GET['last_seen_filter'] && isset( $_GET['last_seen_filter_nonce'] ) && wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' ) ) {
-			$vars['meta_key'] = self::LAST_SEEN_META_KEY;
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-			$vars['meta_value']   = self::get_inactivity_timestamp();
-			$vars['meta_type']    = 'NUMERIC';
-			$vars['meta_compare'] = '<';
+		if (
+		isset( $_GET['last_seen_filter'] ) &&
+		'blocked' === $_GET['last_seen_filter'] &&
+		isset( $_GET['last_seen_filter_nonce'] ) &&
+		wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' )
+		) {
+			$included_roles = self::$elevated_roles;
+
+			$role_queries = [];
+			foreach ( $included_roles as $role ) {
+				$role_queries[] = [
+					'key'     => $GLOBALS['wpdb']->get_blog_prefix() . 'capabilities',
+					'value'   => '"' . $role . '"',
+					'compare' => 'LIKE',
+				];
+			}
+
+      // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			$vars['meta_query'] = [
+				'relation' => 'AND',
+				[
+					'key'     => self::LAST_SEEN_META_KEY,
+					'value'   => self::get_inactivity_timestamp(),
+					'type'    => 'NUMERIC',
+					'compare' => '<',
+				],
+				[
+					'relation' => 'OR',
+					...$role_queries,
+				],
+			];
+
+			// ensure no conflict with top-level meta args
+			unset( $vars['meta_key'], $vars['meta_value'], $vars['meta_type'], $vars['meta_compare'] );
 		}
 
 		return $vars;
 	}
+
 
 	public static function add_last_seen_column_date( $default_value, $column_name, $user_id ) {
 		if ( 'last_seen' !== $column_name ) {
@@ -220,6 +250,7 @@ class Inactive_Users {
 				'meta_compare' => '<',
 				'count_total'  => false,
 				'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
+				'role__in'     => self::$elevated_roles,
 			),
 		);
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -162,15 +162,16 @@ class Inactive_Users {
 
 
 	public static function last_seen_blocked_users_filter_query_args( $vars ) {
+		// Only filter when the “blocked” last_seen_filter is set and valid
 		if (
-		isset( $_GET['last_seen_filter'] ) &&
-		'blocked' === $_GET['last_seen_filter'] &&
-		isset( $_GET['last_seen_filter_nonce'] ) &&
-		wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' )
+			isset( $_GET['last_seen_filter'] ) &&
+			'blocked' === $_GET['last_seen_filter'] &&
+			isset( $_GET['last_seen_filter_nonce'] ) &&
+			wp_verify_nonce( sanitize_text_field( $_GET['last_seen_filter_nonce'] ), 'last_seen_filter' )
 		) {
 			$vars['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
 
-      // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$vars['meta_query'] = [
 				'relation' => 'AND',
 				[

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -170,6 +170,10 @@ class Inactive_Users {
 		) {
 			$included_roles = self::$elevated_roles;
 
+			if ( ! is_array( $included_roles ) || empty( $included_roles ) ) {
+				// Skip adding the OR clause if no elevated roles are defined
+				return $vars;
+			}
 			$role_queries = [];
 			foreach ( $included_roles as $role ) {
 				$role_queries[] = [
@@ -250,7 +254,7 @@ class Inactive_Users {
 				'meta_compare' => '<',
 				'count_total'  => false,
 				'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
-				'role__in'     => self::$elevated_roles,
+				'role__in'     => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
 			),
 		);
 


### PR DESCRIPTION
## Description
Fixes an issue that causes users that do not have a elevated role to appear in the blocked users filter. Also prevents the blocked users filter from being selected in the same case where a user is "inactive" but doesn't have an elevated role.

The following example uses config that blocks administrators after 90 days of inactivity.

Before: The user with an Subscriber role shows up in blocked users filter.
<img width="1544" alt="Screenshot 2025-06-09 at 10 26 05 AM" src="https://github.com/user-attachments/assets/6f338f7f-37ac-413e-9a41-5249c10279d7" />

After: The filter now only shows inactive user that have escalated roles
<img width="1544" alt="Screenshot 2025-06-09 at 11 30 59 AM" src="https://github.com/user-attachments/assets/3f978d81-4914-4508-920d-cca237ee0361" />

Before: When no inactive user has a blocked role but there are inactive users.
<img width="1544" alt="Screenshot 2025-06-09 at 10 50 06 AM" src="https://github.com/user-attachments/assets/e17c2b6b-26d3-4405-a7f7-8bc66bc30947" />

After: Blocked users filter is unable to be selected
<img width="1544" alt="Screenshot 2025-06-09 at 10 52 42 AM" src="https://github.com/user-attachments/assets/298f9357-8d7c-4cf1-bf4d-7543b5b747a3" />




## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

### Fixed
- Inactive users with non escalated roles do not show up in blocked users filter
- Blocked users filter appearing when inactive users exist but none have escalated roles
## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Create vip dev site
1. Enable inactive user security boost module to block administrators for > 90days
1. Create two inactive users, one with a admin role and one with a subscriber role
1. In phpmyadmin, update the users metadata to show that they are both inactive using the following query, replacing x with the user id of each.
1. Confirm the blocked users only contain the admin user
1. Delete the admin user
1. Confirm the Blocked Users filter is no longer selectable

<details open>
<summary>Query to run</summary>

```sql
USE wordpress;

-- Set variables
SET @user_id := X;
SET @registered_date := '2025-06-09 00:00:00';
SET @last_seen := '1752086400'; -- Unix timestamp for June 9, 2025
SET @ignore_until := '1609459200'; -- January 1, 2021 (unchanged)

-- Update registration date
UPDATE wp_users
SET user_registered = @registered_date
WHERE ID = @user_id;

-- Delete and insert wpvip_last_seen
DELETE FROM wp_usermeta
WHERE user_id = @user_id AND meta_key = 'wpvip_last_seen';

INSERT INTO wp_usermeta (user_id, meta_key, meta_value)
VALUES (@user_id, 'wpvip_last_seen', @last_seen);

-- Delete and insert wpvip_last_seen_ignore_inactivity_check_until
DELETE FROM wp_usermeta
WHERE user_id = @user_id AND meta_key = 'wpvip_last_seen_ignore_inactivity_check_until';

INSERT INTO wp_usermeta (user_id, meta_key, meta_value)
VALUES (@user_id, 'wpvip_last_seen_ignore_inactivity_check_until', @ignore_until);

-- Upsert global option
INSERT INTO wp_options (option_name, option_value, autoload)
VALUES ('wpvip_last_seen_release_date_timestamp', @ignore_until, 'no')
ON DUPLICATE KEY UPDATE option_value = @ignore_until;
````

</details>
