### PR TITLE
Fix XML-RPC ALLOW mode incorrectly restricting to application passwords

### DIFF
--- a/modules/xml-rpc/class-xml-rpc.php
+++ b/modules/xml-rpc/class-xml-rpc.php
@@ -20,11 +20,12 @@ class Xml_Rpc {
 				// Completely disable XML-RPC.
 				self::disable_xml_rpc();
 				break;
-
 			case 'RESTRICT':
-			default:
 				// Restrict XML-RPC to only allow Application Passwords.
 				self::restrict_xmlrpc();
+				break;
+			default:
+				// Do nothing.
 				break;
 		}
 	}


### PR DESCRIPTION
## Description

This PR fixes a bug in the XML-RPC module where setting `mode=ALLOW` would still restrict XML-RPC to only allow Application Passwords, instead of allowing all XML-RPC requests as intended.

The issue was caused by the `RESTRICT` case not having a `break` statement, causing it to fall through to the default case.

## Changelog Description

### Fixed
- Fixed XML-RPC ALLOW mode incorrectly restricting requests to application passwords only

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out this PR
2. Configure the XML-RPC module with `mode=ALLOW` ("Default restrictions" on the UI)
3. Attempt to make XML-RPC requests using regular WordPress credentials (not application passwords)
4. Verify that the requests are allowed and not restricted
5. Test that `mode=RESTRICT` still works as expected (only allows application passwords)
6. Test that `mode=DISABLE` still works as expected (completely disables XML-RPC)