### PR TITLE
[PLTFRM-1112] Skip vip_support roles from sending notification emails WP admin

### DIFF
--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -112,7 +112,7 @@ class Notify_Privileged_Activity {
 		if ( class_exists( '\Automattic\VIP\Support_User\User' ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'Skipping notification for VIP Support user: ' . $user->user_login
+				'Skipping notification for VIP Support user: ' . $user->ID
 			);
 			return;
 		}

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Security\PrivilegedActivityNotifier;
 use Automattic\VIP\Security\Email\Email;
 use Automattic\VIP\Security\Constants;
 use Automattic\VIP\Security\Utils\Logger;
+use Automattic\VIP\Support_User\User as Support_User;
 
 class Notify_Privileged_Activity {
 	const LOG_FEATURE_NAME = 'sb_notify_privileged_activity';
@@ -107,6 +108,15 @@ class Notify_Privileged_Activity {
 	 * @param string   $subject The email subject.
 	 */
 	private static function send_notification( $user, $subject, $email_title, $template ) {
+		// Skip notification for VIP Support users
+		if ( class_exists( '\Automattic\VIP\Support_User\User' ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
+			Logger::info(
+				self::LOG_FEATURE_NAME,
+				'Skipping notification for VIP Support user: ' . $user->user_login
+			);
+			return;
+		}
+
 		try {
 			$admin_email = get_option( 'admin_email' );
 

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -109,7 +109,7 @@ class Notify_Privileged_Activity {
 	 */
 	private static function send_notification( $user, $subject, $email_title, $template ) {
 		// Skip notification for VIP Support users
-		if ( class_exists( '\Automattic\VIP\Support_User\User' ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
+		if ( class_exists( Support_User::class ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
 				'Skipping notification for VIP Support user: ' . $user->ID

--- a/tests/phpunit/mocks/class-support-user-mock.php
+++ b/tests/phpunit/mocks/class-support-user-mock.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Mock for VIP Support User class used in tests
+ */
+
+namespace Automattic\VIP\Support_User;
+
+if ( ! class_exists( '\Automattic\VIP\Support_User\User' ) ) {
+	class User {
+		public static $mock_vip_support_users = [];
+		
+		public static function user_has_vip_support_role( $user_id ) {
+			return in_array( $user_id, self::$mock_vip_support_users, true );
+		}
+		
+		public static function reset_mock() {
+			self::$mock_vip_support_users = [];
+		}
+	}
+}

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -11,6 +11,11 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 	protected function tearDown(): void {
 		parent::tearDown();
 		delete_option( 'admin_email' );
+		
+		// Reset VIP Support User mock if it exists
+		if ( class_exists( '\Automattic\VIP\Support_User\User' ) && method_exists( '\Automattic\VIP\Support_User\User', 'reset_mock' ) ) {
+			\Automattic\VIP\Support_User\User::reset_mock();
+		}
 	}
 
 	/**
@@ -287,17 +292,7 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 	 */
 	private function mock_vip_support_user_class() {
 		if ( ! class_exists( '\Automattic\VIP\Support_User\User' ) ) {
-			eval( '
-				namespace Automattic\VIP\Support_User;
-				
-				class User {
-					public static $mock_vip_support_users = [];
-					
-					public static function user_has_vip_support_role( $user_id ) {
-						return in_array( $user_id, self::$mock_vip_support_users, true );
-					}
-				}
-			' );
+			require_once __DIR__ . '/mocks/class-support-user-mock.php';
 		}
 	}
 }

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -211,4 +211,93 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 		$this->assertEquals( 'privileged-super-admin-granted', Email::$last_call_args_for_test['template_id'] );
 		$this->assertEquals( $expected_template_data, Email::$last_call_args_for_test['template_data'] );
 	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_admin_user_creation_skips_vip_support_user() {
+		// Mock the Support_User class
+		$this->mock_vip_support_user_class();
+
+		$user_id = self::factory()->user->create( [
+			'role'       => 'administrator',
+			'user_login' => 'vip_testuser',
+			'user_email' => 'vip-support@automattic.com',
+		] );
+		update_option( 'admin_email', 'admin@example.com' );
+
+		// Set this user as a VIP Support user
+		\Automattic\VIP\Support_User\User::$mock_vip_support_users = [ $user_id ];
+
+		Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for VIP Support user.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_promoted_to_admin_skips_vip_support_user() {
+		// Mock the Support_User class
+		$this->mock_vip_support_user_class();
+
+		$user_id = self::factory()->user->create( [
+			'role'       => 'editor',
+			'user_login' => 'vip_testuser',
+			'user_email' => 'vip_testuser@example.com',
+		] );
+		update_option( 'admin_email', 'admin@example.com' );
+
+		// Set this user as a VIP Support user
+		\Automattic\VIP\Support_User\User::$mock_vip_support_users = [ $user_id ];
+
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'editor' ] );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for VIP Support user promotion.' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_notify_user_granted_super_admin_skips_vip_support_user() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite is required for this test.' );
+		}
+
+		// Mock the Support_User class
+		$this->mock_vip_support_user_class();
+		
+		$user_id = self::factory()->user->create( [
+			'role'       => 'administrator',
+			'user_login' => 'vip_superadmin',
+			'user_email' => 'vip_superadmin@example.com',
+		] );
+		update_option( 'admin_email', 'admin@example.com' );
+
+		// Set this user as a VIP Support user
+		\Automattic\VIP\Support_User\User::$mock_vip_support_users = [ $user_id ];
+
+		Notify_Privileged_Activity::notify_user_granted_super_admin( $user_id );
+		$this->assertNull( Email::$last_call_args_for_test, 'Email::send was called unexpectedly for VIP Support user super admin grant.' );
+	}
+
+	/**
+	 * Mock the VIP Support User class for testing
+	 */
+	private function mock_vip_support_user_class() {
+		if ( ! class_exists( '\Automattic\VIP\Support_User\User' ) ) {
+			eval( '
+				namespace Automattic\VIP\Support_User;
+				
+				class User {
+					public static $mock_vip_support_users = [];
+					
+					public static function user_has_vip_support_role( $user_id ) {
+						return in_array( $user_id, self::$mock_vip_support_users, true );
+					}
+				}
+			' );
+		}
+	}
 }


### PR DESCRIPTION
## Description

Skip sending of new administrator email when a `VIP Support` user is created.
https://linear.app/a8c/issue/PLTFRM-1112/dont-send-emails-for-vip-support-users

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Checkout PR
2. `vip dev-env create && vip dev-env start`
3. Create an Administrator user and verify that New Admin email is sent 
```
vip dev-env exec --slug=vip-security-boost -- wp user generate --role=administrator --count=1 --format=ids
```
4. Create a vip_support user and verify that there are no emails sent
```
vip dev-env exec --slug=vip-security-boost --  wp vipsupport create-user vip_katrina vip@automattic.com password123 --display-name="Katrina"
```