### PR TITLE
Send the plugin name in the Logger class

### DIFF
--- a/class-loader.php
+++ b/class-loader.php
@@ -38,10 +38,7 @@ class Loader {
 				trigger_error( 'Module not found: ' . esc_html( $module ), E_USER_WARNING );
 				Logger::error(
 					self::LOG_FEATURE_NAME,
-					'Module not found: ' . $module,
-					[
-						'plugin' => Constants::LOG_PLUGIN_NAME,
-					]
+					'Module not found: ' . $module
 				);
 			}
 		}

--- a/email/class-email.php
+++ b/email/class-email.php
@@ -84,18 +84,12 @@ class Email {
 		if ( $sent ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'Email sent to ' . $email_address,
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'Email sent to ' . $email_address
 			);
 		} else {
 			Logger::error(
 				self::LOG_FEATURE_NAME,
-				'Email not sent to ' . $email_address,
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'Email not sent to ' . $email_address
 			);
 		}
 	}
@@ -114,7 +108,6 @@ class Email {
 				self::LOG_FEATURE_NAME,
 				'Email template not found',
 				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
 					'template_id' => $template_id,
 				]
 			);

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -113,10 +113,7 @@ class Inactive_Users {
 		if ( $user->ID && self::is_considered_inactive( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'User ' . $user->user_login . ' is flagged as inactive, login was blocked.',
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'User ' . $user->user_login . ' is flagged as inactive, login was blocked.'
 			);
 			if ( Context::is_xmlrpc_api() ) {
 				add_filter('xmlrpc_login_error', function () {
@@ -151,10 +148,7 @@ class Inactive_Users {
 		if ( self::is_considered_inactive( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'User ' . $user->user_login . ' is flagged as inactive, application password authentication was blocked.',
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'User ' . $user->user_login . ' is flagged as inactive, application password authentication was blocked.'
 			);
 			self::$application_password_authentication_error = new \WP_Error( 'inactive_account', __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ), array( 'status' => 403 ) );
 

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -116,10 +116,7 @@ class Notify_Privileged_Activity {
 
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'User granted privileged roles (notification type: ' . $template . ') user: ' . $user->user_login,
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'User granted privileged roles (notification type: ' . $template . ') user: ' . $user->user_login
 			);
 			$params = [
 				'user_login'  => $user->user_login,
@@ -128,7 +125,7 @@ class Notify_Privileged_Activity {
 				'email_title' => $email_title,
 				'admin_url'   => admin_url(),
 			];
-			
+
 			if ( is_multisite() ) {
 				$params['network_admin_url'] = network_admin_url();
 			}
@@ -139,10 +136,7 @@ class Notify_Privileged_Activity {
 		} catch ( \Exception $e ) {
 			Logger::error(
 				self::LOG_FEATURE_NAME,
-				'Failed to notify admin user creation (type: ' . $template . ') user: ' . $user->user_login . ' - error: ' . $e->getMessage(),
-				[
-					'plugin' => Constants::LOG_PLUGIN_NAME,
-				]
+				'Failed to notify admin user creation (type: ' . $template . ') user: ' . $user->user_login . ' - error: ' . $e->getMessage()
 			);
 		}
 	}

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -43,10 +43,7 @@ class Session_Control {
 			if ( ! is_numeric( $expiration_days_value ) ) {
 				Logger::warning(
 					self::LOG_FEATURE_NAME,
-					'Invalid session expiration days. Must be an integer. Reverting to default.',
-					[
-						'plugin' => Constants::LOG_PLUGIN_NAME,
-					]
+					'Invalid session expiration days. Must be an integer. Reverting to default.'
 				);
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error( 'Invalid session expiration days. Must be an integer. Reverting to default.', E_USER_WARNING );
@@ -58,10 +55,7 @@ class Session_Control {
 
 				Logger::warning(
 					self::LOG_FEATURE_NAME,
-					'Invalid session expiration days. Must be between 1 and 13. Reverting to default.',
-					[
-						'plugin' => Constants::LOG_PLUGIN_NAME,
-					]
+					'Invalid session expiration days. Must be between 1 and 13. Reverting to default.'
 				);
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				trigger_error( 'Invalid session expiration days. Must be between 1 and 13. Reverting to default.', E_USER_WARNING );

--- a/utils/class-logger.php
+++ b/utils/class-logger.php
@@ -5,6 +5,8 @@
 
 namespace Automattic\VIP\Security\Utils;
 
+use Automattic\VIP\Security\Constants;
+
 class Logger {
 	/**
 	 * Log data to both error_log (non-production) and Logstash
@@ -19,7 +21,7 @@ class Logger {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 			$backtrace  = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 );
 			$base_index = 0;
-			
+
 			if ( isset( $backtrace[ $base_index ]['file'] ) ) {
 				$data['file'] = $backtrace[ $base_index ]['file'];
 			}
@@ -49,11 +51,11 @@ class Logger {
 				strtoupper( $data['severity'] ?? 'info' ),
 				$data['message'] ?? 'No message'
 			);
-			
+
 			if ( isset( $data['extra'] ) && ! empty( $data['extra'] ) ) {
 				$log_message .= ' | Extra: ' . wp_json_encode( $data['extra'] );
 			}
-			
+
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log( $log_message );
 		}
@@ -74,6 +76,7 @@ class Logger {
 			'severity' => 'info',
 			'feature'  => $feature,
 			'message'  => $message,
+			'plugin'   => Constants::LOG_PLUGIN_NAME,
 			'extra'    => $extra,
 		] );
 	}
@@ -90,6 +93,7 @@ class Logger {
 			'severity' => 'warning',
 			'feature'  => $feature,
 			'message'  => $message,
+			'plugin'   => Constants::LOG_PLUGIN_NAME,
 			'extra'    => $extra,
 		] );
 	}
@@ -106,6 +110,7 @@ class Logger {
 			'severity' => 'error',
 			'feature'  => $feature,
 			'message'  => $message,
+			'plugin'   => Constants::LOG_PLUGIN_NAME,
 			'extra'    => $extra,
 		] );
 	}


### PR DESCRIPTION
## Description
Followup to
* #39

I realized that we're sending the plugin name in the extra field, but we want to send it alongside the extra field; otherwise, it won't get picked up by the ES index.

This PR introduces the plugin directly in the logger class and removes the previous usage of passing the plugin as the extra parameter. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- add an admin user locally, check that Mailpit sent the email
- Verify the logstash logs with `vip dev-env shell -- tail /wp/log/debug.log` and ensure they include the `plugin:` at the same level as the `extra` parameter
- 
