### PR TITLE
fix: update indeterminate label to unknown

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -289,7 +289,7 @@ class Inactive_Users {
 
 		$last_seen_timestamp = get_user_meta( $user_id, self::LAST_SEEN_META_KEY, true );
 
-		$date = __( 'Indeterminate', 'wpvip' );
+		$date = __( 'Unknown', 'wpvip' );
 		if ( $last_seen_timestamp ) {
 			$date = sprintf(
 				/* translators: 1: Comment date, 2: Comment time. */


### PR DESCRIPTION

## Description
Tiny pr to update the indeterminate label to unknown.

## Changelog Description

### Changed
- inactive user indeterminate label

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

No need to test.
<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->