### PR TITLE
feat [PLTFRM-1018]: cache module configs

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\VIP\Security\MFAUsers;
 
-use function Automattic\VIP\Security\Utils\get_module_configs;
+use Automattic\VIP\Security\Utils\Configs;
 
 class Forced_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
@@ -14,7 +14,7 @@ class Forced_MFA_Users {
 	private static $roles;
 
 	public static function init() {
-		$forced_mfa_configs = get_module_configs( 'forced-mfa-users' );
+		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
 
 		self::$roles = $forced_mfa_configs['roles'] ?? [];
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\VIP\Security\MFAUsers;
 
-use function Automattic\VIP\Security\Utils\get_module_configs;
+use Automattic\VIP\Security\Utils\Configs;
 
 class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
@@ -17,7 +17,7 @@ class Highlight_MFA_Users {
 
 	public static function init() {
 		// Feature is always active unless specific users are skipped via option.
-		$highlight_mfa_configs = get_module_configs( 'highlight-mfa-users' );
+		$highlight_mfa_configs = Configs::get_module_configs( 'highlight-mfa-users' );
 		self::$roles           = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS; // Default to administrator and editor if not configured
 
 		if ( ! is_array( self::$roles ) ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -3,7 +3,7 @@ namespace Automattic\VIP\Security\InactiveUsers;
 
 use Automattic\VIP\Utils\Context;
 use Automattic\VIP\Security\Constants;
-use function Automattic\VIP\Security\Utils\get_module_configs;
+use Automattic\VIP\Security\Utils\Configs;
 
 class Inactive_Users {
 	private static $considered_inactive_after_days;
@@ -27,7 +27,7 @@ class Inactive_Users {
 	private static $application_password_authentication_error;
 
 	public static function init() {
-		$inactive_user_configs = get_module_configs( 'inactive-users' );
+		$inactive_user_configs = Configs::get_module_configs( 'inactive-users' );
 
 		self::$release_date                   = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -3,7 +3,7 @@
 namespace Automattic\VIP\Security\SessionControl;
 
 use Automattic\VIP\Security\Constants;
-use function Automattic\VIP\Security\Utils\get_module_configs;
+use Automattic\VIP\Security\Utils\Configs;
 
 /**
  * Session Control module for VIP Security Boost
@@ -32,7 +32,7 @@ class Session_Control {
 			return;
 		}
 
-		$session_configs       = get_module_configs( 'session-control' );
+		$session_configs       = Configs::get_module_configs( 'session-control' );
 		$expiration_days_value = $session_configs['expiration_days'] ?? self::DEFAULT_VALUE;
 
 		// Only apply if a valid expiration time is set

--- a/modules/xml-rpc/class-xml-rpc.php
+++ b/modules/xml-rpc/class-xml-rpc.php
@@ -1,13 +1,13 @@
 <?php
 namespace Automattic\VIP\Security\XmlRpc;
 
-use function Automattic\VIP\Security\Utils\get_module_configs;
+use Automattic\VIP\Security\Utils\Configs;
 
 class Xml_Rpc {
 	private static $mode = 'RESTRICT';
 
 	public static function init() {
-		$xmlrpc_configs = get_module_configs( 'xml-rpc' );
+		$xmlrpc_configs = Configs::get_module_configs( 'xml-rpc' );
 		self::$mode     = strtoupper( $xmlrpc_configs['mode'] ?? 'RESTRICT' );
 
 		if ( vip_is_jetpack_request() ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../utils/configs.php';
+require_once __DIR__ . '/../utils/class-configs.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 require_once __DIR__ . '/../utils/class-constants.php';
 require_once __DIR__ . '/../email/class-email.php';

--- a/tests/phpunit/test-class-configs.php
+++ b/tests/phpunit/test-class-configs.php
@@ -1,0 +1,73 @@
+<?php
+
+use Automattic\VIP\Security\Utils\Configs;
+
+class ClassConfigsTest extends WP_UnitTestCase {
+	protected function setUp(): void {
+		parent::setUp();
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			define('VIP_SECURITY_BOOST_CONFIGS', [
+				'module_configs' => '{"test_module":{"key":"value"}}',
+			]);
+		}
+		// Polyfill config functions if missing.
+		if ( ! function_exists( '\Automattic\VIP\Security\Utils\get_all_module_configs' ) ) {
+			function get_all_module_configs() {
+				return apply_filters( 'vip_security_utils_get_all_module_configs', [] );
+			}
+		}
+		if ( ! function_exists( '\Automattic\VIP\Security\Utils\parse_module_configs' ) ) {
+			function parse_module_configs( $configs ) {
+				return apply_filters( 'vip_security_utils_parse_module_configs', $configs );
+			}
+		}
+		$this->resetConfigsCache();
+	}
+
+	protected function tearDown(): void {
+		remove_all_filters( 'vip_security_utils_get_all_module_configs' );
+		remove_all_filters( 'vip_security_utils_parse_module_configs' );
+		$this->resetConfigsCache();
+		parent::tearDown();
+	}
+
+	private function resetConfigsCache(): void {
+		$reflection = new \ReflectionClass( Configs::class );
+		$property   = $reflection->getProperty( 'cached_module_configs' );
+		$property->setAccessible( true );
+		$property->setValue( null );
+	}
+
+	public function test_returns_config_for_existing_module(): void {
+		add_filter('vip_security_utils_get_all_module_configs', fn() => [
+			'test_module' => [ 'key' => 'value' ],
+		]);
+		add_filter( 'vip_security_utils_parse_module_configs', fn( $configs ) => $configs, 10, 1 );
+
+		$this->assertEquals(
+			[ 'key' => 'value' ],
+			Configs::get_module_configs( 'test_module' )
+		);
+	}
+
+	public function test_returns_empty_for_nonexistent_module(): void {
+		add_filter( 'vip_security_utils_get_all_module_configs', fn() => [] );
+		add_filter( 'vip_security_utils_parse_module_configs', fn( $configs ) => $configs, 10, 1 );
+
+		$this->assertEquals( [], Configs::get_module_configs( 'missing_module' ) );
+	}
+
+	public function test_returns_empty_when_parse_returns_non_array(): void {
+		add_filter( 'vip_security_utils_get_all_module_configs', fn() => [ 'foo' => 'bar' ] );
+		add_filter( 'vip_security_utils_parse_module_configs', fn() => false, 10, 1 );
+
+		$this->assertEquals( [], Configs::get_module_configs( 'foo' ) );
+	}
+
+	public function test_returns_empty_if_module_config_not_array(): void {
+		add_filter( 'vip_security_utils_get_all_module_configs', fn() => [ 'bad' => 'string_value' ] );
+		add_filter( 'vip_security_utils_parse_module_configs', fn() => [ 'bad' => 'string_value' ], 10, 1 );
+
+		$this->assertEquals( [], Configs::get_module_configs( 'bad' ) );
+	}
+}

--- a/utils/class-configs.php
+++ b/utils/class-configs.php
@@ -40,8 +40,8 @@ class Configs {
 
 		if ( ! is_array( $module_configs ) ) {
 			self::$cached_module_configs = [];
+		} else {
+			self::$cached_module_configs = $module_configs;
 		}
-
-		self::$cached_module_configs = $module_configs;
 	}
 }

--- a/utils/class-configs.php
+++ b/utils/class-configs.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Automattic\VIP\Security\Utils;
+
+use function Automattic\VIP\Security\Utils\{ get_all_module_configs, parse_module_configs };
+
+class Configs {
+	private static $cached_module_configs = null;
+
+	/**
+	 * Get the module configs for a given module name.
+	 *
+	 * Attempts to retrieve configuration for a specific security module.
+	 *
+	 * @param string $module_name The name of the module to get the configs for.
+	 * @return array The module configs. Returns an empty array if configs are not found,
+	 * not defined, or if JSON parsing fails.
+	 */
+	public static function get_module_configs( $module_name ): array {
+		if ( null === self::$cached_module_configs ) {
+			self::init();
+		}
+
+		$current_module_config = [];
+
+		if ( isset( self::$cached_module_configs[ $module_name ] ) ) {
+			$current_module_config = self::$cached_module_configs[ $module_name ];
+		}
+
+		if ( ! is_array( $current_module_config ) ) {
+			return [];
+		}
+
+		return $current_module_config;
+	}
+
+	private static function init(): void {
+		$configs        = get_all_module_configs();
+		$module_configs = parse_module_configs( $configs );
+
+		if ( ! is_array( $module_configs ) ) {
+			self::$cached_module_configs = [];
+		}
+
+		self::$cached_module_configs = $module_configs;
+	}
+}

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -17,23 +17,12 @@ function get_module_configs( $module_name, $configs = false ) {
 		$configs = get_all_module_configs();
 	}
 
-	if ( ! is_array( $configs ) || ! isset( $configs['module_configs'] ) ) {
-		return [];
-	}
+	$module_configs = parse_module_configs( $configs );
 
-	$module_configs        = $configs['module_configs'];
 	$current_module_config = [];
 
-	if ( is_string( $module_configs ) ) {
-		$module_configs = json_decode( $module_configs, true );
-
-		if ( is_null( $module_configs ) && json_last_error() !== JSON_ERROR_NONE ) {
-			return [];
-		}
-	}
-
 	if ( is_array( $module_configs ) && isset( $module_configs[ $module_name ] ) ) {
-		$current_module_config = $module_configs[ $module_name ];        
+		$current_module_config = $module_configs[ $module_name ];
 	}
 
 	if ( ! is_array( $current_module_config ) ) {
@@ -43,11 +32,36 @@ function get_module_configs( $module_name, $configs = false ) {
 	return $current_module_config;
 }
 
+function parse_module_configs( $configs ): array {
+	if ( ! isset( $configs['module_configs'] ) ) {
+		return [];
+	}
+
+	$module_configs = $configs['module_configs'];
+
+	if ( is_string( $module_configs ) ) {
+		$module_configs = json_decode( $module_configs, true );
+
+		if ( is_null( $module_configs ) && json_last_error() !== JSON_ERROR_NONE ) {
+			return [];
+		}
+	}
+
+	return $module_configs;
+}
+
 function get_all_module_configs() {
 	if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		trigger_error( '[Security Boost] VIP_SECURITY_BOOST_CONFIGS is not defined.', E_USER_WARNING );
 		return [];
 	}
-	return constant( 'VIP_SECURITY_BOOST_CONFIGS' );
+
+	$configs = constant( 'VIP_SECURITY_BOOST_CONFIGS' );
+
+	if ( ! is_array( $configs ) ) {
+		return [];
+	}
+
+	return $configs;
 }

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -16,6 +16,7 @@
 declare(strict_types = 1);
 
 require_once __DIR__ . '/utils/configs.php';
+require_once __DIR__ . '/utils/class-configs.php';
 require_once __DIR__ . '/email/class-email.php';
 require_once __DIR__ . '/utils/class-constants.php';
 


### PR DESCRIPTION
## Description
Changes the load of module configs to only parse json a single time. 

## Changelog Description

### Added
- cached loading of module config json

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Load configuration that enabled security modules with configuration
1. Verify on WP-admin that security boost plugins load with their configuration