### PR TITLE
feat [PLTFRM-1064]: use relative times when last seen < 1 month

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -328,6 +328,11 @@ class Inactive_Users {
 		$now  = $now ?? current_datetime()->getTimestamp();
 		$diff = $now - $last_seen_timestamp;
 
+		// If the last-seen date is in the future, return "Unknown".
+		if ( $diff < 0 ) {
+			return __( 'Unknown', 'wpvip' );
+		}
+
 		// If the last-seen date is within the last month, show a human-readable diff.
 		if ( $diff >= 0 && $diff < MONTH_IN_SECONDS ) {
 			return sprintf(

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -320,7 +320,7 @@ class Inactive_Users {
 	 * @param int|null $now                 Optional. Timestamp to compare against. Defaults to now.
 	 * @return string
 	 */
-	private static function get_last_seen_date_string( $last_seen_timestamp, $now = null ): string {
+	protected static function get_last_seen_date_string( $last_seen_timestamp, $now = null ): string {
 		if ( ! $last_seen_timestamp ) {
 			return __( 'Unknown', 'wpvip' );
 		}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -291,15 +291,7 @@ class Inactive_Users {
 
 		$last_seen_timestamp = get_user_meta( $user_id, self::LAST_SEEN_META_KEY, true );
 
-		$date = __( 'Unknown', 'wpvip' );
-		if ( $last_seen_timestamp ) {
-			$date = sprintf(
-				/* translators: 1: Comment date, 2: Comment time. */
-				__( '%1$s at %2$s' ),
-				date_i18n( get_option( 'date_format' ), $last_seen_timestamp ),
-				date_i18n( get_option( 'time_format' ), $last_seen_timestamp )
-			);
-		}
+		$date = self::get_last_seen_date_string( $last_seen_timestamp );
 
 		if ( ! self::is_block_action_enabled() || ! self::is_considered_inactive( $user_id ) ) {
 			return sprintf( '<span>%s</span>', esc_html( $date ) );
@@ -316,6 +308,41 @@ class Inactive_Users {
 			$unblock_link = "<div class='row-actions'><span>User blocked due to inactivity. <a class='reset_last_seen_action' href='" . esc_url( $url ) . "'>" . __( 'Unblock', 'wpvip' ) . '</a></span></div>';
 		}
 		return sprintf( '<span class="wp-ui-text-notification">%s</span>' . $unblock_link, esc_html( $date ) );
+	}
+
+	/**
+	 * Return a readable “last-seen” string.
+	 *
+	 * – If the event happened < 1 month ago  → “5 hours ago”.
+	 * – Otherwise                            → “12 Mar 2025 at 14:07”.
+	 *
+	 * @param int      $last_seen_timestamp Unix timestamp (already adjusted for site TZ).
+	 * @param int|null $now                 Optional. Timestamp to compare against. Defaults to now.
+	 * @return string
+	 */
+	private static function get_last_seen_date_string( $last_seen_timestamp, $now = null ): string {
+		if ( ! $last_seen_timestamp ) {
+			return __( 'Unknown', 'wpvip' );
+		}
+
+		$now  = $now ?? current_datetime()->getTimestamp();
+		$diff = $now - $last_seen_timestamp;
+
+		// If the last-seen date is within the last month, show a human-readable diff.
+		if ( $diff >= 0 && $diff < MONTH_IN_SECONDS ) {
+			return sprintf(
+			/* translators: %s: Human-readable time difference, e.g. "5 hours". */
+				__( '%s ago', 'wpvip' ),
+				human_time_diff( $last_seen_timestamp, $now )
+			);
+		}
+
+		return sprintf(
+		/* translators: 1: Last-seen date, 2: Last-seen time. */
+			__( '%1$s at %2$s', 'wpvip' ),
+			date_i18n( get_option( 'date_format' ), $last_seen_timestamp ),
+			date_i18n( get_option( 'time_format' ), $last_seen_timestamp )
+		);
 	}
 
 	public static function add_blocked_users_filter( $views ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -320,7 +320,7 @@ class Inactive_Users {
 	 * @param int|null $now                 Optional. Timestamp to compare against. Defaults to now.
 	 * @return string
 	 */
-	protected static function get_last_seen_date_string( $last_seen_timestamp, $now = null ): string {
+	public static function get_last_seen_date_string( $last_seen_timestamp, $now = null ): string {
 		if ( ! $last_seen_timestamp ) {
 			return __( 'Unknown', 'wpvip' );
 		}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -334,7 +334,7 @@ class Inactive_Users {
 		}
 
 		// If the last-seen date is within the last month, show a human-readable diff.
-		if ( $diff >= 0 && $diff < MONTH_IN_SECONDS ) {
+		if ( $diff < MONTH_IN_SECONDS ) {
 			return sprintf(
 			/* translators: %s: Human-readable time difference, e.g. "5 hours". */
 				__( '%s ago', 'wpvip' ),

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -308,8 +308,6 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'background: #f0b849', $output );
 	}
 
-	// Removed helper method call_last_seen_date_string_helper.
-
 	/**
 	 * Test public method that uses get_last_seen_date_string indirectly.
 	 */

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -311,10 +311,23 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	/**
 	 * Test public method that uses get_last_seen_date_string indirectly.
 	 */
-	public function test_public_method_handles_empty_timestamp_correctly() {
+	public function test_get_last_seen_date_string_handles_empty_timestamp_correctly() {
 		// Example: Replace with a test for a public method that uses get_last_seen_date_string.
-		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_for_user( 0 ) );
-		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_for_user( null ) );
+		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_string( 0 ) );
+		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_string( null ) );
+	}
+
+	/**
+	 * get_last_seen_date_string() returns unknown (date in the future).
+	 */
+	public function test_get_last_seen_date_string__handles_future_timestamp_correctly() {
+		$fixed_now = 1_700_000_000;                     // 2023-11-14 22:13 UTC
+		$two_hours = $fixed_now + 2 * HOUR_IN_SECONDS;  // 2 hours in the future
+
+		$this->assertSame(
+			'Unknown',
+			Inactive_Users::get_last_seen_date_string( $two_hours, $fixed_now )
+		);
 	}
 
 	/**
@@ -326,7 +339,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			'2 hours ago',
-			$this->call_last_seen_date_string_helper( $two_hours, $fixed_now )
+			Inactive_Users::get_last_seen_date_string( $two_hours, $fixed_now )
 		);
 	}
 
@@ -351,7 +364,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		$this->assertSame(
 			$expected,
-			$this->call_last_seen_date_string_helper( $sixty_days_ago, $fixed_now )
+			Inactive_Users::get_last_seen_date_string( $sixty_days_ago, $fixed_now )
 		);
 
 		// Restore environment.

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -307,4 +307,70 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'background: #d63638', $output );
 		$this->assertStringContainsString( 'background: #f0b849', $output );
 	}
+
+	/**
+	 * Helper: call the private static get_last_seen_date_string().
+	 *
+	 * @param int|null $timestamp
+	 * @param int|null $now Optional fixed "current time" for testing.
+	 * @return string
+	 */
+	private function call_last_seen_date_string_helper( $timestamp, $now = null ) {
+		$ref = new ReflectionClass( Inactive_Users::class );
+		$m   = $ref->getMethod( 'get_last_seen_date_string' );
+		$m->setAccessible( true );
+
+		// Pass both arguments.
+		return $m->invoke( null, $timestamp, $now );
+	}
+
+	/**
+	 * get_last_seen_date_string() → "Unknown" when no timestamp supplied.
+	 */
+	public function test_last_seen_returns_unknown_for_empty_value() {
+		$this->assertSame( 'Unknown', $this->call_last_seen_date_string_helper( 0 ) );
+		$this->assertSame( 'Unknown', $this->call_last_seen_date_string_helper( null ) );
+	}
+
+	/**
+	 * get_last_seen_date_string() returns a relative phrase (< 1 day old).
+	 */
+	public function test_last_seen_uses_relative_time_for_recent_activity() {
+		$fixed_now = 1_700_000_000;                     // 2023-11-14 22:13 UTC
+		$two_hours = $fixed_now - 2 * HOUR_IN_SECONDS;  // 2 hours earlier
+
+		$this->assertSame(
+			'2 hours ago',
+			$this->call_last_seen_date_string_helper( $two_hours, $fixed_now )
+		);
+	}
+
+	/**
+	 * get_last_seen_date_string() falls back to absolute date/time (≥ 30 days old).
+	 */
+	public function test_last_seen_uses_absolute_time_for_older_activity() {
+		$fixed_now      = 1_700_000_000;
+		$sixty_days_ago = $fixed_now - 60 * DAY_IN_SECONDS;
+
+		// Use deterministic site formats and remember originals.
+		$old_date_format = get_option( 'date_format' );
+		$old_time_format = get_option( 'time_format' );
+		update_option( 'date_format', 'j M Y' ); // "9 Dec 2023"
+		update_option( 'time_format', 'H:i' );   // "05:33"
+
+		$expected = sprintf(
+			'%1$s at %2$s',
+			date_i18n( get_option( 'date_format' ), $sixty_days_ago ),
+			date_i18n( get_option( 'time_format' ), $sixty_days_ago )
+		);
+
+		$this->assertSame(
+			$expected,
+			$this->call_last_seen_date_string_helper( $sixty_days_ago, $fixed_now )
+		);
+
+		// Restore environment.
+		update_option( 'date_format', $old_date_format );
+		update_option( 'time_format', $old_time_format );
+	}
 }

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -308,28 +308,15 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'background: #f0b849', $output );
 	}
 
-	/**
-	 * Helper: call the private static get_last_seen_date_string().
-	 *
-	 * @param int|null $timestamp
-	 * @param int|null $now Optional fixed "current time" for testing.
-	 * @return string
-	 */
-	private function call_last_seen_date_string_helper( $timestamp, $now = null ) {
-		$ref = new ReflectionClass( Inactive_Users::class );
-		$m   = $ref->getMethod( 'get_last_seen_date_string' );
-		$m->setAccessible( true );
-
-		// Pass both arguments.
-		return $m->invoke( null, $timestamp, $now );
-	}
+	// Removed helper method call_last_seen_date_string_helper.
 
 	/**
-	 * get_last_seen_date_string() → "Unknown" when no timestamp supplied.
+	 * Test public method that uses get_last_seen_date_string indirectly.
 	 */
-	public function test_last_seen_returns_unknown_for_empty_value() {
-		$this->assertSame( 'Unknown', $this->call_last_seen_date_string_helper( 0 ) );
-		$this->assertSame( 'Unknown', $this->call_last_seen_date_string_helper( null ) );
+	public function test_public_method_handles_empty_timestamp_correctly() {
+		// Example: Replace with a test for a public method that uses get_last_seen_date_string.
+		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_for_user( 0 ) );
+		$this->assertSame( 'Unknown', Inactive_Users::get_last_seen_date_for_user( null ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
Use relative times when last seen timestamp is < 1 month for inactive users.
<img width="1263" alt="Screenshot 2025-06-19 at 5 42 02 PM" src="https://github.com/user-attachments/assets/b57e74a5-ad25-4de3-9cd1-357a74b51c66" />


## Changelog Description

### Added
- relative times shown when user is inactive for < 1 month.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test


1. Check out PR.
1. Go to `wp-admin` > `Users`
1. Confirm relative times are being used when user < 1 month logged in.