### PR TITLE
Improve performance of MFA user count lookup with caching

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -4,8 +4,6 @@ namespace Automattic\VIP\Security\MFAUsers;
 use Automattic\VIP\Security\Utils\Configs;
 
 class Forced_MFA_Users {
-	const MFA_SKIP_USER_IDS_OPTION_KEY = 'vip_security_mfa_skip_user_ids';
-
 	/**
 	 * The roles that should have MFA enforced.
 	 *

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -7,6 +7,9 @@ class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
 	const ROLE_COLUMN_KEY                 = 'role';
 	const DEFAULT_ADMIN_EDITOR_ROLE_SLUGS = [ 'administrator', 'editor' ];
+	const MFA_COUNT_CACHE_GROUP           = 'vip_security_mfa_count';
+	const MFA_COUNT_CACHE_KEY             = 'mfa_disabled_count';
+	const MFA_COUNT_CACHE_TTL             = HOUR_IN_SECONDS; // Cache for 1 hour
 
 	/**
 	 * The roles used to highlight users without MFA.
@@ -16,6 +19,20 @@ class Highlight_MFA_Users {
 	private static $roles;
 
 	public static function init() {
+		// If plugins_loaded has already fired (e.g., in tests), register hooks immediately
+		if ( did_action( 'plugins_loaded' ) ) {
+			self::register_hooks();
+		} else {
+			add_action( 'plugins_loaded', [ __CLASS__, 'register_hooks' ] );
+		}
+	}
+
+	public static function register_hooks() {
+		// Ensure the Two Factor plugin is active
+		if ( ! class_exists( '\Two_Factor_Core' ) ) {
+			return;
+		}
+
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = Configs::get_module_configs( 'highlight-mfa-users' );
 		self::$roles           = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS; // Default to administrator and editor if not configured
@@ -28,6 +45,9 @@ class Highlight_MFA_Users {
 		if ( empty( self::$roles ) ) {
 			self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
 		}
+
+		// Use a global cache group since users are shared among network sites.
+		wp_cache_add_global_groups( array( self::MFA_COUNT_CACHE_GROUP ) );
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
 		add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
@@ -47,16 +67,92 @@ class Highlight_MFA_Users {
 
 		// Handle sorting
 		add_filter( 'users_list_table_query_args', [ __CLASS__, 'sort_columns' ] );
+
+		// Clear cache when users or MFA settings change
+		add_action( 'two_factor_user_settings_action', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		add_action( 'updated_user_meta', [ __CLASS__, 'clear_mfa_count_cache_on_meta_update' ], 10, 3 );
+		add_action( 'user_register', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		add_action( 'delete_user', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		add_action( 'set_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		add_action( 'add_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		add_action( 'remove_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
 	}
 
 	/**
-		* Display an admin notice on the Users page showing the count of users with MFA disabled.
-		*/
-	public static function display_mfa_disabled_notice() {
-		if ( ! class_exists( '\Two_Factor_Core' ) ) {
-			return;
+	 * Get the count of users with MFA disabled, with caching.
+	 *
+	 * @return int The number of users with MFA disabled.
+	 */
+	private static function get_mfa_disabled_count() {
+		// Try to get from cache first
+		$cached_count = wp_cache_get( self::MFA_COUNT_CACHE_KEY, self::MFA_COUNT_CACHE_GROUP );
+		if ( false !== $cached_count ) {
+			return (int) $cached_count;
 		}
 
+		// Cache miss - calculate the count
+		$skipped_user_ids = \get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
+		if ( ! is_array( $skipped_user_ids ) ) {
+			$skipped_user_ids = [];
+		}
+
+		// Exclude the wpcomvip user from the list
+		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+		if ( false !== $wpcomvip ) {
+			$skipped_user_ids[] = $wpcomvip->ID;
+		}
+		$skipped_user_ids = array_unique( array_filter( array_map( 'intval', $skipped_user_ids ) ) );
+
+		// Cache miss - calculate the count
+		$args       = [
+			'role__in' => self::$roles,
+			'fields'   => 'ID',
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
+			'exclude'  => $skipped_user_ids,
+			'number'   => -1, // Get all relevant users
+		];
+		$user_query = new \WP_User_Query( $args );
+		$user_ids   = $user_query->get_results();
+
+		$mfa_disabled_count = 0;
+		foreach ( $user_ids as $user_id ) {
+			if ( ! \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
+				++$mfa_disabled_count;
+			}
+		}
+
+		// Cache the result
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		wp_cache_set( self::MFA_COUNT_CACHE_KEY, $mfa_disabled_count, self::MFA_COUNT_CACHE_GROUP, self::MFA_COUNT_CACHE_TTL );
+
+		return $mfa_disabled_count;
+	}
+
+	/**
+	 * Clear the MFA disabled count cache.
+	 * Called when user MFA settings or roles change.
+	 */
+	public static function clear_mfa_count_cache() {
+		wp_cache_delete( self::MFA_COUNT_CACHE_KEY, self::MFA_COUNT_CACHE_GROUP );
+	}
+
+	/**
+	 * Clear the MFA count cache when Two Factor user meta is updated.
+	 *
+	 * @param int    $meta_id  ID of updated metadata entry.
+	 * @param int    $user_id  User ID.
+	 * @param string $meta_key Metadata key.
+	 */
+	public static function clear_mfa_count_cache_on_meta_update( $meta_id, $user_id, $meta_key ) {
+		if ( \Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY === $meta_key ) {
+			self::clear_mfa_count_cache();
+		}
+	}
+
+	/**
+	* Display an admin notice on the Users page showing the count of users with MFA disabled.
+	*/
+	public static function display_mfa_disabled_notice() {
 		// Only show the notice to admins
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
@@ -76,33 +172,8 @@ class Highlight_MFA_Users {
 		// unordered array check with ==
 		$is_default_config = ( self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS === $configured_roles_for_comparison || empty( $configured_roles_for_comparison ) );
 
-		$skipped_user_ids = get_option( self::MFA_SKIP_USER_IDS_OPTION_KEY, [] );
-		if ( ! is_array( $skipped_user_ids ) ) {
-			$skipped_user_ids = [];
-		}
-
-		// Exclude the wpcomvip user from the list
-		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
-		if ( false !== $wpcomvip ) {
-			$skipped_user_ids[] = $wpcomvip->ID;
-		}
-		// Query for user IDs with the configured roles, excluding skipped ones
-		$args       = [
-			'role__in' => self::$roles,
-			'fields'   => 'ID',
-			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'  => $skipped_user_ids,
-			'number'   => -1, // Get all relevant users
-		];
-		$user_query = new \WP_User_Query( $args );
-		$user_ids   = $user_query->get_results();
-
-		$mfa_disabled_count = 0;
-		foreach ( $user_ids as $user_id ) {
-			if ( ! \Two_Factor_Core::is_user_using_two_factor( $user_id ) ) {
-				++$mfa_disabled_count;
-			}
-		}
+		// Get the cached MFA disabled count
+		$mfa_disabled_count = self::get_mfa_disabled_count();
 
 		if ( $mfa_disabled_count > 0 ) {
 			// Check if the filter is currently active

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -8,7 +8,7 @@ class Highlight_MFA_Users {
 	const ROLE_COLUMN_KEY                 = 'role';
 	const DEFAULT_ADMIN_EDITOR_ROLE_SLUGS = [ 'administrator', 'editor' ];
 	const MFA_COUNT_CACHE_GROUP           = 'vip_security_mfa_count';
-	const MFA_COUNT_CACHE_KEY             = 'mfa_disabled_count';
+	const MFA_COUNT_CACHE_KEY_PREFIX      = 'mfa_disabled_count';
 	const MFA_COUNT_CACHE_TTL             = HOUR_IN_SECONDS; // Cache for 1 hour
 
 	/**
@@ -46,9 +46,6 @@ class Highlight_MFA_Users {
 			self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
 		}
 
-		// Use a global cache group since users are shared among network sites.
-		wp_cache_add_global_groups( array( self::MFA_COUNT_CACHE_GROUP ) );
-
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
 		add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_tracking_scripts' ] );
@@ -68,14 +65,36 @@ class Highlight_MFA_Users {
 		// Handle sorting
 		add_filter( 'users_list_table_query_args', [ __CLASS__, 'sort_columns' ] );
 
-		// Clear cache when users or MFA settings change
-		add_action( 'two_factor_user_settings_action', [ __CLASS__, 'clear_mfa_count_cache' ] );
-		add_action( 'updated_user_meta', [ __CLASS__, 'clear_mfa_count_cache_on_meta_update' ], 10, 3 );
+		// Clear cache when users are created or deleted
 		add_action( 'user_register', [ __CLASS__, 'clear_mfa_count_cache' ] );
 		add_action( 'delete_user', [ __CLASS__, 'clear_mfa_count_cache' ] );
-		add_action( 'set_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
-		add_action( 'add_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
-		add_action( 'remove_user_role', [ __CLASS__, 'clear_mfa_count_cache' ] );
+
+		// Multisite-specific hooks for user deletion/removal
+		if ( is_multisite() ) {
+			add_action( 'wpmu_delete_user', [ __CLASS__, 'clear_mfa_count_cache_for_user_sites' ] );
+			add_action( 'remove_user_from_blog', [ __CLASS__, 'clear_mfa_count_cache' ] );
+			add_action( 'add_user_to_blog', [ __CLASS__, 'clear_mfa_count_cache' ] );
+		}
+
+		// Clear cache when users or MFA settings change
+		add_action( 'updated_user_meta', [ __CLASS__, 'clear_mfa_count_cache_on_meta_update' ], 10, 3 );
+		add_action( 'added_user_meta', [ __CLASS__, 'clear_mfa_count_cache_on_meta_update' ], 10, 3 );
+		add_action( 'deleted_user_meta', [ __CLASS__, 'clear_mfa_count_cache_on_meta_update' ], 10, 3 );
+
+		// Clear cache when user roles change
+		add_action( 'set_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
+		add_action( 'add_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
+		add_action( 'remove_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
+	}
+
+	/**
+	 * Get the site-specific cache key for MFA count.
+	 *
+	 * @return string The cache key for the current site.
+	 */
+	private static function get_mfa_count_cache_key() {
+		$blog_id = get_current_blog_id();
+		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id;
 	}
 
 	/**
@@ -85,7 +104,7 @@ class Highlight_MFA_Users {
 	 */
 	private static function get_mfa_disabled_count() {
 		// Try to get from cache first
-		$cached_count = wp_cache_get( self::MFA_COUNT_CACHE_KEY, self::MFA_COUNT_CACHE_GROUP );
+		$cached_count = wp_cache_get( self::get_mfa_count_cache_key(), self::MFA_COUNT_CACHE_GROUP );
 		if ( false !== $cached_count ) {
 			return (int) $cached_count;
 		}
@@ -123,7 +142,7 @@ class Highlight_MFA_Users {
 
 		// Cache the result
 		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
-		wp_cache_set( self::MFA_COUNT_CACHE_KEY, $mfa_disabled_count, self::MFA_COUNT_CACHE_GROUP, self::MFA_COUNT_CACHE_TTL );
+		wp_cache_set( self::get_mfa_count_cache_key(), $mfa_disabled_count, self::MFA_COUNT_CACHE_GROUP, self::MFA_COUNT_CACHE_TTL );
 
 		return $mfa_disabled_count;
 	}
@@ -133,7 +152,34 @@ class Highlight_MFA_Users {
 	 * Called when user MFA settings or roles change.
 	 */
 	public static function clear_mfa_count_cache() {
-		wp_cache_delete( self::MFA_COUNT_CACHE_KEY, self::MFA_COUNT_CACHE_GROUP );
+		wp_cache_delete( self::get_mfa_count_cache_key(), self::MFA_COUNT_CACHE_GROUP );
+	}
+
+	/**
+	 * Clear the MFA count cache for all sites where a user has roles.
+	 * This is used when user meta is updated to ensure cache consistency across the network.
+	 *
+	 * @param int $user_id The user ID whose sites should have cache cleared.
+	 */
+	public static function clear_mfa_count_cache_for_user_sites( $user_id ) {
+		if ( ! is_multisite() ) {
+			// Single site - just clear the current cache
+			self::clear_mfa_count_cache();
+			return;
+		}
+
+		// Get all sites where this user has roles
+		$user_blogs = get_blogs_of_user( $user_id );
+
+		if ( empty( $user_blogs ) ) {
+			return;
+		}
+
+		// Clear cache for each site where the user has roles
+		foreach ( $user_blogs as $blog ) {
+			$cache_key = self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog->userblog_id;
+			wp_cache_delete( $cache_key, self::MFA_COUNT_CACHE_GROUP );
+		}
 	}
 
 	/**
@@ -145,8 +191,18 @@ class Highlight_MFA_Users {
 	 */
 	public static function clear_mfa_count_cache_on_meta_update( $meta_id, $user_id, $meta_key ) {
 		if ( \Two_Factor_Core::ENABLED_PROVIDERS_USER_META_KEY === $meta_key ) {
-			self::clear_mfa_count_cache();
+			self::clear_mfa_count_cache_for_user_sites( $user_id );
 		}
+	}
+
+	/**
+	 * Clear the MFA count cache when user roles change.
+	 * This handles set_user_role, add_user_role, and remove_user_role hooks.
+	 *
+	 * @param int    $user_id The user ID whose roles changed.
+	 */
+	public static function clear_mfa_count_cache_for_user_role_change( $user_id ) {
+		self::clear_mfa_count_cache_for_user_sites( $user_id );
 	}
 
 	/**

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -82,6 +82,11 @@ class Inactive_Users {
 			return $user_id;
 		}
 
+		if ( wp_cache_get( $user_id, self::LAST_SEEN_CACHE_GROUP ) ) {
+			// Last seen meta was checked recently
+			return $user_id;
+		}
+
 		$user = get_userdata( $user_id );
 		if ( ! $user ) {
 			return $user_id;
@@ -89,11 +94,6 @@ class Inactive_Users {
 
 		if ( self::is_considered_inactive( $user_id ) ) {
 			// User needs to be unblocked first
-			return $user_id;
-		}
-
-		if ( wp_cache_get( $user_id, self::LAST_SEEN_CACHE_GROUP ) ) {
-			// Last seen meta was checked recently
 			return $user_id;
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -2,7 +2,6 @@
 namespace Automattic\VIP\Security\InactiveUsers;
 
 use Automattic\VIP\Utils\Context;
-use Automattic\VIP\Security\Constants;
 use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Security\Utils\Configs;
 

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -22,9 +22,6 @@ class Session_Control {
 	 * Initialize the module
 	 */
 	public static function init() {
-		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
-			return;
-		}
 		$expiration_days_value = self::get_expiration_days_from_config();
 
 		// Only apply if a valid expiration time is set

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -2,7 +2,6 @@
 
 namespace Automattic\VIP\Security\SessionControl;
 
-use Automattic\VIP\Security\Constants;
 use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Security\Utils\Configs;
 

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -458,16 +458,13 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertNotFalse( has_action( 'set_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
 		$this->assertNotFalse( has_action( 'add_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
 		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
-	}
 
-	/**
-	 * Test that multisite-specific methods exist for cache clearing.
-	 */
-	public function test_multisite_cache_methods_exist() {
-		// Test that the multisite-specific cache clearing methods exist
-		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_sites' ) );
-		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache' ) );
-		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ) );
+		// Test that the multisite-specific cache clearing actions are hooked
+		if ( is_multisite() ) {
+			$this->assertNotFalse( has_action( 'wpmu_delete_user', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_sites' ] ) );
+			$this->assertNotFalse( has_action( 'remove_user_from_blog', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+			$this->assertNotFalse( has_action( 'add_user_to_blog', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		}
 	}
 
 	/**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -459,38 +459,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 	}
 
-	/**
-	 * Test that MFA count caching works correctly.
-	 */
-	public function test_mfa_count_caching() {
-		$this->set_admin_screen_users();
 
-		// Clear any existing cache
-		Highlight_MFA_Users::clear_mfa_count_cache();
-
-		// First call should calculate and cache the result
-		ob_start();
-		Highlight_MFA_Users::display_mfa_disabled_notice();
-		$output1 = ob_get_clean();
-
-		// Second call should use cached result and produce the same output
-		ob_start();
-		Highlight_MFA_Users::display_mfa_disabled_notice();
-		$output2 = ob_get_clean();
-
-		// Both outputs should be identical, indicating caching is working
-		$this->assertEquals( $output1, $output2 );
-
-		// Clear cache and verify it can be cleared
-		Highlight_MFA_Users::clear_mfa_count_cache();
-
-		// After clearing cache, the result should still be the same (but recalculated)
-		ob_start();
-		Highlight_MFA_Users::display_mfa_disabled_notice();
-		$output3 = ob_get_clean();
-
-		$this->assertEquals( $output1, $output3 );
-	}
 
 	/**
 	 * Test that the role column is added to the users table.

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -450,13 +450,24 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'pre_get_users', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status' ] ) );
 
 		// Test that cache clearing actions are hooked
-		$this->assertNotFalse( has_action( 'two_factor_user_settings_action', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 		$this->assertNotFalse( has_action( 'updated_user_meta', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertNotFalse( has_action( 'added_user_meta', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertNotFalse( has_action( 'deleted_user_meta', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_on_meta_update' ] ) );
 		$this->assertNotFalse( has_action( 'user_register', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 		$this->assertNotFalse( has_action( 'delete_user', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
-		$this->assertNotFalse( has_action( 'set_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
-		$this->assertNotFalse( has_action( 'add_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
-		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'set_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
+		$this->assertNotFalse( has_action( 'add_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
+		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ] ) );
+	}
+
+	/**
+	 * Test that multisite-specific methods exist for cache clearing.
+	 */
+	public function test_multisite_cache_methods_exist() {
+		// Test that the multisite-specific cache clearing methods exist
+		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_sites' ) );
+		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache' ) );
+		$this->assertTrue( method_exists( Highlight_MFA_Users::class, 'clear_mfa_count_cache_for_user_role_change' ) );
 	}
 
 	/**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -4,6 +4,8 @@ if ( ! class_exists( 'Two_Factor_Core' ) ) {
 		/** @var array<int> Stores user IDs that the mock should treat as MFA enabled */
 		public static $mock_enabled_user_ids = [];
 
+		const ENABLED_PROVIDERS_USER_META_KEY = '_two_factor_enabled_providers';
+
 		public static function is_user_using_two_factor( $user_id ) {
 			return in_array( (int) $user_id, self::$mock_enabled_user_ids, true );
 		}
@@ -25,6 +27,11 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+
+		// Define the config constant if not already defined
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			define( 'VIP_SECURITY_BOOST_CONFIGS', [] );
+		}
 
 		Two_Factor_Core::$mock_enabled_user_ids = [];
 
@@ -77,6 +84,9 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		// Clean up options
 		delete_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY );
+
+		// Clear MFA count cache to ensure clean state for next test
+		Highlight_MFA_Users::clear_mfa_count_cache();
 
 		// No need to restore config state manually as setUp handles it or tests run isolated.
 
@@ -438,6 +448,48 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->assertNotFalse( has_action( 'pre_get_users', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status' ] ) );
 		$this->assertEquals( 10, has_action( 'pre_get_users', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status' ] ) );
+
+		// Test that cache clearing actions are hooked
+		$this->assertNotFalse( has_action( 'two_factor_user_settings_action', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'updated_user_meta', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertNotFalse( has_action( 'user_register', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'delete_user', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'set_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'add_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
+	}
+
+	/**
+	 * Test that MFA count caching works correctly.
+	 */
+	public function test_mfa_count_caching() {
+		$this->set_admin_screen_users();
+
+		// Clear any existing cache
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// First call should calculate and cache the result
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output1 = ob_get_clean();
+
+		// Second call should use cached result and produce the same output
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output2 = ob_get_clean();
+
+		// Both outputs should be identical, indicating caching is working
+		$this->assertEquals( $output1, $output2 );
+
+		// Clear cache and verify it can be cleared
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// After clearing cache, the result should still be the same (but recalculated)
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output3 = ob_get_clean();
+
+		$this->assertEquals( $output1, $output3 );
 	}
 
 	/**

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -459,8 +459,6 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertNotFalse( has_action( 'remove_user_role', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 	}
 
-
-
 	/**
 	 * Test that the role column is added to the users table.
 	 */

--- a/tests/phpunit/test-session-control.php
+++ b/tests/phpunit/test-session-control.php
@@ -33,7 +33,7 @@ class SessionControlTest extends WP_UnitTestCase {
 		define('VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
 				'session-control' => [
-					'expiration_days' => Session_Control::DEFAULT_VALUE,
+					'expiration_days' => 'default',
 				],
 			],
 		]);


### PR DESCRIPTION
## Description

This PR implements caching for the user count lookup in the `Highlight_MFA_Users` module to address performance feedback. The module was performing expensive database queries on every admin page load to count users with MFA disabled, which could impact performance on sites with many users.

The implementation adds a 1-hour cache for the MFA disabled user count, with smart cache invalidation when user MFA settings or roles change. The solution follows existing caching patterns in the codebase and uses proper WordPress hooks from the Two Factor plugin.

### Commits in this PR:
1. **Remove unused constant** (`b86f06c`) - Cleaned up unused constant from initial implementation
2. **Remove unnecessary check** (`a54f90f`) - Simplified logic by removing redundant conditional checks
3. **Move cache check to the top so we don't perform unnecessary queries** (`08d6d35`) - Optimized performance by checking cache first before any expensive operations
4. **Cache user count for better performance** (`9358afc`) - Main implementation of caching system with proper invalidation hooks

**Key improvements:**
- Caches potentially expensive user queries
- Implements cache invalidation on relevant user changes
- Maintains full backward compatibility

### Links
- https://linear.app/a8c/issue/PLTFRM-1137/cleanup-unused-vars

## Changelog Description

### Changed
- Improved performance of MFA user count lookup by implementing 1-hour caching with smart invalidation

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

There should be no change to any functionality