### PR TITLE
Fix "Warning Module Not found" when "enabled_modules" is empty

### DIFF
--- a/class-loader.php
+++ b/class-loader.php
@@ -13,6 +13,11 @@ class Loader {
 		$configs         = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
 		$enabled_modules = $configs['enabled_modules'] ?? [];
 
+		// return if there are no enabled modules (empty array or string)
+		if ( empty( $enabled_modules ) ) {
+			return;
+		}
+
 		// If enabled_modules is a string, convert it to an array
 		// I noticed the integrations-config can output a string so we need to handle that
 		if ( is_string( $enabled_modules ) ) {


### PR DESCRIPTION
## Description

In some tests we saw this warning
```
Warning	Module not found:	
class-loader.php:29
```
Which is triggered when the `enabled_modules` is empty

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->