### PR TITLE
Remove error_log call

### DIFF
--- a/utils/class-logger.php
+++ b/utils/class-logger.php
@@ -43,23 +43,6 @@ class Logger {
 			}
 		}
 
-		// Log to error_log if not in production and not during testing
-		$is_testing = ( defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' ) );
-		if ( ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) && ! $is_testing ) {
-			$log_message = sprintf(
-				'[VIP Security Boost] %s: %s',
-				strtoupper( $data['severity'] ?? 'info' ),
-				$data['message'] ?? 'No message'
-			);
-
-			if ( isset( $data['extra'] ) && ! empty( $data['extra'] ) ) {
-				$log_message .= ' | Extra: ' . wp_json_encode( $data['extra'] );
-			}
-
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $log_message );
-		}
-
 		// Send to Logstash
 		\Automattic\VIP\Logstash\Logger::log2logstash( $data );
 	}

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -161,7 +161,7 @@ class Tracking {
 	private static function record_stats( $stat_name ) {
 		// We're tracking the stats in production only
 		if ( 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			Logger::info( 'vip-security-boost', 'Bumping stats for https://mc.a8c.com/s/' . self::PREFIX . "/{$stat_name}", [
+			Logger::info( 'vip-security-boost', 'Bumping stats for /s/' . self::PREFIX . "/{$stat_name}", [
 				'stat_name' => $stat_name,
 			] );
 			return;


### PR DESCRIPTION
## Description

This is a very small PR to ensure we don't print error logs if the environment is called "test." This is because customers might have this environment name, so it's better not to rely on that logic to print the log to Logstash.

Additionally, if you want to debug it, you can just print it from the command line, so it can still be debugged locally. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->