### PR TITLE
Add PHPStan for basic typechecking

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    name: Review Dependencies
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.deps.dev:443
+            api.github.com:443
+            api.securityscorecards.dev:443
+            github.com:443
+
+      - name: Check out the source code
+        uses: actions/checkout@v4.2.2
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4.7.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           coverage: none
         env:
-          fail-fast: 'true'
+          fail-fast: "true"
 
       - name: Install PHP dependencies
         uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run style check
         run: composer lint
+
+      - name: PHPStan
+        run: composer analyze

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Cache Composer dependencies
         uses: actions/cache@v4
         with:
+          path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Install PHP dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,13 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
-      - uses: actions/cache@v4
+      - name: mu-plugins cache
+        uses: actions/cache@v4
         with:
           path: mu-plugins
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-build-pr-${{ github.event.pull_request.number }}
+          restore-keys: |
+            ${{ runner.os }}-build-pr-
 
       - name: Download mu-plugins
         run: ./bin/load-mu-plugins.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cache Composer dependencies
         uses: actions/cache@v4
         with:
-          path: /tmp/composer-cache
+          path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Install PHP dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: actions/cache@v4
+        with:
+          path: mu-plugins
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
+      - name: Download mu-plugins
+        run: ./bin/load-mu-plugins.sh
+
       - name: Set up PHP
         uses: shivammathur/setup-php@fc14643b0a99ee9db10a3c025a33d76544fa3761 # 2.30.5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,11 @@ jobs:
         env:
           fail-fast: "true"
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
       - name: Install PHP dependencies
         uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,6 +41,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-pr-
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+
       - uses: php-actions/composer@v6
         with:
           php_version: "${{ matrix.config.php }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: mu-plugins cache
+        uses: actions/cache@v4
+        with:
+          path: mu-plugins
+          key: ${{ runner.os }}-build-pr-${{ github.event.pull_request.number }}
+          restore-keys: |
+            ${{ runner.os }}-build-pr-
+
       - uses: php-actions/composer@v6
         with:
           php_version: "${{ matrix.config.php }}"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Cache Composer dependencies
         uses: actions/cache@v4
         with:
+          path: /tmp/composer-cache
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - uses: php-actions/composer@v6

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Cache Composer dependencies
         uses: actions/cache@v4
         with:
-          path: /tmp/composer-cache
+          path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - uses: php-actions/composer@v6

--- a/bin/load-mu-plugins.sh
+++ b/bin/load-mu-plugins.sh
@@ -1,0 +1,22 @@
+# download github.com/automattic/vip-go-mu-plugins zip and extract it to the mu-plugins folder
+if [ ! -d "mu-plugins" ]; then
+	repo_url="https://github.com/Automattic/vip-go-mu-plugins-built/archive/refs/heads/master.zip"
+
+	echo "Downloading repository from $repo_url..."
+	curl -sL $repo_url -o mu-plugins.zip
+
+	# Check if download was successful
+	if [ $? -ne 0 ]; then
+		echo "Failed to download repository. Exiting..."
+		exit 1
+	fi
+
+	# Extract the downloaded zip file
+	echo "Extracting repository"
+	unzip -o -q mu-plugins.zip
+
+	mv "vip-go-mu-plugins-built-master" "mu-plugins"
+
+	# Cleanup: Remove the temporary zip file
+	rm mu-plugins.zip
+fi

--- a/bin/load-mu-plugins.sh
+++ b/bin/load-mu-plugins.sh
@@ -19,4 +19,6 @@ if [ ! -d "mu-plugins" ]; then
 
 	# Cleanup: Remove the temporary zip file
 	rm mu-plugins.zip
+else
+	echo "mu-plugins directory already exists. Skipping download."
 fi

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -74,30 +74,7 @@ echo "--------------"
 echo
 
 
-
-
-# download github.com/automattic/vip-go-mu-plugins zip and extract it to the mu-plugins folder
-if [ ! -d "mu-plugins" ]; then
-	repo_url="https://github.com/Automattic/vip-go-mu-plugins-built/archive/refs/heads/master.zip"
-
-	echo "Downloading repository from $repo_url..."
-	curl -sL $repo_url -o mu-plugins.zip
-
-	# Check if download was successful
-	if [ $? -ne 0 ]; then
-		echo "Failed to download repository. Exiting..."
-		exit 1
-	fi
-
-	# Extract the downloaded zip file
-	echo "Extracting repository"
-	unzip -o -q mu-plugins.zip
-
-	mv "vip-go-mu-plugins-built-master" "mu-plugins"
-
-	# Cleanup: Remove the temporary zip file
-	rm mu-plugins.zip
-fi
+./bin/load-mu-plugins.sh
 
 UUID=$(date +%s000)
 if [ -z "${NETWORK_NAME_OVERRIDE}" ]; then

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
 	},
 	"autoload-dev": {
 		"classmap": [
-			"./modules/",
-			"./email/"
+			"./modules/"
 		]
 	},
 	"config": {

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
 		"guzzlehttp/guzzle": "^7.9",
 		"php-stubs/wordpress-tests-stubs": "^6.8",
 		"phpcompatibility/phpcompatibility-wp": "^2",
-		"phpstan/phpstan": "^1.10",
+		"phpstan/phpstan": "^2.0",
 		"phpunit/phpunit": "^9",
-		"szepeviktor/phpstan-wordpress": "*",
+		"szepeviktor/phpstan-wordpress": "^2.0",
 		"wp-phpunit/wp-phpunit": "^6.5",
 		"yoast/phpunit-polyfills": "3.0.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,18 @@
 	"require-dev": {
 		"automattic/vipwpcs": "^3",
 		"guzzlehttp/guzzle": "^7.9",
+		"php-stubs/wordpress-tests-stubs": "^6.8",
 		"phpcompatibility/phpcompatibility-wp": "^2",
+		"phpstan/phpstan": "^1.10",
 		"phpunit/phpunit": "^9",
+		"szepeviktor/phpstan-wordpress": "*",
 		"wp-phpunit/wp-phpunit": "^6.5",
 		"yoast/phpunit-polyfills": "3.0.0"
 	},
 	"autoload-dev": {
 		"classmap": [
-			"./modules/"
+			"./modules/",
+			"./email/"
 		]
 	},
 	"config": {
@@ -26,11 +30,13 @@
 			"php": "8.2"
 		},
 		"allow-plugins": {
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"phpstan/extension-installer": false
 		}
 	},
 	"scripts": {
 		"lint": "./vendor/bin/phpcs --standard=.phpcs.xml.dist",
+		"analyze": "./vendor/bin/phpstan analyse --memory-limit=1024M",
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
 		"phpcs": "./vendor/bin/phpcs",
 		"test": "./bin/test.sh --php 8.2 --wp 6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "1910f4f14789dc46df72a853ab6eccc9",
+	"content-hash": "fde78a4fc6b1bbc2834c25f1da8d1973",
 	"packages": [
 		{
 			"name": "spatie/mjml-php",
@@ -1388,20 +1388,20 @@
 		},
 		{
 			"name": "phpstan/phpstan",
-			"version": "1.12.27",
+			"version": "2.1.17",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/phpstan/phpstan.git",
-				"reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
+				"reference": "89b5ef665716fa2a52ecd2633f21007a6a349053"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
-				"reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
+				"url": "https://api.github.com/repos/phpstan/phpstan/zipball/89b5ef665716fa2a52ecd2633f21007a6a349053",
+				"reference": "89b5ef665716fa2a52ecd2633f21007a6a349053",
 				"shasum": ""
 			},
 			"require": {
-				"php": "^7.2|^8.0"
+				"php": "^7.4|^8.0"
 			},
 			"conflict": {
 				"phpstan/phpstan-shim": "*"
@@ -1442,7 +1442,7 @@
 					"type": "github"
 				}
 			],
-			"time": "2025-05-21T20:51:45+00:00"
+			"time": "2025-05-21T20:55:28+00:00"
 		},
 		{
 			"name": "phpunit/php-code-coverage",
@@ -3250,107 +3250,30 @@
 			"time": "2024-09-25T14:21:43+00:00"
 		},
 		{
-			"name": "symfony/polyfill-php73",
-			"version": "v1.32.0",
-			"source": {
-				"type": "git",
-				"url": "https://github.com/symfony/polyfill-php73.git",
-				"reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
-			},
-			"dist": {
-				"type": "zip",
-				"url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
-				"reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
-				"shasum": ""
-			},
-			"require": {
-				"php": ">=7.2"
-			},
-			"type": "library",
-			"extra": {
-				"thanks": {
-					"url": "https://github.com/symfony/polyfill",
-					"name": "symfony/polyfill"
-				}
-			},
-			"autoload": {
-				"files": [
-					"bootstrap.php"
-				],
-				"psr-4": {
-					"Symfony\\Polyfill\\Php73\\": ""
-				},
-				"classmap": [
-					"Resources/stubs"
-				]
-			},
-			"notification-url": "https://packagist.org/downloads/",
-			"license": [
-				"MIT"
-			],
-			"authors": [
-				{
-					"name": "Nicolas Grekas",
-					"email": "p@tchwork.com"
-				},
-				{
-					"name": "Symfony Community",
-					"homepage": "https://symfony.com/contributors"
-				}
-			],
-			"description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
-			"homepage": "https://symfony.com",
-			"keywords": [
-				"compatibility",
-				"polyfill",
-				"portable",
-				"shim"
-			],
-			"support": {
-				"source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
-			},
-			"funding": [
-				{
-					"url": "https://symfony.com/sponsor",
-					"type": "custom"
-				},
-				{
-					"url": "https://github.com/fabpot",
-					"type": "github"
-				},
-				{
-					"url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-					"type": "tidelift"
-				}
-			],
-			"time": "2024-09-09T11:45:10+00:00"
-		},
-		{
 			"name": "szepeviktor/phpstan-wordpress",
-			"version": "v1.3.5",
+			"version": "v2.0.2",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-				"reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+				"reference": "963887b04c21fe7ac78e61c1351f8b00fff9f8f8"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
-				"reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+				"url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/963887b04c21fe7ac78e61c1351f8b00fff9f8f8",
+				"reference": "963887b04c21fe7ac78e61c1351f8b00fff9f8f8",
 				"shasum": ""
 			},
 			"require": {
-				"php": "^7.2 || ^8.0",
-				"php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-				"phpstan/phpstan": "^1.10.31",
-				"symfony/polyfill-php73": "^1.12.0"
+				"php": "^7.4 || ^8.0",
+				"php-stubs/wordpress-stubs": "^6.6.2",
+				"phpstan/phpstan": "^2.0"
 			},
 			"require-dev": {
 				"composer/composer": "^2.1.14",
 				"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
 				"php-parallel-lint/php-parallel-lint": "^1.1",
-				"phpstan/phpstan-strict-rules": "^1.2",
-				"phpunit/phpunit": "^8.0 || ^9.0",
+				"phpstan/phpstan-strict-rules": "^2.0",
+				"phpunit/phpunit": "^9.0",
 				"szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
 				"wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
 			},
@@ -3384,9 +3307,9 @@
 			],
 			"support": {
 				"issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-				"source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+				"source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.2"
 			},
-			"time": "2024-06-28T22:27:19+00:00"
+			"time": "2025-02-12T18:43:37+00:00"
 		},
 		{
 			"name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "332b15bc5d0df46e7d6df36085bdfd82",
+	"content-hash": "1910f4f14789dc46df72a853ab6eccc9",
 	"packages": [
 		{
 			"name": "spatie/mjml-php",
@@ -69,16 +69,16 @@
 		},
 		{
 			"name": "symfony/process",
-			"version": "v7.2.5",
+			"version": "v7.3.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/symfony/process.git",
-				"reference": "87b7c93e57df9d8e39a093d32587702380ff045d"
+				"reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/symfony/process/zipball/87b7c93e57df9d8e39a093d32587702380ff045d",
-				"reference": "87b7c93e57df9d8e39a093d32587702380ff045d",
+				"url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+				"reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
 				"shasum": ""
 			},
 			"require": {
@@ -110,7 +110,7 @@
 			"description": "Executes commands in sub-processes",
 			"homepage": "https://symfony.com",
 			"support": {
-				"source": "https://github.com/symfony/process/tree/v7.2.5"
+				"source": "https://github.com/symfony/process/tree/v7.3.0"
 			},
 			"funding": [
 				{
@@ -126,7 +126,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-03-13T12:21:46+00:00"
+			"time": "2025-04-17T09:11:12+00:00"
 		}
 	],
 	"packages-dev": [
@@ -186,28 +186,28 @@
 		},
 		{
 			"name": "dealerdirect/phpcodesniffer-composer-installer",
-			"version": "v1.0.0",
+			"version": "v1.1.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/PHPCSStandards/composer-installer.git",
-				"reference": "4be43904336affa5c2f70744a348312336afd0da"
+				"reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-				"reference": "4be43904336affa5c2f70744a348312336afd0da",
+				"url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
+				"reference": "6e0fa428497bf560152ee73ffbb8af5c6a56b0dd",
 				"shasum": ""
 			},
 			"require": {
-				"composer-plugin-api": "^1.0 || ^2.0",
+				"composer-plugin-api": "^2.2",
 				"php": ">=5.4",
 				"squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
 			},
 			"require-dev": {
-				"composer/composer": "*",
+				"composer/composer": "^2.2",
 				"ext-json": "*",
 				"ext-zip": "*",
-				"php-parallel-lint/php-parallel-lint": "^1.3.1",
+				"php-parallel-lint/php-parallel-lint": "^1.4.0",
 				"phpcompatibility/php-compatibility": "^9.0",
 				"yoast/phpunit-polyfills": "^1.0"
 			},
@@ -227,9 +227,9 @@
 			"authors": [
 				{
 					"name": "Franck Nijhof",
-					"email": "franck.nijhof@dealerdirect.com",
-					"homepage": "http://www.frenck.nl",
-					"role": "Developer / IT Manager"
+					"email": "opensource@frenck.dev",
+					"homepage": "https://frenck.dev",
+					"role": "Open source developer"
 				},
 				{
 					"name": "Contributors",
@@ -237,7 +237,6 @@
 				}
 			],
 			"description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-			"homepage": "http://www.dealerdirect.com",
 			"keywords": [
 				"PHPCodeSniffer",
 				"PHP_CodeSniffer",
@@ -258,9 +257,28 @@
 			],
 			"support": {
 				"issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+				"security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
 				"source": "https://github.com/PHPCSStandards/composer-installer"
 			},
-			"time": "2023-01-05T11:28:13+00:00"
+			"funding": [
+				{
+					"url": "https://github.com/PHPCSStandards",
+					"type": "github"
+				},
+				{
+					"url": "https://github.com/jrfnl",
+					"type": "github"
+				},
+				{
+					"url": "https://opencollective.com/php_codesniffer",
+					"type": "open_collective"
+				},
+				{
+					"url": "https://thanks.dev/u/gh/phpcsstandards",
+					"type": "thanks_dev"
+				}
+			],
+			"time": "2025-06-27T17:24:01+00:00"
 		},
 		{
 			"name": "doctrine/instantiator",
@@ -659,16 +677,16 @@
 		},
 		{
 			"name": "myclabs/deep-copy",
-			"version": "1.13.0",
+			"version": "1.13.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/myclabs/DeepCopy.git",
-				"reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+				"reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-				"reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+				"url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+				"reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
 				"shasum": ""
 			},
 			"require": {
@@ -707,7 +725,7 @@
 			],
 			"support": {
 				"issues": "https://github.com/myclabs/DeepCopy/issues",
-				"source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+				"source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
 			},
 			"funding": [
 				{
@@ -715,29 +733,31 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-02-12T12:17:51+00:00"
+			"time": "2025-04-29T12:36:36+00:00"
 		},
 		{
 			"name": "nikic/php-parser",
-			"version": "v4.19.4",
+			"version": "v5.5.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/nikic/PHP-Parser.git",
-				"reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
+				"reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-				"reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+				"reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
 				"shasum": ""
 			},
 			"require": {
+				"ext-ctype": "*",
+				"ext-json": "*",
 				"ext-tokenizer": "*",
-				"php": ">=7.1"
+				"php": ">=7.4"
 			},
 			"require-dev": {
 				"ircmaxell/php-yacc": "^0.0.7",
-				"phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+				"phpunit/phpunit": "^9.0"
 			},
 			"bin": [
 				"bin/php-parse"
@@ -745,7 +765,7 @@
 			"type": "library",
 			"extra": {
 				"branch-alias": {
-					"dev-master": "4.9-dev"
+					"dev-master": "5.0-dev"
 				}
 			},
 			"autoload": {
@@ -769,9 +789,9 @@
 			],
 			"support": {
 				"issues": "https://github.com/nikic/PHP-Parser/issues",
-				"source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+				"source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
 			},
-			"time": "2024-09-29T15:01:53+00:00"
+			"time": "2025-05-31T08:24:38+00:00"
 		},
 		{
 			"name": "phar-io/manifest",
@@ -890,6 +910,97 @@
 				"source": "https://github.com/phar-io/version/tree/3.2.1"
 			},
 			"time": "2022-02-21T01:04:05+00:00"
+		},
+		{
+			"name": "php-stubs/wordpress-stubs",
+			"version": "v6.8.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-stubs/wordpress-stubs.git",
+				"reference": "92e444847d94f7c30f88c60004648f507688acd5"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/92e444847d94f7c30f88c60004648f507688acd5",
+				"reference": "92e444847d94f7c30f88c60004648f507688acd5",
+				"shasum": ""
+			},
+			"conflict": {
+				"phpdocumentor/reflection-docblock": "5.6.1"
+			},
+			"require-dev": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+				"nikic/php-parser": "^5.4",
+				"php": "^7.4 || ^8.0",
+				"php-stubs/generator": "^0.8.3",
+				"phpdocumentor/reflection-docblock": "^5.4.1",
+				"phpstan/phpstan": "^2.1",
+				"phpunit/phpunit": "^9.5",
+				"szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+				"wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+			},
+			"suggest": {
+				"paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+				"symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+				"szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+			},
+			"type": "library",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "WordPress function and class declaration stubs for static analysis.",
+			"homepage": "https://github.com/php-stubs/wordpress-stubs",
+			"keywords": [
+				"PHPStan",
+				"static analysis",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+				"source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.1"
+			},
+			"time": "2025-05-02T12:33:34+00:00"
+		},
+		{
+			"name": "php-stubs/wordpress-tests-stubs",
+			"version": "v6.8.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-stubs/wordpress-tests-stubs.git",
+				"reference": "95979e5c671c72350dde78b89e29afdd88c37140"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-stubs/wordpress-tests-stubs/zipball/95979e5c671c72350dde78b89e29afdd88c37140",
+				"reference": "95979e5c671c72350dde78b89e29afdd88c37140",
+				"shasum": ""
+			},
+			"require-dev": {
+				"php": "^7.3 || ^8.0",
+				"php-stubs/generator": "^0.8.0"
+			},
+			"suggest": {
+				"symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+				"szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+			},
+			"type": "library",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "WordPress Tests function and class declaration stubs for static analysis.",
+			"homepage": "https://github.com/php-stubs/wordpress-tests-stubs",
+			"keywords": [
+				"PHPStan",
+				"static analysis",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/php-stubs/wordpress-tests-stubs/issues",
+				"source": "https://github.com/php-stubs/wordpress-tests-stubs/tree/v6.8.0"
+			},
+			"time": "2025-04-15T20:54:04+00:00"
 		},
 		{
 			"name": "phpcompatibility/php-compatibility",
@@ -1027,21 +1138,22 @@
 		},
 		{
 			"name": "phpcompatibility/phpcompatibility-wp",
-			"version": "2.1.6",
+			"version": "2.1.7",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-				"reference": "80ccb1a7640995edf1b87a4409fa584cd5869469"
+				"reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/80ccb1a7640995edf1b87a4409fa584cd5869469",
-				"reference": "80ccb1a7640995edf1b87a4409fa584cd5869469",
+				"url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
+				"reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
 				"shasum": ""
 			},
 			"require": {
 				"phpcompatibility/php-compatibility": "^9.0",
-				"phpcompatibility/phpcompatibility-paragonie": "^1.0"
+				"phpcompatibility/phpcompatibility-paragonie": "^1.0",
+				"squizlabs/php_codesniffer": "^3.3"
 			},
 			"require-dev": {
 				"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
@@ -1091,35 +1203,39 @@
 				{
 					"url": "https://opencollective.com/php_codesniffer",
 					"type": "open_collective"
+				},
+				{
+					"url": "https://thanks.dev/u/gh/phpcompatibility",
+					"type": "thanks_dev"
 				}
 			],
-			"time": "2025-01-16T22:34:19+00:00"
+			"time": "2025-05-12T16:38:37+00:00"
 		},
 		{
 			"name": "phpcsstandards/phpcsextra",
-			"version": "1.2.1",
+			"version": "1.4.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-				"reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+				"reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-				"reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+				"reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
 				"shasum": ""
 			},
 			"require": {
 				"php": ">=5.4",
-				"phpcsstandards/phpcsutils": "^1.0.9",
-				"squizlabs/php_codesniffer": "^3.8.0"
+				"phpcsstandards/phpcsutils": "^1.1.0",
+				"squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
 			},
 			"require-dev": {
 				"php-parallel-lint/php-console-highlighter": "^1.0",
-				"php-parallel-lint/php-parallel-lint": "^1.3.2",
+				"php-parallel-lint/php-parallel-lint": "^1.4.0",
 				"phpcsstandards/phpcsdevcs": "^1.1.6",
 				"phpcsstandards/phpcsdevtools": "^1.2.1",
-				"phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+				"phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
 			},
 			"type": "phpcodesniffer-standard",
 			"extra": {
@@ -1169,35 +1285,39 @@
 				{
 					"url": "https://opencollective.com/php_codesniffer",
 					"type": "open_collective"
+				},
+				{
+					"url": "https://thanks.dev/u/gh/phpcsstandards",
+					"type": "thanks_dev"
 				}
 			],
-			"time": "2023-12-08T16:49:07+00:00"
+			"time": "2025-06-14T07:40:39+00:00"
 		},
 		{
 			"name": "phpcsstandards/phpcsutils",
-			"version": "1.0.12",
+			"version": "1.1.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-				"reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+				"reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-				"reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/65355670ac17c34cd235cf9d3ceae1b9252c4dad",
+				"reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad",
 				"shasum": ""
 			},
 			"require": {
 				"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
 				"php": ">=5.4",
-				"squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+				"squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
 			},
 			"require-dev": {
 				"ext-filter": "*",
 				"php-parallel-lint/php-console-highlighter": "^1.0",
-				"php-parallel-lint/php-parallel-lint": "^1.3.2",
+				"php-parallel-lint/php-parallel-lint": "^1.4.0",
 				"phpcsstandards/phpcsdevcs": "^1.1.6",
-				"yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+				"yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
 			},
 			"type": "phpcodesniffer-standard",
 			"extra": {
@@ -1234,6 +1354,7 @@
 				"phpcodesniffer-standard",
 				"phpcs",
 				"phpcs3",
+				"phpcs4",
 				"standards",
 				"static analysis",
 				"tokens",
@@ -1257,9 +1378,71 @@
 				{
 					"url": "https://opencollective.com/php_codesniffer",
 					"type": "open_collective"
+				},
+				{
+					"url": "https://thanks.dev/u/gh/phpcsstandards",
+					"type": "thanks_dev"
 				}
 			],
-			"time": "2024-05-20T13:34:27+00:00"
+			"time": "2025-06-12T04:32:33+00:00"
+		},
+		{
+			"name": "phpstan/phpstan",
+			"version": "1.12.27",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/phpstan/phpstan.git",
+				"reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
+				"reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2|^8.0"
+			},
+			"conflict": {
+				"phpstan/phpstan-shim": "*"
+			},
+			"bin": [
+				"phpstan",
+				"phpstan.phar"
+			],
+			"type": "library",
+			"autoload": {
+				"files": [
+					"bootstrap.php"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "PHPStan - PHP Static Analysis Tool",
+			"keywords": [
+				"dev",
+				"static analysis"
+			],
+			"support": {
+				"docs": "https://phpstan.org/user-guide/getting-started",
+				"forum": "https://github.com/phpstan/phpstan/discussions",
+				"issues": "https://github.com/phpstan/phpstan/issues",
+				"security": "https://github.com/phpstan/phpstan/security/policy",
+				"source": "https://github.com/phpstan/phpstan-src"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/ondrejmirtes",
+					"type": "github"
+				},
+				{
+					"url": "https://github.com/phpstan",
+					"type": "github"
+				}
+			],
+			"time": "2025-05-21T20:51:45+00:00"
 		},
 		{
 			"name": "phpunit/php-code-coverage",
@@ -1582,16 +1765,16 @@
 		},
 		{
 			"name": "phpunit/phpunit",
-			"version": "9.6.22",
+			"version": "9.6.23",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/sebastianbergmann/phpunit.git",
-				"reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+				"reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-				"reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+				"reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
 				"shasum": ""
 			},
 			"require": {
@@ -1602,7 +1785,7 @@
 				"ext-mbstring": "*",
 				"ext-xml": "*",
 				"ext-xmlwriter": "*",
-				"myclabs/deep-copy": "^1.12.1",
+				"myclabs/deep-copy": "^1.13.1",
 				"phar-io/manifest": "^2.0.4",
 				"phar-io/version": "^3.2.1",
 				"php": ">=7.3",
@@ -1665,7 +1848,7 @@
 			"support": {
 				"issues": "https://github.com/sebastianbergmann/phpunit/issues",
 				"security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-				"source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+				"source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
 			},
 			"funding": [
 				{
@@ -1677,11 +1860,19 @@
 					"type": "github"
 				},
 				{
+					"url": "https://liberapay.com/sebastianbergmann",
+					"type": "liberapay"
+				},
+				{
+					"url": "https://thanks.dev/u/gh/sebastianbergmann",
+					"type": "thanks_dev"
+				},
+				{
 					"url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
 					"type": "tidelift"
 				}
 			],
-			"time": "2024-12-05T13:48:26+00:00"
+			"time": "2025-05-02T06:40:34+00:00"
 		},
 		{
 			"name": "psr/http-client",
@@ -2909,16 +3100,16 @@
 		},
 		{
 			"name": "squizlabs/php_codesniffer",
-			"version": "3.12.0",
+			"version": "3.13.2",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-				"reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
+				"reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
-				"reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+				"url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+				"reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
 				"shasum": ""
 			},
 			"require": {
@@ -2989,20 +3180,20 @@
 					"type": "thanks_dev"
 				}
 			],
-			"time": "2025-03-18T05:04:51+00:00"
+			"time": "2025-06-17T22:17:01+00:00"
 		},
 		{
 			"name": "symfony/deprecation-contracts",
-			"version": "v3.5.1",
+			"version": "v3.6.0",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/symfony/deprecation-contracts.git",
-				"reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+				"reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-				"reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+				"url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+				"reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
 				"shasum": ""
 			},
 			"require": {
@@ -3015,7 +3206,7 @@
 					"name": "symfony/contracts"
 				},
 				"branch-alias": {
-					"dev-main": "3.5-dev"
+					"dev-main": "3.6-dev"
 				}
 			},
 			"autoload": {
@@ -3040,7 +3231,7 @@
 			"description": "A generic function and convention to trigger deprecation notices",
 			"homepage": "https://symfony.com",
 			"support": {
-				"source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+				"source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
 			},
 			"funding": [
 				{
@@ -3056,7 +3247,146 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2024-09-25T14:20:29+00:00"
+			"time": "2024-09-25T14:21:43+00:00"
+		},
+		{
+			"name": "symfony/polyfill-php73",
+			"version": "v1.32.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/symfony/polyfill-php73.git",
+				"reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+				"reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.2"
+			},
+			"type": "library",
+			"extra": {
+				"thanks": {
+					"url": "https://github.com/symfony/polyfill",
+					"name": "symfony/polyfill"
+				}
+			},
+			"autoload": {
+				"files": [
+					"bootstrap.php"
+				],
+				"psr-4": {
+					"Symfony\\Polyfill\\Php73\\": ""
+				},
+				"classmap": [
+					"Resources/stubs"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Nicolas Grekas",
+					"email": "p@tchwork.com"
+				},
+				{
+					"name": "Symfony Community",
+					"homepage": "https://symfony.com/contributors"
+				}
+			],
+			"description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+			"homepage": "https://symfony.com",
+			"keywords": [
+				"compatibility",
+				"polyfill",
+				"portable",
+				"shim"
+			],
+			"support": {
+				"source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
+			},
+			"funding": [
+				{
+					"url": "https://symfony.com/sponsor",
+					"type": "custom"
+				},
+				{
+					"url": "https://github.com/fabpot",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+					"type": "tidelift"
+				}
+			],
+			"time": "2024-09-09T11:45:10+00:00"
+		},
+		{
+			"name": "szepeviktor/phpstan-wordpress",
+			"version": "v1.3.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+				"reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+				"reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2 || ^8.0",
+				"php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+				"phpstan/phpstan": "^1.10.31",
+				"symfony/polyfill-php73": "^1.12.0"
+			},
+			"require-dev": {
+				"composer/composer": "^2.1.14",
+				"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+				"php-parallel-lint/php-parallel-lint": "^1.1",
+				"phpstan/phpstan-strict-rules": "^1.2",
+				"phpunit/phpunit": "^8.0 || ^9.0",
+				"szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+				"wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+			},
+			"suggest": {
+				"swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+			},
+			"type": "phpstan-extension",
+			"extra": {
+				"phpstan": {
+					"includes": [
+						"extension.neon"
+					]
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"SzepeViktor\\PHPStan\\WordPress\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "WordPress extensions for PHPStan",
+			"keywords": [
+				"PHPStan",
+				"code analyse",
+				"code analysis",
+				"static analysis",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+				"source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+			},
+			"time": "2024-06-28T22:27:19+00:00"
 		},
 		{
 			"name": "theseer/tokenizer",
@@ -3176,16 +3506,16 @@
 		},
 		{
 			"name": "wp-phpunit/wp-phpunit",
-			"version": "6.7.2",
+			"version": "6.8.1",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/wp-phpunit/wp-phpunit.git",
-				"reference": "e2bb06bacc92a8e9e405e83f56989e8ed9359db1"
+				"reference": "a33d328dab5a4a9ddf0c560bcadbabb58b5ee67f"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/e2bb06bacc92a8e9e405e83f56989e8ed9359db1",
-				"reference": "e2bb06bacc92a8e9e405e83f56989e8ed9359db1",
+				"url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/a33d328dab5a4a9ddf0c560bcadbabb58b5ee67f",
+				"reference": "a33d328dab5a4a9ddf0c560bcadbabb58b5ee67f",
 				"shasum": ""
 			},
 			"type": "library",
@@ -3220,7 +3550,7 @@
 				"issues": "https://github.com/wp-phpunit/issues",
 				"source": "https://github.com/wp-phpunit/wp-phpunit"
 			},
-			"time": "2025-02-12T01:22:52+00:00"
+			"time": "2025-04-16T01:40:54+00:00"
 		},
 		{
 			"name": "yoast/phpunit-polyfills",

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -1,6 +1,10 @@
+# Linting and Static Analysis
+
+This document outlines the tools and procedures for linting and static analysis in this project.
+
 ## PHPCS for checking coding standards
 
-We check against the following standards/rulesets
+We check against the following standards/rulesets:
 
 - [VIP Coding Standards](https://github.com/Automattic/VIP-Coding-Standards)
 - [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards)

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -15,3 +15,17 @@ vendor/bin/phpcs
 ```
 
 See the [PHPCS documentation](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage) (or run `phpcs -h`) for the available command line arguments.
+
+## PHPStan for static analysis
+
+We use [PHPStan](https://phpstan.org/) for static analysis to find potential bugs and improve code quality. It's configured in the `phpstan.neon` file.
+
+To run PHPStan locally, use the following command:
+
+```sh
+composer analyze
+```
+
+This will run PHPStan with the configuration defined in `phpstan.neon`. The command is an alias for `vendor/bin/phpstan analyse --memory-limit=1024M`.
+
+PHPStan is also part of our CI pipeline and runs automatically on every pull request.

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -473,7 +473,7 @@ class Inactive_Users {
 		if ( ! wp_doing_ajax() && ! get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY ) ) {
 			// Right after the first admin_init, set the release date timestamp
 			// to be used as a fallback for users that never logged in before.
-			add_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY, time(), '', 'no' );
+			add_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY, time(), '', false );
 		}
 	}
 

--- a/modules/session-control/class-session-control.php
+++ b/modules/session-control/class-session-control.php
@@ -17,12 +17,6 @@ use Automattic\VIP\Security\Utils\Configs;
 class Session_Control {
 	const LOG_FEATURE_NAME     = 'sb_session_control';
 	public const DEFAULT_VALUE = 'default';
-	/**
-	 * Session expiration time in days
-	 *
-	 * @var string|int
-	 */
-	private static $expiration_days = self::DEFAULT_VALUE;
 
 	/**
 	 * Initialize the module

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,127 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Filter callback return statement is missing\\.$#"
+			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: modules/forced-mfa-users/class-forced-mfa-users.php
+
+		-
+			message: '#^Right side of && is always true\.$#'
+			identifier: booleanAnd.rightAlwaysTrue
+			count: 1
+			path: modules/forced-mfa-users/class-forced-mfa-users.php
+
+		-
+			message: '#^Left side of && is always true\.$#'
+			identifier: booleanAnd.leftAlwaysTrue
+			count: 1
+			path: modules/inactive-users/class-inactive-users.php
+
+		-
+			message: '#^Call to static method send\(\) on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
+			identifier: class.notFound
+			count: 1
+			path: modules/notify-privileged-activity/class-notify-privileged-activity.php
+
+		-
+			message: '#^Filter callback return statement is missing\.$#'
+			identifier: return.missing
 			count: 1
 			path: modules/xml-rpc/class-xml-rpc.php
 
 		-
-			message: "#^Inner named functions are not supported by PHPStan\\. Consider refactoring to an anonymous function, class method, or a top\\-level\\-defined function\\. See issue \\#165 \\(https\\://github\\.com/phpstan/phpstan/issues/165\\) for more details\\.$#"
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: modules/xml-rpc/class-xml-rpc.php
+
+		-
+			message: '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
+			identifier: function.inner
 			count: 2
 			path: tests/phpunit/test-class-configs.php
 
 		-
-			message: "#^Action callback returns true but should not return anything\\.$#"
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertIsArray\(\) with array will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 3
+			path: tests/phpunit/test-configs.php
+
+		-
+			message: '#^Action callback returns true but should not return anything\.$#'
+			identifier: return.void
 			count: 1
 			path: tests/phpunit/test-forced-mfa-users.php
+
+		-
+			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
+			identifier: method.alreadyNarrowedType
+			count: 3
+			path: tests/phpunit/test-inactive-users.php
+
+		-
+			message: '#^Parameter \#1 \$last_seen_timestamp of static method Automattic\\VIP\\Security\\InactiveUsers\\Inactive_Users\:\:get_last_seen_date_string\(\) expects int, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/phpunit/test-inactive-users.php
+
+		-
+			message: '#^Access to static property \$last_call_args_for_test on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
+			identifier: class.notFound
+			count: 27
+			path: tests/phpunit/test-notify-privileged-activity.php
+
+		-
+			message: '#^Call to function method_exists\(\) with ''\\\\Automattic\\\\VIP…'' and ''reset_mock'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/phpunit/test-notify-privileged-activity.php
+
+		-
+			message: '#^Call to static method reset_last_call_args_for_test\(\) on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
+			identifier: class.notFound
+			count: 1
+			path: tests/phpunit/test-notify-privileged-activity.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: utils/class-configs.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between ''production'' and ''test'' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: utils/class-tracking.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''local'' and ''test'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 2
+			path: utils/class-tracking.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: utils/class-tracking.php
+
+		-
+			message: '#^Unreachable statement \- code above always terminates\.$#'
+			identifier: deadCode.unreachable
+			count: 1
+			path: utils/dev-env.php
+
+		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: vip-security-boost.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between ''local'' and ''test'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: vip-security-boost.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,16 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Filter callback return statement is missing\\.$#"
+			count: 1
+			path: modules/xml-rpc/class-xml-rpc.php
+
+		-
+			message: "#^Inner named functions are not supported by PHPStan\\. Consider refactoring to an anonymous function, class method, or a top\\-level\\-defined function\\. See issue \\#165 \\(https\\://github\\.com/phpstan/phpstan/issues/165\\) for more details\\.$#"
+			count: 2
+			path: tests/phpunit/test-class-configs.php
+
+		-
+			message: "#^Action callback returns true but should not return anything\\.$#"
+			count: 1
+			path: tests/phpunit/test-forced-mfa-users.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -73,43 +73,7 @@ parameters:
 			path: utils/class-configs.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between ''production'' and ''test'' will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: utils/class-tracking.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between ''production'' and ''test'' will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: email/class-email.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between ''local'' and ''test'' will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 2
-			path: utils/class-tracking.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: utils/class-tracking.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 1
 			path: utils/dev-env.php
-
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: vip-security-boost.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between ''local'' and ''test'' will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: vip-security-boost.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: modules/inactive-users/class-inactive-users.php
 
 		-
-			message: '#^Call to static method send\(\) on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
-			identifier: class.notFound
-			count: 1
-			path: modules/notify-privileged-activity/class-notify-privileged-activity.php
-
-		-
 			message: '#^Filter callback return statement is missing\.$#'
 			identifier: return.missing
 			count: 1
@@ -67,20 +61,8 @@ parameters:
 			path: tests/phpunit/test-inactive-users.php
 
 		-
-			message: '#^Access to static property \$last_call_args_for_test on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
-			identifier: class.notFound
-			count: 27
-			path: tests/phpunit/test-notify-privileged-activity.php
-
-		-
 			message: '#^Call to function method_exists\(\) with ''\\\\Automattic\\\\VIP…'' and ''reset_mock'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
-			count: 1
-			path: tests/phpunit/test-notify-privileged-activity.php
-
-		-
-			message: '#^Call to static method reset_last_call_args_for_test\(\) on an unknown class Automattic\\VIP\\Security\\Email\\Email\.$#'
-			identifier: class.notFound
 			count: 1
 			path: tests/phpunit/test-notify-privileged-activity.php
 
@@ -95,6 +77,12 @@ parameters:
 			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: utils/class-tracking.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between ''production'' and ''test'' will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: email/class-email.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between ''local'' and ''test'' will always evaluate to false\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,17 @@
+includes:
+	- phpstan-baseline.neon
+	- vendor/szepeviktor/phpstan-wordpress/extension.neon
+parameters:
+  level: 3
+  paths:
+    - modules
+    - utils
+    - tests
+    - class-loader.php
+    - vip-security-boost.php
+  scanDirectories:
+    - mu-plugins
+  scanFiles:
+    - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
+    - %rootDir%/../../php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,7 @@ parameters:
     - modules
     - utils
     - tests
+    - email
     - class-loader.php
     - vip-security-boost.php
   scanDirectories:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,4 +15,7 @@ parameters:
   scanFiles:
     - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
     - %rootDir%/../../php-stubs/wordpress-tests-stubs/wordpress-tests-stubs.php
-
+  dynamicConstantNames:
+    - VIP_GO_APP_ENVIRONMENT
+    - VIP_GO_APP_ID
+    - VIP_SECURITY_BOOST_CONFIGS

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- phpstan-baseline.neon
 	- vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-  level: 3
+  level: 5
   paths:
     - modules
     - utils

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -20,13 +20,6 @@ class Tracking {
 	 */
 	private static ?Telemetry $telemetry = null;
 
-	private Counter $mfa_display_counter;
-	private Counter $mfa_filter_click_counter;
-	private Counter $mfa_sorting_counter;
-	private Counter $blocked_users_view_counter;
-	private Counter $user_unblock_counter;
-	private Counter $privileged_email_sent_counter;
-
 	/**
 	 * Get the Telemetry instance.
 	 *
@@ -72,53 +65,6 @@ class Tracking {
 			return 'nonprod' . $trailing_underscore;
 		}
 		return '';
-	}
-
-	/**
-	 * Initialize stats used by the class-collector.php for the prometheus stats.
-	 */
-	public function initialize( RegistryInterface $registry ): void {
-		$this->mfa_display_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'mfa_display_total',
-			'Number of MFA display views',
-			[ 'filtered' ]
-		);
-
-		$this->mfa_filter_click_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'mfa_filter_click_total',
-			'Number of MFA filter clicks',
-			[ 'filter_type' ]
-		);
-
-		$this->mfa_sorting_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'mfa_sorting_total',
-			'Number of MFA sorting actions',
-			[ 'sort_column', 'sort_order' ]
-		);
-
-		$this->blocked_users_view_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'blocked_users_view_total',
-			'Number of blocked users view accesses',
-			[]
-		);
-
-		$this->user_unblock_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'user_unblock_total',
-			'Number of user unblock actions',
-			[ 'user_role' ]
-		);
-
-		$this->privileged_email_sent_counter = $registry->getOrRegisterCounter(
-			'vip_security_boost',
-			'privileged_email_sent_total',
-			'Number of privileged activity emails sent',
-			[ 'email_type', 'recipient_role' ]
-		);
 	}
 
 	public static function mfa_display( $filter_enabled ) {

--- a/utils/class-tracking.php
+++ b/utils/class-tracking.php
@@ -117,7 +117,6 @@ class Tracking {
 	 * Record stats using VIP Stats
 	 *
 	 * @param string $stat_name Stat name.
-	 * @param mixed  $value Stat value.
 	 */
 	private static function record_stats( $stat_name ) {
 		$env_prefix = self::maybe_get_non_production_prefix( false );

--- a/utils/configs.php
+++ b/utils/configs.php
@@ -21,7 +21,7 @@ function get_module_configs( $module_name, $configs = false ) {
 
 	$current_module_config = [];
 
-	if ( is_array( $module_configs ) && isset( $module_configs[ $module_name ] ) ) {
+	if ( isset( $module_configs[ $module_name ] ) ) {
 		$current_module_config = $module_configs[ $module_name ];
 	}
 


### PR DESCRIPTION
## Description

After #51 I realized that we were lacking a bit of type checking. As a result, I decided to experiment with [PHPStan](https://phpstan.org/u), which is used across other WordPress plugins. I introduced the latest version into this codebase.

I also reviewed some dependencies and code used in the MI plugins. More importantly, I addressed some basic errors that we had overlooked. PHPStan offers multiple levels of type checking. 
For now, I have settled on [level five](https://phpstan.org/user-guide/rule-levels), I know WP Parse.ly is using level 9 (😮 ), and I think we should eventually get there, but for now, I'm playing it safe. 

I also added a caching to both the composer dependency and the mu-plugins dependency to speed up the build flow.

**PHPStan level 5 description**
https://phpstan.org/user-guide/rule-levels

* basic checks, unknown classes, unknown functions, unknown methods called on $this, wrong number of arguments passed to those methods and functions, always undefined variables
* possibly undefined variables, unknown magic methods and properties on classes with __call and __get
* unknown methods checked on all expressions (not just $this), validating PHPDocs
* return types, types assigned to properties
* basic dead code checking - always false instanceof and other type checks, dead else branches, unreachable code after return; etc.
* checking types of arguments passed to methods and functions

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

- Until #51 is merged tests will fail as expected, indicating the type error.