### PR TITLE
[PLTFRM-1023] Fix Enforce MFA to catch the correct filter

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -28,7 +28,7 @@ class Forced_MFA_Users {
 			return;
 		}
 		// don't enforce 2FA if the user is already excluded by VIP mu-plugins logic
-		if ( function_exists( 'wpcom_vip_should_force_two_factor' ) && ! wpcom_vip_should_force_two_factor() ) {
+		if ( function_exists( 'wpcom_vip_is_two_factor_forced' ) && ! wpcom_vip_is_two_factor_forced() ) {
 			return;
 		}
 

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -6,7 +6,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		add_action( 'wpcom_vip_is_two_factor_local_testing', '__return_true' ); // Tell the two-factor plugin we're in local testing
-		// Loads the Two_Factor_Core class (required for the wpcom_vip_should_force_two_factor to work)
+		// Loads the Two_Factor_Core class (required for the wpcom_vip_is_two_factor_forced to work)
 		require_once WPVIP_MU_PLUGIN_DIR . '/shared-plugins/two-factor/two-factor.php';
 	}
 
@@ -39,13 +39,13 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_ensure_wpcom_vip_should_force_two_factor_exists() {
+	public function test_ensure_wpcom_vip_is_two_factor_forced_exists() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
 				'forced-mfa-users' => [ 'roles' => 'administrator' ],
 			],
 		] );
-		$this->assertTrue( function_exists( 'wpcom_vip_should_force_two_factor' ) );
+		$this->assertTrue( function_exists( 'wpcom_vip_is_two_factor_forced' ) );
 	}
 
 	/**
@@ -227,20 +227,20 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 	/**
 	 * We want to test that under a normal condition, if a user has the required capability, the filter returns false because
-	 * wpcom_vip_should_force_two_factor returns false.
+	 * wpcom_vip_is_two_factor_forced returns false.
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
-	public function test_should_skip_user_if_wpcom_vip_should_force_two_factor_returns_false() {
+	public function test_should_skip_user_if_wpcom_vip_is_two_factor_forced_returns_false() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
 				'forced-mfa-users' => [ 'capabilities' => 'edit_posts' ],
 			],
 		] );
 		Forced_MFA_Users::init();
-		add_filter( 'wpcom_vip_is_user_using_two_factor', '__return_true' ); // we're using this to change the behavior of the wpcom_vip_should_force_two_factor to return false.
+		add_filter( 'wpcom_vip_is_user_using_two_factor', '__return_true' ); // we're using this to change the behavior of the wpcom_vip_is_two_factor_forced to return false.
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_should_force_two_factor returns false even if the user has the required capability.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_is_two_factor_forced returns false even if the user has the required capability.' );
 	}
 }


### PR DESCRIPTION
## Description
Fix to check for the correct filter when customers force 2fa for their WP users via code: https://docs.wpvip.com/security/two-factor-authentication/#h-enforce-two-factor-authentication-for-all-users

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Added
- <!-- e.g. "Added a new set of filters for MFA status" -->
- <!-- e.g. "Dev-env: Added PHP 8.3 image" -->

### Removed
- <!-- e.g. "Dropped support of Node.js 14" -->
- 

### Fixed
- <!-- e.g. "Fixed a bug causing blank lines in content to be ignored when using the Regex Parser" -->

### Changed
- <!-- e.g. "Increased priority of wp_mail_from filter in VIP Dashboard to prevent unintentional overriding" -->
- <!-- e.g. "HyperDB: Updated to latest version to fix PHP error with addslashes()" -->


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->