### PR TITLE
Add notification when user is promoted to administrator role

### DIFF
--- a/email/email.php
+++ b/email/email.php
@@ -50,9 +50,13 @@ class Email {
 		}
 
 		// Fetch email template and replace variables.
-		$template_data['subject']           = $subject;
-		$template_data['email_title']       = $subject;
+		$template_data['subject'] = $subject;
+		// If email_title is empty, use subject as default.
+		if ( empty( $template_data['email_title'] ) ) {
+			$template_data['email_title'] = $subject;
+		}
 		$template_data['site_url']          = home_url();
+		$template_data['site_name']         = get_bloginfo( 'name' );
 		$template_data['display_name']      = $user_name ?: $user->display_name;
 		$template_data['date']              = gmdate( 'F j, Y' );
 		$template_data['utc_time']          = gmdate( 'H:i \U\T\C' );

--- a/email/mjml/privileged-user-created.mjml
+++ b/email/mjml/privileged-user-created.mjml
@@ -11,13 +11,13 @@
 						below:
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Username: <strong>{{%=user_login%}}</strong>
+						<strong>Username</strong>: {{%=user_login%}}
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Email: <strong>{{%=user_email%}}</strong>
+						<strong>Email</strong>: {{%=user_email%}}
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Role: <strong>{{%=user_role%}}</strong>
+						<strong>Role</strong>: {{%=user_role%}}
 					</mj-text>
 					<mj-text font-size="20px" padding="14px 0px 24px" line-height="30px">
 						If you authorized this change, no action is needed.<br />

--- a/email/mjml/privileged-user-promoted.mjml
+++ b/email/mjml/privileged-user-promoted.mjml
@@ -6,9 +6,8 @@
 			<mj-section padding-bottom="30px">
 				<mj-column>
 					<mj-text font-size="20px" padding="14px 0px 24px" line-height="30px">
-						A new user with an Administrator user role has been added to your
-						site "<strong>{{%=site_name%}}</strong>". Please review the details
-						below:
+						A user has been granted Administrator role on your site "<strong>{{%=site_name%}}</strong>".</br>
+						Please review the details below:
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
 						Username: <strong>{{%=user_login%}}</strong>

--- a/email/mjml/privileged-user-promoted.mjml
+++ b/email/mjml/privileged-user-promoted.mjml
@@ -10,13 +10,13 @@
 						Please review the details below:
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Username: <strong>{{%=user_login%}}</strong>
+						<strong>Username</strong>: {{%=user_login%}}
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Email: <strong>{{%=user_email%}}</strong>
+						<strong>Email</strong>: {{%=user_email%}}
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
-						Role: <strong>{{%=user_role%}}</strong>
+						<strong>Role</strong>: {{%=user_role%}}
 					</mj-text>
 					<mj-text font-size="20px" padding="14px 0px 24px" line-height="30px">
 						If you authorized this change, no action is needed.<br />

--- a/email/mjml/privileged-user-promoted.mjml
+++ b/email/mjml/privileged-user-promoted.mjml
@@ -6,8 +6,7 @@
 			<mj-section padding-bottom="30px">
 				<mj-column>
 					<mj-text font-size="20px" padding="14px 0px 24px" line-height="30px">
-						A user has been granted Administrator role on your site "<strong>{{%=site_name%}}</strong>".</br>
-						Please review the details below:
+						A user has been granted the Administrator role on your site "<strong>{{%=site_name%}}</strong>".<br /> Please review the details below:
 					</mj-text>
 					<mj-text align="center" font-size="20px" line-height="5px">
 						<strong>Username</strong>: {{%=user_login%}}

--- a/email/templates/privileged-user-created.html
+++ b/email/templates/privileged-user-created.html
@@ -156,7 +156,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:14px 0px 24px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">A new administrator account has been created on your site. Please review the details below:</div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">A new user with an Administrator user role has been added to your site "<strong>{{%=site_name%}}</strong>". Please review the details below:</div>
                                 </td>
                               </tr>
                               <tr>
@@ -176,7 +176,9 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:14px 0px 24px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">If you authorized this change, no action is needed. <strong>If this was unexpected, please remove this user immediately through <a href="{{%=admin_url%}}users.php">wp-admin</a>.</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">If you authorized this change, no action is needed.<br />
+                                    <strong> If this was unexpected, you can remove this user immediately in the <a href="{{%=admin_url%}}users.php">WordPress Admin</a>. </strong>
+                                  </div>
                                 </td>
                               </tr>
                             </tbody>

--- a/email/templates/privileged-user-created.html
+++ b/email/templates/privileged-user-created.html
@@ -161,17 +161,17 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Username: <strong>{{%=user_login%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Username</strong>: {{%=user_login%}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Email: <strong>{{%=user_email%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Email</strong>: {{%=user_email%}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Role: <strong>{{%=user_role%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Role</strong>: {{%=user_role%}}</div>
                                 </td>
                               </tr>
                               <tr>

--- a/email/templates/privileged-user-promoted.html
+++ b/email/templates/privileged-user-promoted.html
@@ -161,17 +161,17 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Username: <strong>{{%=user_login%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Username</strong>: {{%=user_login%}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Email: <strong>{{%=user_email%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Email</strong>: {{%=user_email%}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Role: <strong>{{%=user_role%}}</strong></div>
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;"><strong>Role</strong>: {{%=user_role%}}</div>
                                 </td>
                               </tr>
                               <tr>

--- a/email/templates/privileged-user-promoted.html
+++ b/email/templates/privileged-user-promoted.html
@@ -1,562 +1,235 @@
-<!DOCTYPE html>
-<html
-	lang="und"
-	dir="auto"
-	xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:v="urn:schemas-microsoft-com:vml"
-	xmlns:o="urn:schemas-microsoft-com:office:office"
->
-	<head>
-		<title></title>
-		<!--[if !mso]><!-->
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<!--<![endif]-->
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<style type="text/css">
-			#outlook a {
-				padding: 0;
-			}
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
-			body {
-				margin: 0;
-				padding: 0;
-				-webkit-text-size-adjust: 100%;
-				-ms-text-size-adjust: 100%;
-			}
+<head>
+  <title></title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
 
-			table,
-			td {
-				border-collapse: collapse;
-				mso-table-lspace: 0pt;
-				mso-table-rspace: 0pt;
-			}
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
 
-			img {
-				border: 0;
-				height: auto;
-				line-height: 100%;
-				outline: none;
-				text-decoration: none;
-				-ms-interpolation-mode: bicubic;
-			}
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
 
-			p {
-				display: block;
-				margin: 13px 0;
-			}
-		</style>
-		<!--[if mso]>
-			<noscript>
-				<xml>
-					<o:OfficeDocumentSettings>
-						<o:AllowPNG />
-						<o:PixelsPerInch>96</o:PixelsPerInch>
-					</o:OfficeDocumentSettings>
-				</xml>
-			</noscript>
-		<![endif]-->
-		<!--[if lte mso 11]>
-			<style type="text/css">
-				.mj-outlook-group-fix {
-					width: 100% !important;
-				}
-			</style>
-		<![endif]-->
-		<style type="text/css">
-			@media only screen and (min-width: 480px) {
-				.mj-column-per-100 {
-					width: 100% !important;
-					max-width: 100%;
-				}
-			}
-		</style>
-		<style media="screen and (min-width:480px)">
-			.moz-text-html .mj-column-per-100 {
-				width: 100% !important;
-				max-width: 100%;
-			}
-		</style>
-		<style type="text/css">
-			@media only screen and (max-width: 479px) {
-				table.mj-full-width-mobile {
-					width: 100% !important;
-				}
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
 
-				td.mj-full-width-mobile {
-					width: auto !important;
-				}
-			}
-		</style>
-		<style type="text/css">
-			@font-face {
-				font-family: "Aktiv Grotesk VF";
-				src: url("https://wpvip.com/wp-content/themes/vip-valet/assets/fonts/aktiv-grotesk/AktivGroteskVF_W_WghtWdthItal.woff2")
-					format("woff2");
-				font-weight: 200 800;
-				font-style: normal italic;
-			}
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+    }
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+  </style>
+  <style type="text/css">
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
 
-			a:link {
-				color: #9a6014;
-			}
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+  </style>
+  <style type="text/css">
+    @font-face {
+      font-family: 'Aktiv Grotesk VF';
+      src: url('https://wpvip.com/wp-content/themes/vip-valet/assets/fonts/aktiv-grotesk/AktivGroteskVF_W_WghtWdthItal.woff2') format('woff2');
+      font-weight: 200 800;
+      font-style: normal italic;
+    }
 
-			* {
-				font-family: "Aktiv Grotesk VF", "Helvetica Neue", sans-serif;
-			}
-		</style>
-	</head>
+    a:link {
+      color: #9A6014;
+    }
 
-	<body style="word-spacing: normal">
-		<div style="" lang="und" dir="auto">
-			<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-			<div
-				style="
-					background: #ffffff;
-					background-color: #ffffff;
-					margin: 0px auto;
-					max-width: 552px;
-				"
-			>
-				<table
-					align="center"
-					border="0"
-					cellpadding="0"
-					cellspacing="0"
-					role="presentation"
-					style="background: #ffffff; background-color: #ffffff; width: 100%"
-				>
-					<tbody>
-						<tr>
-							<td
-								style="
-									direction: ltr;
-									font-size: 0px;
-									padding: 48px 24px;
-									text-align: center;
-								"
-							>
-								<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-								<div style="margin: 0px auto; max-width: 504px">
-									<table
-										align="center"
-										border="0"
-										cellpadding="0"
-										cellspacing="0"
-										role="presentation"
-										style="width: 100%"
-									>
-										<tbody>
-											<tr>
-												<td
-													style="
-														direction: ltr;
-														font-size: 0px;
-														padding: 0px;
-														text-align: center;
-													"
-												>
-													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
-													<div
-														class="mj-column-per-100 mj-outlook-group-fix"
-														style="
-															font-size: 0px;
-															text-align: left;
-															direction: ltr;
-															display: inline-block;
-															vertical-align: top;
-															width: 100%;
-														"
-													>
-														<table
-															border="0"
-															cellpadding="0"
-															cellspacing="0"
-															role="presentation"
-															style="vertical-align: top"
-															width="100%"
-														>
-															<tbody>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 25px;
-																			padding-top: 0px;
-																			padding-bottom: 22px;
-																			word-break: break-word;
-																		"
-																	>
-																		<table
-																			border="0"
-																			cellpadding="0"
-																			cellspacing="0"
-																			role="presentation"
-																			style="
-																				border-collapse: collapse;
-																				border-spacing: 0px;
-																			"
-																		>
-																			<tbody>
-																				<tr>
-																					<td style="width: 223px">
-																						<img
-																							alt=""
-																							src="https://dashboard.wpvip.com/email/vip-enterprise-wordpress.png"
-																							style="
-																								border: 0;
-																								display: block;
-																								outline: none;
-																								text-decoration: none;
-																								height: auto;
-																								width: 100%;
-																								font-size: 13px;
-																							"
-																							width="223"
-																							height="auto"
-																						/>
-																					</td>
-																				</tr>
-																			</tbody>
-																		</table>
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 0px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 44px;
-																				font-weight: 700;
-																				letter-spacing: -1.1px;
-																				line-height: 1;
-																				text-align: center;
-																				color: #000000;
-																			"
-																		>
-																			{{%=email_title%}}
-																		</div>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
-													<!--[if mso | IE]></td></tr></table><![endif]-->
-												</td>
-											</tr>
-										</tbody>
-									</table>
-								</div>
-								<!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-								<div style="margin: 0px auto; max-width: 504px">
-									<table
-										align="center"
-										border="0"
-										cellpadding="0"
-										cellspacing="0"
-										role="presentation"
-										style="width: 100%"
-									>
-										<tbody>
-											<tr>
-												<td
-													style="
-														direction: ltr;
-														font-size: 0px;
-														padding: 0px;
-														padding-bottom: 30px;
-														text-align: center;
-													"
-												>
-													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
-													<div
-														class="mj-column-per-100 mj-outlook-group-fix"
-														style="
-															font-size: 0px;
-															text-align: left;
-															direction: ltr;
-															display: inline-block;
-															vertical-align: top;
-															width: 100%;
-														"
-													>
-														<table
-															border="0"
-															cellpadding="0"
-															cellspacing="0"
-															role="presentation"
-															style="vertical-align: top"
-															width="100%"
-														>
-															<tbody>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 14px 0px 24px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 20px;
-																				line-height: 30px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			A user has been promoted to administrator
-																			on your site. Please review the details
-																			below:
-																		</div>
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 0px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 20px;
-																				line-height: 5px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			Username:
-																			<strong>{{%=user_login%}}</strong>
-																		</div>
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 0px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 20px;
-																				line-height: 5px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			Email: <strong>{{%=user_email%}}</strong>
-																		</div>
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 0px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 20px;
-																				line-height: 5px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			Role: <strong>{{%=user_role%}}</strong>
-																		</div>
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 14px 0px 24px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 20px;
-																				line-height: 30px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			If you authorized this change, no action
-																			is needed.
-																			<strong
-																				>If this was unexpected, please remove
-																				this user immediately through
-																				<a href="{{%=admin_url%}}users.php"
-																					>wp-admin</a
-																				>.</strong
-																			>
-																		</div>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
-													<!--[if mso | IE]></td></tr></table><![endif]-->
-												</td>
-											</tr>
-										</tbody>
-									</table>
-								</div>
-								<!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-								<div style="margin: 0px auto; max-width: 504px">
-									<table
-										align="center"
-										border="0"
-										cellpadding="0"
-										cellspacing="0"
-										role="presentation"
-										style="width: 100%"
-									>
-										<tbody>
-											<tr>
-												<td
-													style="
-														direction: ltr;
-														font-size: 0px;
-														padding: 0px;
-														text-align: center;
-													"
-												>
-													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
-													<div
-														class="mj-column-per-100 mj-outlook-group-fix"
-														style="
-															font-size: 0px;
-															text-align: left;
-															direction: ltr;
-															display: inline-block;
-															vertical-align: top;
-															width: 100%;
-														"
-													>
-														<table
-															border="0"
-															cellpadding="0"
-															cellspacing="0"
-															role="presentation"
-															style="vertical-align: top"
-															width="100%"
-														>
-															<tbody>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 0px 0px 6px;
-																			word-break: break-word;
-																		"
-																	>
-																		<p
-																			style="
-																				border-top: solid 1px #e3e0df;
-																				font-size: 1px;
-																				margin: 0px auto;
-																				width: 100%;
-																			"
-																		></p>
-																		<!--[if mso | IE
-																			]><table
-																				align="center"
-																				border="0"
-																				cellpadding="0"
-																				cellspacing="0"
-																				style="
-																					border-top: solid 1px #e3e0df;
-																					font-size: 1px;
-																					margin: 0px auto;
-																					width: 504px;
-																				"
-																				role="presentation"
-																				width="504px"
-																			>
-																				<tr>
-																					<td style="height: 0; line-height: 0">
-																						&nbsp;
-																					</td>
-																				</tr>
-																			</table><!
-																		[endif]-->
-																	</td>
-																</tr>
-																<tr>
-																	<td
-																		align="center"
-																		style="
-																			font-size: 0px;
-																			padding: 10px 0px;
-																			word-break: break-word;
-																		"
-																	>
-																		<div
-																			style="
-																				font-family: 'Aktiv Grotesk VF',
-																					'Helvetica Neue', sans-serif;
-																				font-size: 12px;
-																				line-height: 18px;
-																				text-align: center;
-																				color: #514e4d;
-																			"
-																		>
-																			​​You are receiving this email from the
-																			VIP Security Boost to ensure you are aware
-																			of any security-related change in your
-																			account.
-																		</div>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
-													<!--[if mso | IE]></td></tr></table><![endif]-->
-												</td>
-											</tr>
-										</tbody>
-									</table>
-								</div>
-								<!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			</div>
-			<!--[if mso | IE]></td></tr></table><![endif]-->
-		</div>
-	</body>
+    * {
+      font-family: 'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;
+    }
+  </style>
+</head>
+
+<body style="word-spacing:normal;">
+  <div style="" lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:552px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:48px 24px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:504px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-bottom:22px;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                    <tbody>
+                                      <tr>
+                                        <td style="width:223px;">
+                                          <img alt="" src="https://dashboard.wpvip.com/email/vip-enterprise-wordpress.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="223" height="auto" />
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:44px;font-weight:700;letter-spacing:-1.1px;line-height:1;text-align:center;color:#000000;">{{%=email_title%}}</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:504px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:0px;padding-bottom:30px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:14px 0px 24px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">A user has been granted Administrator role on your site "<strong>{{%=site_name%}}</strong>".</br> Please review the details below:</div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Username: <strong>{{%=user_login%}}</strong></div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Email: <strong>{{%=user_email%}}</strong></div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:5px;text-align:center;color:#514E4D;">Role: <strong>{{%=user_role%}}</strong></div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:14px 0px 24px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:20px;line-height:30px;text-align:center;color:#514E4D;">If you authorized this change, no action is needed.<br />
+                                    <strong> If this was unexpected, you can remove this user immediately in the <a href="{{%=admin_url%}}users.php">WordPress Admin</a>. </strong>
+                                  </div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:504px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:0px 0px 6px;word-break:break-word;">
+                                  <p style="border-top:solid 1px #E3E0DF;font-size:1px;margin:0px auto;width:100%;">
+                                  </p>
+                                  <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" style="border-top:solid 1px #E3E0DF;font-size:1px;margin:0px auto;width:504px;" role="presentation" width="504px" ><tr><td style="height:0;line-height:0;"> &nbsp;
+</td></tr></table><![endif]-->
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 0px;word-break:break-word;">
+                                  <div style="font-family:'Aktiv Grotesk VF', 'Helvetica Neue', sans-serif;font-size:12px;line-height:18px;text-align:center;color:#514E4D;">​​You are receiving this email from the VIP Security Boost to ensure you are aware of any security-related change in your account.</div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
 </html>

--- a/email/templates/privileged-user-promoted.html
+++ b/email/templates/privileged-user-promoted.html
@@ -1,0 +1,562 @@
+<!DOCTYPE html>
+<html
+	lang="und"
+	dir="auto"
+	xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:v="urn:schemas-microsoft-com:vml"
+	xmlns:o="urn:schemas-microsoft-com:office:office"
+>
+	<head>
+		<title></title>
+		<!--[if !mso]><!-->
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<!--<![endif]-->
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<style type="text/css">
+			#outlook a {
+				padding: 0;
+			}
+
+			body {
+				margin: 0;
+				padding: 0;
+				-webkit-text-size-adjust: 100%;
+				-ms-text-size-adjust: 100%;
+			}
+
+			table,
+			td {
+				border-collapse: collapse;
+				mso-table-lspace: 0pt;
+				mso-table-rspace: 0pt;
+			}
+
+			img {
+				border: 0;
+				height: auto;
+				line-height: 100%;
+				outline: none;
+				text-decoration: none;
+				-ms-interpolation-mode: bicubic;
+			}
+
+			p {
+				display: block;
+				margin: 13px 0;
+			}
+		</style>
+		<!--[if mso]>
+			<noscript>
+				<xml>
+					<o:OfficeDocumentSettings>
+						<o:AllowPNG />
+						<o:PixelsPerInch>96</o:PixelsPerInch>
+					</o:OfficeDocumentSettings>
+				</xml>
+			</noscript>
+		<![endif]-->
+		<!--[if lte mso 11]>
+			<style type="text/css">
+				.mj-outlook-group-fix {
+					width: 100% !important;
+				}
+			</style>
+		<![endif]-->
+		<style type="text/css">
+			@media only screen and (min-width: 480px) {
+				.mj-column-per-100 {
+					width: 100% !important;
+					max-width: 100%;
+				}
+			}
+		</style>
+		<style media="screen and (min-width:480px)">
+			.moz-text-html .mj-column-per-100 {
+				width: 100% !important;
+				max-width: 100%;
+			}
+		</style>
+		<style type="text/css">
+			@media only screen and (max-width: 479px) {
+				table.mj-full-width-mobile {
+					width: 100% !important;
+				}
+
+				td.mj-full-width-mobile {
+					width: auto !important;
+				}
+			}
+		</style>
+		<style type="text/css">
+			@font-face {
+				font-family: "Aktiv Grotesk VF";
+				src: url("https://wpvip.com/wp-content/themes/vip-valet/assets/fonts/aktiv-grotesk/AktivGroteskVF_W_WghtWdthItal.woff2")
+					format("woff2");
+				font-weight: 200 800;
+				font-style: normal italic;
+			}
+
+			a:link {
+				color: #9a6014;
+			}
+
+			* {
+				font-family: "Aktiv Grotesk VF", "Helvetica Neue", sans-serif;
+			}
+		</style>
+	</head>
+
+	<body style="word-spacing: normal">
+		<div style="" lang="und" dir="auto">
+			<!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+			<div
+				style="
+					background: #ffffff;
+					background-color: #ffffff;
+					margin: 0px auto;
+					max-width: 552px;
+				"
+			>
+				<table
+					align="center"
+					border="0"
+					cellpadding="0"
+					cellspacing="0"
+					role="presentation"
+					style="background: #ffffff; background-color: #ffffff; width: 100%"
+				>
+					<tbody>
+						<tr>
+							<td
+								style="
+									direction: ltr;
+									font-size: 0px;
+									padding: 48px 24px;
+									text-align: center;
+								"
+							>
+								<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+								<div style="margin: 0px auto; max-width: 504px">
+									<table
+										align="center"
+										border="0"
+										cellpadding="0"
+										cellspacing="0"
+										role="presentation"
+										style="width: 100%"
+									>
+										<tbody>
+											<tr>
+												<td
+													style="
+														direction: ltr;
+														font-size: 0px;
+														padding: 0px;
+														text-align: center;
+													"
+												>
+													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+													<div
+														class="mj-column-per-100 mj-outlook-group-fix"
+														style="
+															font-size: 0px;
+															text-align: left;
+															direction: ltr;
+															display: inline-block;
+															vertical-align: top;
+															width: 100%;
+														"
+													>
+														<table
+															border="0"
+															cellpadding="0"
+															cellspacing="0"
+															role="presentation"
+															style="vertical-align: top"
+															width="100%"
+														>
+															<tbody>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 25px;
+																			padding-top: 0px;
+																			padding-bottom: 22px;
+																			word-break: break-word;
+																		"
+																	>
+																		<table
+																			border="0"
+																			cellpadding="0"
+																			cellspacing="0"
+																			role="presentation"
+																			style="
+																				border-collapse: collapse;
+																				border-spacing: 0px;
+																			"
+																		>
+																			<tbody>
+																				<tr>
+																					<td style="width: 223px">
+																						<img
+																							alt=""
+																							src="https://dashboard.wpvip.com/email/vip-enterprise-wordpress.png"
+																							style="
+																								border: 0;
+																								display: block;
+																								outline: none;
+																								text-decoration: none;
+																								height: auto;
+																								width: 100%;
+																								font-size: 13px;
+																							"
+																							width="223"
+																							height="auto"
+																						/>
+																					</td>
+																				</tr>
+																			</tbody>
+																		</table>
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 0px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 44px;
+																				font-weight: 700;
+																				letter-spacing: -1.1px;
+																				line-height: 1;
+																				text-align: center;
+																				color: #000000;
+																			"
+																		>
+																			{{%=email_title%}}
+																		</div>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+													</div>
+													<!--[if mso | IE]></td></tr></table><![endif]-->
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+								<!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+								<div style="margin: 0px auto; max-width: 504px">
+									<table
+										align="center"
+										border="0"
+										cellpadding="0"
+										cellspacing="0"
+										role="presentation"
+										style="width: 100%"
+									>
+										<tbody>
+											<tr>
+												<td
+													style="
+														direction: ltr;
+														font-size: 0px;
+														padding: 0px;
+														padding-bottom: 30px;
+														text-align: center;
+													"
+												>
+													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+													<div
+														class="mj-column-per-100 mj-outlook-group-fix"
+														style="
+															font-size: 0px;
+															text-align: left;
+															direction: ltr;
+															display: inline-block;
+															vertical-align: top;
+															width: 100%;
+														"
+													>
+														<table
+															border="0"
+															cellpadding="0"
+															cellspacing="0"
+															role="presentation"
+															style="vertical-align: top"
+															width="100%"
+														>
+															<tbody>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 14px 0px 24px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 20px;
+																				line-height: 30px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			A user has been promoted to administrator
+																			on your site. Please review the details
+																			below:
+																		</div>
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 0px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 20px;
+																				line-height: 5px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			Username:
+																			<strong>{{%=user_login%}}</strong>
+																		</div>
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 0px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 20px;
+																				line-height: 5px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			Email: <strong>{{%=user_email%}}</strong>
+																		</div>
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 0px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 20px;
+																				line-height: 5px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			Role: <strong>{{%=user_role%}}</strong>
+																		</div>
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 14px 0px 24px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 20px;
+																				line-height: 30px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			If you authorized this change, no action
+																			is needed.
+																			<strong
+																				>If this was unexpected, please remove
+																				this user immediately through
+																				<a href="{{%=admin_url%}}users.php"
+																					>wp-admin</a
+																				>.</strong
+																			>
+																		</div>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+													</div>
+													<!--[if mso | IE]></td></tr></table><![endif]-->
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+								<!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="552px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:504px;" width="504" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+								<div style="margin: 0px auto; max-width: 504px">
+									<table
+										align="center"
+										border="0"
+										cellpadding="0"
+										cellspacing="0"
+										role="presentation"
+										style="width: 100%"
+									>
+										<tbody>
+											<tr>
+												<td
+													style="
+														direction: ltr;
+														font-size: 0px;
+														padding: 0px;
+														text-align: center;
+													"
+												>
+													<!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:504px;" ><![endif]-->
+													<div
+														class="mj-column-per-100 mj-outlook-group-fix"
+														style="
+															font-size: 0px;
+															text-align: left;
+															direction: ltr;
+															display: inline-block;
+															vertical-align: top;
+															width: 100%;
+														"
+													>
+														<table
+															border="0"
+															cellpadding="0"
+															cellspacing="0"
+															role="presentation"
+															style="vertical-align: top"
+															width="100%"
+														>
+															<tbody>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 0px 0px 6px;
+																			word-break: break-word;
+																		"
+																	>
+																		<p
+																			style="
+																				border-top: solid 1px #e3e0df;
+																				font-size: 1px;
+																				margin: 0px auto;
+																				width: 100%;
+																			"
+																		></p>
+																		<!--[if mso | IE
+																			]><table
+																				align="center"
+																				border="0"
+																				cellpadding="0"
+																				cellspacing="0"
+																				style="
+																					border-top: solid 1px #e3e0df;
+																					font-size: 1px;
+																					margin: 0px auto;
+																					width: 504px;
+																				"
+																				role="presentation"
+																				width="504px"
+																			>
+																				<tr>
+																					<td style="height: 0; line-height: 0">
+																						&nbsp;
+																					</td>
+																				</tr>
+																			</table><!
+																		[endif]-->
+																	</td>
+																</tr>
+																<tr>
+																	<td
+																		align="center"
+																		style="
+																			font-size: 0px;
+																			padding: 10px 0px;
+																			word-break: break-word;
+																		"
+																	>
+																		<div
+																			style="
+																				font-family: 'Aktiv Grotesk VF',
+																					'Helvetica Neue', sans-serif;
+																				font-size: 12px;
+																				line-height: 18px;
+																				text-align: center;
+																				color: #514e4d;
+																			"
+																		>
+																			​​You are receiving this email from the
+																			VIP Security Boost to ensure you are aware
+																			of any security-related change in your
+																			account.
+																		</div>
+																	</td>
+																</tr>
+															</tbody>
+														</table>
+													</div>
+													<!--[if mso | IE]></td></tr></table><![endif]-->
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</div>
+								<!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<!--[if mso | IE]></td></tr></table><![endif]-->
+		</div>
+	</body>
+</html>

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -27,7 +27,7 @@ class Notify_Privileged_Activity {
 
 		if ( in_array( 'administrator', (array) $user->roles, true ) ) {
 			/* Translators: %s: Site name. */
-			$subject = sprintf( __( '[%s] New Administrator Added', 'wpvip' ),
+			$subject     = sprintf( __( '[%s] New Administrator Added', 'wpvip' ),
 				get_bloginfo( 'name' )
 			);
 			$email_title = sprintf( __( 'New Administrator Added', 'wpvip' ) );
@@ -54,7 +54,7 @@ class Notify_Privileged_Activity {
 		}
 
 		/* Translators: %s: Site name. */
-		$subject = sprintf( __( '[%s] User Promoted to Administrator', 'wpvip' ),
+		$subject     = sprintf( __( '[%s] User Promoted to Administrator', 'wpvip' ),
 			get_bloginfo( 'name' )
 		);
 		$email_title = sprintf( __( 'User Promoted to Administrator', 'wpvip' ) );
@@ -76,11 +76,11 @@ class Notify_Privileged_Activity {
 		}
 
 		Email::send( $user->ID, $admin_email, $subject, $template, [
-			'user_login' => $user->user_login,
-			'user_email' => $user->user_email,
-			'user_role'  => 'Administrator',
+			'user_login'  => $user->user_login,
+			'user_email'  => $user->user_email,
+			'user_role'   => 'Administrator',
 			'email_title' => $email_title,
-			'admin_url'  => admin_url(),
+			'admin_url'   => admin_url(),
 		] );
 	}
 }

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -10,6 +10,8 @@ class Notify_Privileged_Activity {
 		} else {
 			add_action( 'user_register', [ __CLASS__, 'notify_admin_user_creation' ] );
 		}
+
+		add_action( 'set_user_role', [ __CLASS__, 'notify_user_promoted_to_admin' ], 10, 3 );
 	}
 
 	/**
@@ -24,24 +26,59 @@ class Notify_Privileged_Activity {
 		}
 
 		if ( in_array( 'administrator', (array) $user->roles, true ) ) {
-			$admin_email = get_option( 'admin_email' );
-
-			if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {
-				return;
-			}
-
 			/* Translators: %s: Site name. */
 			$subject = sprintf( __( '[%s] New Administrator User Created', 'wpvip' ),
 				get_bloginfo( 'name' )
 			);
 
-			Email::send( $user_id, $admin_email, $subject, 'privileged-user-created', [
-				'user_login' => $user->user_login,
-				'user_email' => $user->user_email,
-				'user_role'  => 'Administrator',
-				'admin_url'  => admin_url(),
-			] );
+			self::send_notification( $user, $subject, 'privileged-user-created' );
 		}
+	}
+
+	/**
+	 * Handle user promotion to administrator.
+	 *
+	 * @param int    $user_id   The user ID.
+	 * @param string $new_role  The new role.
+	 * @param array  $old_roles An array of the user's previous roles.
+	 */
+	public static function notify_user_promoted_to_admin( $user_id, $new_role, $old_roles ) {
+		if ( 'administrator' !== $new_role || in_array( 'administrator', $old_roles, true ) ) {
+			return;
+		}
+
+		$user = get_userdata( $user_id );
+		if ( ! $user ) {
+			return;
+		}
+
+		/* Translators: %s: Site name. */
+		$subject = sprintf( __( '[%s] User Promoted to Administrator', 'wpvip' ),
+			get_bloginfo( 'name' )
+		);
+
+		self::send_notification( $user, $subject, 'privileged-user-promoted' );
+	}
+
+	/**
+	 * Send the notification email.
+	 *
+	 * @param \WP_User $user    The user object.
+	 * @param string   $subject The email subject.
+	 */
+	private static function send_notification( $user, $subject, $template ) {
+		$admin_email = get_option( 'admin_email' );
+
+		if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {
+			return;
+		}
+
+		Email::send( $user->ID, $admin_email, $subject, $template, [
+			'user_login' => $user->user_login,
+			'user_email' => $user->user_email,
+			'user_role'  => 'Administrator',
+			'admin_url'  => admin_url(),
+		] );
 	}
 }
 

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -27,11 +27,12 @@ class Notify_Privileged_Activity {
 
 		if ( in_array( 'administrator', (array) $user->roles, true ) ) {
 			/* Translators: %s: Site name. */
-			$subject = sprintf( __( '[%s] New Administrator User Created', 'wpvip' ),
+			$subject = sprintf( __( '[%s] New Administrator Added', 'wpvip' ),
 				get_bloginfo( 'name' )
 			);
+			$email_title = sprintf( __( 'New Administrator Added', 'wpvip' ) );
 
-			self::send_notification( $user, $subject, 'privileged-user-created' );
+			self::send_notification( $user, $subject, $email_title, 'privileged-user-created' );
 		}
 	}
 
@@ -56,8 +57,9 @@ class Notify_Privileged_Activity {
 		$subject = sprintf( __( '[%s] User Promoted to Administrator', 'wpvip' ),
 			get_bloginfo( 'name' )
 		);
+		$email_title = sprintf( __( 'User Promoted to Administrator', 'wpvip' ) );
 
-		self::send_notification( $user, $subject, 'privileged-user-promoted' );
+		self::send_notification( $user, $subject, $email_title, 'privileged-user-promoted' );
 	}
 
 	/**
@@ -66,7 +68,7 @@ class Notify_Privileged_Activity {
 	 * @param \WP_User $user    The user object.
 	 * @param string   $subject The email subject.
 	 */
-	private static function send_notification( $user, $subject, $template ) {
+	private static function send_notification( $user, $subject,$email_title,$template ) {
 		$admin_email = get_option( 'admin_email' );
 
 		if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {
@@ -77,6 +79,7 @@ class Notify_Privileged_Activity {
 			'user_login' => $user->user_login,
 			'user_email' => $user->user_email,
 			'user_role'  => 'Administrator',
+			'email_title' => $email_title,
 			'admin_url'  => admin_url(),
 		] );
 	}

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -68,7 +68,7 @@ class Notify_Privileged_Activity {
 	 * @param \WP_User $user    The user object.
 	 * @param string   $subject The email subject.
 	 */
-	private static function send_notification( $user, $subject,$email_title,$template ) {
+	private static function send_notification( $user, $subject, $email_title, $template ) {
 		$admin_email = get_option( 'admin_email' );
 
 		if ( empty( $admin_email ) || ! is_email( $admin_email ) ) {

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -44,7 +44,8 @@ class Notify_Privileged_Activity {
 	 * @param array  $old_roles An array of the user's previous roles.
 	 */
 	public static function notify_user_promoted_to_admin( $user_id, $new_role, $old_roles ) {
-		if ( 'administrator' !== $new_role || in_array( 'administrator', $old_roles, true ) ) {
+		// Don't send a notification if the user is being created (empty roles), or if they are already an administrator.
+		if ( empty( $old_roles ) || 'administrator' !== $new_role || in_array( 'administrator', $old_roles, true ) ) {
 			return;
 		}
 

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -28,6 +28,7 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 	public function test_init_adds_action() {
 		Notify_Privileged_Activity::init();
 		$this->assertNotFalse( has_action( 'user_register', [ Notify_Privileged_Activity::class, 'notify_admin_user_creation' ] ), 'Action user_register was not added.' );
+		$this->assertNotFalse( has_action( 'set_user_role', [ Notify_Privileged_Activity::class, 'notify_user_promoted_to_admin' ] ), 'Action set_user_role was not added.' );
 	}
 
 	private function check_email_spy_property_exists() {
@@ -119,6 +120,7 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 			'user_login' => $user_data->user_login,
 			'user_email' => $user_data->user_email,
 			'user_role'  => 'Administrator',
+			'admin_url'  => admin_url(),
 		];
 		
 		Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
@@ -129,6 +131,83 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 			$this->assertEquals( $admin_email_val, Email::$last_call_args_for_test['email_address'] );
 			$this->assertEquals( $expected_subject, Email::$last_call_args_for_test['subject'] );
 			$this->assertEquals( 'privileged-user-created', Email::$last_call_args_for_test['template_id'] );
+			$this->assertEquals( $expected_template_data, Email::$last_call_args_for_test['template_data'] );
+		}
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_promoted_to_admin_invalid_user_id() {
+		if ( ! $this->check_email_spy_property_exists() ) {
+			return;
+		}
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( 99999, 'administrator', [ 'editor' ] );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for invalid user ID.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_promoted_to_admin_not_promoted_to_admin() {
+		if ( ! $this->check_email_spy_property_exists() ) {
+			return;
+		}
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'editor', [ 'subscriber' ] );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for non-admin promotion.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_promoted_to_admin_already_admin() {
+		if ( ! $this->check_email_spy_property_exists() ) {
+			return;
+		}
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'administrator', 'editor' ] );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for user who was already an admin.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_promoted_to_admin_sends_email_successfully() {
+		if ( ! $this->check_email_spy_property_exists() ) {
+			return;
+		}
+
+		$user_data       = self::factory()->user->create_and_get( [
+			'role'       => 'editor',
+			'user_login' => 'promotedadmin',
+			'user_email' => 'promotedadmin@example.com',
+		] );
+		$user_id         = $user_data->ID;
+		$admin_email_val = 'admin@example.com';
+		update_option( 'admin_email', $admin_email_val );
+		$site_name = get_bloginfo( 'name' );
+
+		$expected_subject       = sprintf( '[%s] User Promoted to Administrator', $site_name );
+		$expected_template_data = [
+			'user_login' => $user_data->user_login,
+			'user_email' => $user_data->user_email,
+			'user_role'  => 'Administrator',
+			'admin_url'  => admin_url(),
+		];
+
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'editor' ] );
+
+		$this->assertNotNull( Email::$last_call_args_for_test, 'Email::send was not called.' );
+		if ( Email::$last_call_args_for_test ) {
+			$this->assertEquals( $user_id, Email::$last_call_args_for_test['user_id'] );
+			$this->assertEquals( $admin_email_val, Email::$last_call_args_for_test['email_address'] );
+			$this->assertEquals( $expected_subject, Email::$last_call_args_for_test['subject'] );
+			$this->assertEquals( 'privileged-user-promoted', Email::$last_call_args_for_test['template_id'] );
 			$this->assertEquals( $expected_template_data, Email::$last_call_args_for_test['template_data'] );
 		}
 	}

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -115,14 +115,15 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 		update_option( 'admin_email', $admin_email_val );
 		$site_name = get_bloginfo( 'name' );
 
-		$expected_subject       = sprintf( '[%s] New Administrator User Created', $site_name );
+		$expected_subject       = sprintf( '[%s] New Administrator Added', $site_name );
 		$expected_template_data = [
-			'user_login' => $user_data->user_login,
-			'user_email' => $user_data->user_email,
-			'user_role'  => 'Administrator',
-			'admin_url'  => admin_url(),
+			'user_login'  => $user_data->user_login,
+			'user_email'  => $user_data->user_email,
+			'user_role'   => 'Administrator',
+			'admin_url'   => admin_url(),
+			'email_title' => 'New Administrator Added',
 		];
-		
+
 		Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
 
 		$this->assertNotNull( Email::$last_call_args_for_test, 'Email::send was not called.' );
@@ -194,10 +195,11 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 
 		$expected_subject       = sprintf( '[%s] User Promoted to Administrator', $site_name );
 		$expected_template_data = [
-			'user_login' => $user_data->user_login,
-			'user_email' => $user_data->user_email,
-			'user_role'  => 'Administrator',
-			'admin_url'  => admin_url(),
+			'user_login'  => $user_data->user_login,
+			'user_email'  => $user_data->user_email,
+			'user_role'   => 'Administrator',
+			'admin_url'   => admin_url(),
+			'email_title' => 'User Promoted to Administrator',
 		];
 
 		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'editor' ] );
@@ -211,4 +213,4 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 			$this->assertEquals( $expected_template_data, Email::$last_call_args_for_test['template_data'] );
 		}
 	}
-} 
+}


### PR DESCRIPTION
## Description

This pull request enhances the notify-privileged-activity module to send an email notification when an existing user is promoted to an administrator. This adds another layer of security monitoring on top of the existing notification for newly created administrator accounts.

It also includes some improvements in the emails contents
![CleanShot 2025-06-10 at 16 17 07@2x](https://github.com/user-attachments/assets/1f838969-bd95-44bb-a046-ac98fb701b3f)

![CleanShot 2025-06-10 at 16 16 06@2x](https://github.com/user-attachments/assets/3dd3b1b4-2a5c-498d-b119-636714ab8937)


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Ensure the notify-privileged-activity module is enabled.
- Create a user with a non-administrator role (e.g., Editor).
- From the WordPress admin, edit the user and change their role to "Administrator."
- Go into mailpit (get the URL via `vip dev-env info`) and 
 confirm that an email is sent to the site's admin email address with the subject [Site Name] User Promoted to Administrator.
- Confirm that the existing notification for creating a new administrator user still works as expected.