### PR TITLE
Add format check action to CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,27 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  php:
+  php-format-check:
+    name: Format PHP files check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    
+      - name: Set up PHP
+        uses: shivammathur/setup-php@fc14643b0a99ee9db10a3c025a33d76544fa3761 # 2.30.5
+        with:
+          coverage: none
+        env:
+          fail-fast: 'true'
+
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
+
+      - name: Run style check
+        run: composer format-check
+
+  php-lint:
     name: Lint PHP files
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
 	"scripts": {
 		"lint": "./vendor/bin/phpcs --standard=.phpcs.xml.dist",
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
+		"format-check": "./vendor/bin/phpcs --standard=.phpcs.xml.dist --severity=4",
 		"phpcs": "./vendor/bin/phpcs",
 		"test": "./bin/test.sh --php 8.2 --wp 6.5",
 		"test:integration": "./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/",

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -16,7 +16,7 @@ class Highlight_MFA_Users {
 	private static $roles;
 
 	public static function init() {
-		// Feature is always active unless specific users are skipped via option.
+			 // Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = get_module_configs( 'highlight-mfa-users' );
 		self::$roles           = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS; // Default to administrator and editor if not configured
 


### PR DESCRIPTION
## Description

This PR adds a new format check job to the CI workflow that validates PHP code formatting using PHPCS with severity level 4. This ensures that all code follows the established formatting standards before merging.

The changes include:
- Added a new `php-format-check` job to the lint workflow that runs `composer format-check`
- Added a new `format-check` composer script that runs PHPCS with severity 4
- Renamed the existing PHP job to `php-lint` for clarity
- Included a formatting issue simulation for testing purposes

## Changelog Description

### Added
- Added format check action to CI workflow to validate PHP code formatting standards

### Changed
- Renamed PHP lint job in CI workflow from `php` to `php-lint` for better clarity
- Added `format-check` composer script for running PHPCS with severity 4

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
2. Push a commit with formatting issues to trigger the CI workflow
3. Verify that the `php-format-check` job fails when there are formatting issues
4. Fix the formatting issues and verify the job passes
5. Confirm that the existing `php-lint` job continues to work as expected