### PR TITLE
Add default $event_data value to the tracking function

### DIFF
--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -51,7 +51,7 @@ class Tracking {
 	 * @param string $event_name Event name.
 	 * @param array  $event_data Event data.
 	 */
-	private static function record_event( $event_name, $event_data ) {
+	private static function record_event( $event_name, $event_data = [] ) {
 		$telemetry = self::get_telemetry();
 		if ( $telemetry ) {
 			$telemetry->record_event( $event_name, $event_data );


### PR DESCRIPTION
## Description
The default value was missing, which would cause an issue when calling the "Blocked Users" view from the inactive user module


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Click on the blocked users view in the inactive user module and ensure it works.