### PR TITLE
Use Telemetry class instead of the specific telemetry tooling

### DIFF
--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -6,7 +6,7 @@
 namespace Automattic\VIP\Security\Utils;
 
 use Automattic\VIP\Security\Constants;
-use Automattic\VIP\Telemetry\Tracks;
+use Automattic\VIP\Telemetry\Telemetry;
 
 class Tracking {
 
@@ -16,9 +16,9 @@ class Tracking {
 	const PREFIX = 'vip_security_boost';
 
 	/**
-	 * Tracks instance.
+	 * Telemetry instance.
 	 */
-	private static ?Tracks $tracks = null;
+	private static ?Telemetry $telemetry = null;
 
 	private Counter $mfa_display_counter;
 	private Counter $mfa_filter_click_counter;
@@ -28,13 +28,13 @@ class Tracking {
 	private Counter $privileged_email_sent_counter;
 
 	/**
-	 * Get the Tracks instance.
+	 * Get the Telemetry instance.
 	 *
-	 * @return Tracks|null The Tracks instance or null if not available.
+	 * @return Telemetry|null The Telemetry instance or null if not available.
 	 */
-	private static function get_tracks(): ?Tracks {
-		if ( null === self::$tracks && class_exists( '\Automattic\VIP\Telemetry\Tracks' ) ) {
-			self::$tracks = new Tracks(
+	private static function get_telemetry(): ?Telemetry {
+		if ( null === self::$telemetry && class_exists( '\Automattic\VIP\Telemetry\Telemetry' ) ) {
+			self::$telemetry = new Telemetry(
 				self::PREFIX . '_',
 				[
 					'plugin_name' => Constants::LOG_PLUGIN_NAME,
@@ -42,7 +42,7 @@ class Tracking {
 				]
 			);
 		}
-		return self::$tracks;
+		return self::$telemetry;
 	}
 
 	public function initialize( RegistryInterface $registry ): void {
@@ -90,25 +90,25 @@ class Tracking {
 	}
 
 	public static function mfa_display( $filter_enabled ) {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'mfa_page_view', [ 'filtered' => $filter_enabled ] );
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'mfa_page_view', [ 'filtered' => $filter_enabled ] );
 		}
 		self::record_stats( 'mfa-display' . ( $filter_enabled ? '-filtered' : '' ) );
 	}
 
 	public static function mfa_filter_click( $filter_type ) {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'mfa_filter_click', [ 'filter_type' => $filter_type ] );
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'mfa_filter_click', [ 'filter_type' => $filter_type ] );
 		}
 		self::record_stats( 'mfa-filter-click' );
 	}
 
 	public static function mfa_sorting( $sort_column, $sort_order ) {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'mfa_sort', [
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'mfa_sort', [
 				'sort_column' => $sort_column,
 				'sort_order'  => $sort_order,
 			] );
@@ -117,17 +117,17 @@ class Tracking {
 	}
 
 	public static function blocked_users_view() {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'blocked_users_view' );
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'blocked_users_view' );
 		}
 		self::record_stats( 'blocked-users-view' );
 	}
 
 	public static function user_unblock( $user_id, $user_role ) {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'blocked_users_unblock', [
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'blocked_users_unblock', [
 				'user_role'   => $user_role,
 				'has_user_id' => ! empty( $user_id ),
 			] );
@@ -136,9 +136,9 @@ class Tracking {
 	}
 
 	public static function privileged_email_sent( $email_type, $recipient_role ) {
-		$tracks = self::get_tracks();
-		if ( $tracks ) {
-			$tracks->record_event( 'privileged_activity_email_sent', [
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( 'privileged_activity_email_sent', [
 				'email_type'     => $email_type,
 				'recipient_role' => $recipient_role,
 			] );

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -51,7 +51,7 @@ class Tracking {
 	 * @return string `local_` if local, `nonprod_` if nonproduction, empty otherwise.
 	 */
 	private static function maybe_get_non_production_prefix(): string {
-		if ( 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 			return 'local_';
 		}
 		if ( 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
@@ -60,49 +60,47 @@ class Tracking {
 		return '';
 	}
 
+	/**
+	 * Initialize stats used by the class-colletor.php for the prometheus stats.
+	 */
 	public function initialize( RegistryInterface $registry ): void {
-		$env_prefix = self::maybe_get_non_production_prefix();
-		$stat_name  = self::PREFIX;
-		if ( ! empty( $env_prefix ) ) {
-			$stat_name .= '_' . $env_prefix;
-		}
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'mfa_display_total',
 			'Number of MFA display views',
 			[ 'filtered' ]
 		);
 
 		$this->mfa_filter_click_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'mfa_filter_click_total',
 			'Number of MFA filter clicks',
 			[ 'filter_type' ]
 		);
 
 		$this->mfa_sorting_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'mfa_sorting_total',
 			'Number of MFA sorting actions',
 			[ 'sort_column', 'sort_order' ]
 		);
 
 		$this->blocked_users_view_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'blocked_users_view_total',
 			'Number of blocked users view accesses',
 			[]
 		);
 
 		$this->user_unblock_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'user_unblock_total',
 			'Number of user unblock actions',
 			[ 'user_role' ]
 		);
 
 		$this->privileged_email_sent_counter = $registry->getOrRegisterCounter(
-			$stat_name,
+			'vip_security_boost',
 			'privileged_email_sent_total',
 			'Number of privileged activity emails sent',
 			[ 'email_type', 'recipient_role' ]
@@ -179,9 +177,14 @@ class Tracking {
 	 * @param mixed  $value Stat value.
 	 */
 	private static function record_stats( $stat_name ) {
+		$env_prefix = self::maybe_get_non_production_prefix();
+		$stat_code  = self::PREFIX;
+		if ( ! empty( $env_prefix ) ) {
+			$stat_code = self::PREFIX . '_' . $env_prefix;
+		}
 		// We're tracking the stats in production only
 		if ( 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			Logger::info( 'vip-security-boost', 'Bumping stats for /s/' . self::PREFIX . "/{$stat_name}", [
+			Logger::info( 'vip-security-boost', 'Bumping stats for /s/' . $stat_code . '/' . $stat_name, [
 				'stat_name' => $stat_name,
 			] );
 			return;
@@ -189,7 +192,7 @@ class Tracking {
 
 		if ( function_exists( '\Automattic\VIP\Stats\send_pixel' ) ) {
 			try {
-				\Automattic\VIP\Stats\send_pixel( [ self::PREFIX => $stat_name ] );
+				\Automattic\VIP\Stats\send_pixel( [ $stat_code => $stat_name ] );
 			} catch ( \Exception $e ) {
 				Logger::error( 'vip-security-boost', 'Stats recording failed', [
 					'stat_name' => $stat_name,

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -46,6 +46,19 @@ class Tracking {
 	}
 
 	/**
+	 * Record an event using Telemetry, only if Telemetry class is available.
+	 *
+	 * @param string $event_name Event name.
+	 * @param array  $event_data Event data.
+	 */
+	private static function record_event( $event_name, $event_data ) {
+		$telemetry = self::get_telemetry();
+		if ( $telemetry ) {
+			$telemetry->record_event( $event_name, $event_data );
+		}
+	}
+
+	/**
 	 * Get the prefix for stats and events.
 	 *
 	 * @return string `local_` if local, `nonprod_` if nonproduction, empty otherwise.
@@ -117,51 +130,37 @@ class Tracking {
 	}
 
 	public static function mfa_filter_click( $filter_type ) {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'mfa_filter_click', [ 'filter_type' => $filter_type ] );
-		}
+		self::record_event( 'mfa_filter_click', [ 'filter_type' => $filter_type ] );
 		self::record_stats( 'mfa-filter-click' );
 	}
 
 	public static function mfa_sorting( $sort_column, $sort_order ) {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'mfa_sort', [
-				'sort_column' => $sort_column,
-				'sort_order'  => $sort_order,
-			] );
-		}
+		self::record_event( 'mfa_sort', [
+			'sort_column' => $sort_column,
+			'sort_order'  => $sort_order,
+		] );
 		self::record_stats( 'mfa-sorting' );
 	}
 
 	public static function blocked_users_view() {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'blocked_users_view' );
-		}
+		self::record_event( 'blocked_users_view' );
 		self::record_stats( 'blocked-users-view' );
 	}
 
 	public static function user_unblock( $user_id, $user_role ) {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'blocked_users_unblock', [
-				'user_role'   => $user_role,
-				'has_user_id' => ! empty( $user_id ),
-			] );
-		}
+		self::record_event( 'blocked_users_unblock', [
+			'user_role'   => $user_role,
+			'has_user_id' => ! empty( $user_id ),
+		] );
 		self::record_stats( 'user-unblock' );
 	}
 
 	public static function privileged_email_sent( $email_type, $recipient_role ) {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'privileged_activity_email_sent', [
-				'email_type'     => $email_type,
-				'recipient_role' => $recipient_role,
-			] );
-		}
+		self::record_event( 'privileged_activity_email_sent', [
+			'email_type'     => $email_type,
+			'recipient_role' => $recipient_role,
+		] );
+
 		self::record_stats( 'privileged-email-sent' );
 
 		Logger::info( 'vip-security-boost', 'Privileged user email notification sent', [

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -75,7 +75,7 @@ class Tracking {
 	}
 
 	/**
-	 * Initialize stats used by the class-colletor.php for the prometheus stats.
+	 * Initialize stats used by the class-collector.php for the prometheus stats.
 	 */
 	public function initialize( RegistryInterface $registry ): void {
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -63,8 +63,8 @@ class Tracking {
 	 *
 	 * @return string `local_` if local, `nonprod_` if nonproduction, empty otherwise.
 	 */
-	private static function maybe_get_non_production_prefix( $trailining_underscore = true ): string {
-		$trailing_underscore = $trailining_underscore ? '_' : '';
+	private static function maybe_get_non_production_prefix( $trailing_underscore = true ): string {
+		$trailing_underscore = $trailing_underscore ? '_' : '';
 		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 			return 'local' . $trailing_underscore;
 		}

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -35,7 +35,7 @@ class Tracking {
 	private static function get_telemetry(): ?Telemetry {
 		if ( null === self::$telemetry && class_exists( '\Automattic\VIP\Telemetry\Telemetry' ) ) {
 			self::$telemetry = new Telemetry(
-				self::PREFIX . '_',
+				self::PREFIX . '_' . self::maybe_get_non_production_prefix(),
 				[
 					'plugin_name' => Constants::LOG_PLUGIN_NAME,
 					'site_id'     => defined( 'VIP_GO_APP_ID' ) ? VIP_GO_APP_ID : 0,
@@ -45,44 +45,60 @@ class Tracking {
 		return self::$telemetry;
 	}
 
+	/**
+	 * Get the prefix for stats and events.
+	 *
+	 * @return string `local_` if local, `nonprod_` if nonproduction, empty otherwise.
+	 */
+	private static function maybe_get_non_production_prefix(): string {
+		if ( 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return 'local_';
+		}
+		if ( 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+			return 'nonprod_';
+		}
+		return '';
+	}
+
 	public function initialize( RegistryInterface $registry ): void {
+		$event_name                = self::PREFIX . '_' . self::maybe_get_non_production_prefix();
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'mfa_display_total',
 			'Number of MFA display views',
 			[ 'filtered' ]
 		);
 
 		$this->mfa_filter_click_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'mfa_filter_click_total',
 			'Number of MFA filter clicks',
 			[ 'filter_type' ]
 		);
 
 		$this->mfa_sorting_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'mfa_sorting_total',
 			'Number of MFA sorting actions',
 			[ 'sort_column', 'sort_order' ]
 		);
 
 		$this->blocked_users_view_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'blocked_users_view_total',
 			'Number of blocked users view accesses',
 			[]
 		);
 
 		$this->user_unblock_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'user_unblock_total',
 			'Number of user unblock actions',
 			[ 'user_role' ]
 		);
 
 		$this->privileged_email_sent_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
+			$event_name,
 			'privileged_email_sent_total',
 			'Number of privileged activity emails sent',
 			[ 'email_type', 'recipient_role' ]

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -122,10 +122,7 @@ class Tracking {
 	}
 
 	public static function mfa_display( $filter_enabled ) {
-		$telemetry = self::get_telemetry();
-		if ( $telemetry ) {
-			$telemetry->record_event( 'mfa_page_view', [ 'filtered' => $filter_enabled ] );
-		}
+		self::record_event( 'mfa_page_view', [ 'filtered' => $filter_enabled ] );
 		self::record_stats( 'mfa-display' . ( $filter_enabled ? '-filtered' : '' ) );
 	}
 

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -180,7 +180,7 @@ class Tracking {
 			$stat_code = self::PREFIX . '_' . $env_prefix;
 		}
 		// We're tracking the stats in production only
-		if ( 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 			Logger::info( 'vip-security-boost', 'Bumping stats for /s/' . $stat_code . '/' . $stat_name, [
 				'stat_name' => $stat_name,
 			] );

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -61,44 +61,48 @@ class Tracking {
 	}
 
 	public function initialize( RegistryInterface $registry ): void {
-		$event_name                = self::PREFIX . '_' . self::maybe_get_non_production_prefix();
+		$env_prefix = self::maybe_get_non_production_prefix();
+		$stat_name  = self::PREFIX;
+		if ( ! empty( $env_prefix ) ) {
+			$stat_name .= '_' . $env_prefix;
+		}
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'mfa_display_total',
 			'Number of MFA display views',
 			[ 'filtered' ]
 		);
 
 		$this->mfa_filter_click_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'mfa_filter_click_total',
 			'Number of MFA filter clicks',
 			[ 'filter_type' ]
 		);
 
 		$this->mfa_sorting_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'mfa_sorting_total',
 			'Number of MFA sorting actions',
 			[ 'sort_column', 'sort_order' ]
 		);
 
 		$this->blocked_users_view_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'blocked_users_view_total',
 			'Number of blocked users view accesses',
 			[]
 		);
 
 		$this->user_unblock_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'user_unblock_total',
 			'Number of user unblock actions',
 			[ 'user_role' ]
 		);
 
 		$this->privileged_email_sent_counter = $registry->getOrRegisterCounter(
-			$event_name,
+			$stat_name,
 			'privileged_email_sent_total',
 			'Number of privileged activity emails sent',
 			[ 'email_type', 'recipient_role' ]

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -50,12 +50,13 @@ class Tracking {
 	 *
 	 * @return string `local_` if local, `nonprod_` if nonproduction, empty otherwise.
 	 */
-	private static function maybe_get_non_production_prefix(): string {
+	private static function maybe_get_non_production_prefix( $trailining_underscore = true ): string {
+		$trailing_underscore = $trailining_underscore ? '_' : '';
 		if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			return 'local_';
+			return 'local' . $trailing_underscore;
 		}
 		if ( 'production' !== constant( 'VIP_GO_APP_ENVIRONMENT' ) ) {
-			return 'nonprod_';
+			return 'nonprod' . $trailing_underscore;
 		}
 		return '';
 	}
@@ -177,7 +178,7 @@ class Tracking {
 	 * @param mixed  $value Stat value.
 	 */
 	private static function record_stats( $stat_name ) {
-		$env_prefix = self::maybe_get_non_production_prefix();
+		$env_prefix = self::maybe_get_non_production_prefix( false );
 		$stat_code  = self::PREFIX;
 		if ( ! empty( $env_prefix ) ) {
 			$stat_code = self::PREFIX . '_' . $env_prefix;


### PR DESCRIPTION
## Description

This PR introduces a couple of differences. The first is that it uses the generic telemetry class, which allows sending events to multiple resources.

We now distinguish between production and local environments so that the stats are not all merged together, making them less confusing.

I also took the liberty to refactor the class slightly to reduce duplicate code in the way we check for the presence of the instance. 

This change will introduce some differences in event names for non-prod environment
* `local` will be prefixed for events/stats triggered in a local environment
* `nonprod` for non-prod environment (this is because the non production name can be anything and it would make it hard for us to actually use them meaningfully)

Production stats name are unaffected.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Visi https://vip-security-boost.vipdev.lndo.site/wp-admin/users.php?filter_mfa_disabled=1 and ensure the events are being triggered either by checking the Tracks Live View (Wait 5 minutes) or in the `debug.log`