### PR TITLE
[PLTFRM-1136] Remove hardcoded `wpcomvip` user and move to constant

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -116,7 +116,7 @@ class Highlight_MFA_Users {
 		}
 
 		// Exclude the wpcomvip user from the list
-		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+		$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
 		if ( false !== $wpcomvip ) {
 			$skipped_user_ids[] = $wpcomvip->ID;
 		}
@@ -380,7 +380,7 @@ class Highlight_MFA_Users {
 			}
 
 			// Exclude the wpcomvip user from the list
-			$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+			$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
 			if ( false !== $wpcomvip ) {
 				$skipped_user_ids[] = $wpcomvip->ID;
 			}

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -82,7 +82,7 @@ class Highlight_MFA_Users {
 		}
 
 		// Exclude the wpcomvip user from the list
-		$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+		$wpcomvip = get_user_by( 'login', WPCOM_VIP_LOGIN );
 		if ( false !== $wpcomvip ) {
 			$skipped_user_ids[] = $wpcomvip->ID;
 		}
@@ -253,7 +253,7 @@ class Highlight_MFA_Users {
 			}
 
 			// Exclude the wpcomvip user from the list
-			$wpcomvip = get_user_by( 'login', 'wpcomvip' );
+			$wpcomvip = get_user_by( 'login', WPCOM_VIP_LOGIN );
 			if ( false !== $wpcomvip ) {
 				$skipped_user_ids[] = $wpcomvip->ID;
 			}

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -82,7 +82,7 @@ class Highlight_MFA_Users {
 		}
 
 		// Exclude the wpcomvip user from the list
-		$wpcomvip = get_user_by( 'login', WPCOM_VIP_LOGIN );
+		$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
 		if ( false !== $wpcomvip ) {
 			$skipped_user_ids[] = $wpcomvip->ID;
 		}
@@ -253,7 +253,7 @@ class Highlight_MFA_Users {
 			}
 
 			// Exclude the wpcomvip user from the list
-			$wpcomvip = get_user_by( 'login', WPCOM_VIP_LOGIN );
+			$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
 			if ( false !== $wpcomvip ) {
 				$skipped_user_ids[] = $wpcomvip->ID;
 			}

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -116,7 +116,7 @@ class Highlight_MFA_Users {
 		}
 
 		// Exclude the wpcomvip user from the list
-		$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
+		$wpcomvip = get_user_by( 'login', Configs::get_bot_login() );
 		if ( false !== $wpcomvip ) {
 			$skipped_user_ids[] = $wpcomvip->ID;
 		}
@@ -380,7 +380,7 @@ class Highlight_MFA_Users {
 			}
 
 			// Exclude the wpcomvip user from the list
-			$wpcomvip = get_user_by( 'login', vip_security_boost_get_bot_login() );
+			$wpcomvip = get_user_by( 'login', Configs::get_bot_login() );
 			if ( false !== $wpcomvip ) {
 				$skipped_user_ids[] = $wpcomvip->ID;
 			}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -527,7 +527,7 @@ class Inactive_Users {
 		}
 
 		// Exclude wpcomvip user from inactivity checks
-		if ( vip_security_boost_get_bot_login() === $user->user_login ) {
+		if ( Configs::get_bot_login() === $user->user_login ) {
 			return false;
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -526,6 +526,11 @@ class Inactive_Users {
 			throw new \Exception( sprintf( 'User #%d found', esc_html( $user_id ) ) );
 		}
 
+		// Exclude wpcomvip user from inactivity checks
+		if ( vip_security_boost_get_bot_login() === $user->user_login ) {
+			return false;
+		}
+
 		if ( $user->user_registered && strtotime( $user->user_registered ) > self::get_inactivity_timestamp() ) {
 			return false;
 		}

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -112,7 +112,7 @@ class Notify_Privileged_Activity {
 		if ( class_exists( Support_User::class ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,
-				'Skipping notification for VIP Support user: ' . $user->ID
+				'Skipping notification for VIP Support user: ' . $user->user_login
 			);
 			return;
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,3 +98,10 @@ if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 
 
 \Automattic\VIP\Security\Utils\Testable_Logger::set_track_logs( true );
+
+// Helper function for bot login in tests
+if ( ! function_exists( 'vip_security_boost_get_bot_login' ) ) {
+	function vip_security_boost_get_bot_login(): string {
+		return 'wpcomvip';
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,6 +53,9 @@ function _manually_load_plugin() {
 	require_once __DIR__ . '/../mu-plugins/logstash/logstash.php';
 
 	require_once __DIR__ . '/../mu-plugins/z-client-mu-plugins.php';
+	
+	// Load our main plugin to get the helper function
+	require_once __DIR__ . '/../vip-security-boost.php';
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,8 +54,6 @@ function _manually_load_plugin() {
 
 	require_once __DIR__ . '/../mu-plugins/z-client-mu-plugins.php';
 	
-	// Load our main plugin to get the helper function
-	require_once __DIR__ . '/../vip-security-boost.php';
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,10 +98,3 @@ if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 
 
 \Automattic\VIP\Security\Utils\Testable_Logger::set_track_logs( true );
-
-// Helper function for bot login in tests
-if ( ! function_exists( 'vip_security_boost_get_bot_login' ) ) {
-	function vip_security_boost_get_bot_login(): string {
-		return 'wpcomvip';
-	}
-}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -94,3 +94,8 @@ require $_tests_dir . '/includes/bootstrap.php';
 if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 	define( 'VIP_GO_APP_ENVIRONMENT', 'test' );
 }
+
+// Define wpcomvip user login constant for tests
+if ( ! defined( 'WPCOM_VIP_LOGIN' ) ) {
+	define( 'WPCOM_VIP_LOGIN', 'wpcomvip' );
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,7 +53,6 @@ function _manually_load_plugin() {
 	require_once __DIR__ . '/../mu-plugins/logstash/logstash.php';
 
 	require_once __DIR__ . '/../mu-plugins/z-client-mu-plugins.php';
-	
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -96,9 +96,5 @@ if ( ! defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
 	define( 'VIP_GO_APP_ENVIRONMENT', 'test' );
 }
 
-// Define wpcomvip user login constant for tests
-if ( ! defined( 'WPCOM_VIP_LOGIN' ) ) {
-	define( 'WPCOM_VIP_LOGIN', 'wpcomvip' );
-}
 
 \Automattic\VIP\Security\Utils\Testable_Logger::set_track_logs( true );

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -1,12 +1,4 @@
 <?php
-
-// Helper function for bot login in tests
-if ( ! function_exists( 'vip_security_boost_get_bot_login' ) ) {
-	function vip_security_boost_get_bot_login(): string {
-		return 'wpcomvip';
-	}
-}
-
 if ( ! class_exists( 'Two_Factor_Core' ) ) {
 	class Two_Factor_Core {
 		/** @var array<int> Stores user IDs that the mock should treat as MFA enabled */

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -41,7 +41,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->admin_wpcomvip_ignored_id = $this->factory()->user->create([
 			'role'       => 'administrator',
-			'user_login' => 'wpcomvip',
+			'user_login' => WPCOM_VIP_LOGIN,
 		]);
 
 		$this->admin_user_mfa_disabled_id = $this->factory()->user->create([

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -13,6 +13,7 @@ if ( ! class_exists( 'Two_Factor_Core' ) ) {
 }
 
 use Automattic\VIP\Security\MFAUsers\Highlight_MFA_Users;
+use Automattic\VIP\Security\Utils\Configs;
 
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class HighlightMFAUsersTest extends WP_UnitTestCase {
@@ -48,7 +49,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->admin_wpcomvip_ignored_id = $this->factory()->user->create([
 			'role'       => 'administrator',
-			'user_login' => vip_security_boost_get_bot_login(),
+			'user_login' => Configs::get_bot_login(),
 		]);
 
 		$this->admin_user_mfa_disabled_id = $this->factory()->user->create([

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -1,4 +1,12 @@
 <?php
+
+// Helper function for bot login in tests
+if ( ! function_exists( 'vip_security_boost_get_bot_login' ) ) {
+	function vip_security_boost_get_bot_login(): string {
+		return 'wpcomvip';
+	}
+}
+
 if ( ! class_exists( 'Two_Factor_Core' ) ) {
 	class Two_Factor_Core {
 		/** @var array<int> Stores user IDs that the mock should treat as MFA enabled */

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -41,7 +41,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->admin_wpcomvip_ignored_id = $this->factory()->user->create([
 			'role'       => 'administrator',
-			'user_login' => WPCOM_VIP_LOGIN,
+			'user_login' => vip_security_boost_get_bot_login(),
 		]);
 
 		$this->admin_user_mfa_disabled_id = $this->factory()->user->create([

--- a/utils/class-configs.php
+++ b/utils/class-configs.php
@@ -44,4 +44,19 @@ class Configs {
 			self::$cached_module_configs = $module_configs;
 		}
 	}
+	/**
+ * Get the bot user login based on environment.
+ * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
+ * In local/test, we want to use 'wpcomvip'.
+ */
+	public static function get_bot_login(): string {
+		$is_local_env = ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' );
+		$is_test_env  = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' );
+	
+		if ( $is_local_env || $is_test_env ) {
+			return 'wpcomvip';
+		}
+	
+		return defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) ? constant( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) : 'wpcomvip';
+	}
 }

--- a/utils/class-configs.php
+++ b/utils/class-configs.php
@@ -45,10 +45,10 @@ class Configs {
 		}
 	}
 	/**
- * Get the bot user login based on environment.
- * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
- * In local/test, we want to use 'wpcomvip'.
- */
+	 * Get the bot user login based on environment.
+	 * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
+	 * In local/test, we want to use 'wpcomvip'.
+	 */
 	public static function get_bot_login(): string {
 		$is_local_env = ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' );
 		$is_test_env  = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' );

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -15,6 +15,10 @@
 
 declare(strict_types = 1);
 
+if ( ! defined( 'WPCOM_VIP_LOGIN' ) ) {
+	define( 'WPCOM_VIP_LOGIN', 'wpcomvip' );
+}
+
 require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/utils/class-configs.php';
 require_once __DIR__ . '/email/class-email.php';

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -15,22 +15,6 @@
 
 declare(strict_types = 1);
 
-/**
- * Get the bot user login based on environment.
- * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
- * In local/test, we want to use 'wpcomvip'.
- */
-function vip_security_boost_get_bot_login(): string {
-	$is_local_env = ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' );
-	$is_test_env  = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' );
-	
-	if ( $is_local_env || $is_test_env ) {
-		return 'wpcomvip';
-	}
-	
-	return defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) ? constant( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) : 'wpcomvip';
-}
-
 require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/utils/class-configs.php';
 require_once __DIR__ . '/email/class-email.php';

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -15,8 +15,20 @@
 
 declare(strict_types = 1);
 
-if ( ! defined( 'WPCOM_VIP_LOGIN' ) ) {
-	define( 'WPCOM_VIP_LOGIN', 'wpcomvip' );
+/**
+ * Get the bot user login based on environment.
+ * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
+ * In local/test, we want to use 'wpcomvip'.
+ */
+function vip_security_boost_get_bot_login() {
+	$is_local_env = ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' );
+	$is_test_env  = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' );
+	
+	if ( $is_local_env || $is_test_env ) {
+		return 'wpcomvip';
+	}
+	
+	return defined( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) ? constant( 'WPCOM_VIP_MACHINE_USER_LOGIN' ) : 'wpcomvip';
 }
 
 require_once __DIR__ . '/utils/configs.php';

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
  * In production, WPCOM_VIP_MACHINE_USER_LOGIN is overridden via secrets.
  * In local/test, we want to use 'wpcomvip'.
  */
-function vip_security_boost_get_bot_login() {
+function vip_security_boost_get_bot_login(): string {
 	$is_local_env = ! defined( 'VIP_GO_APP_ENVIRONMENT' ) || 'local' === constant( 'VIP_GO_APP_ENVIRONMENT' );
 	$is_test_env  = defined( 'VIP_GO_APP_ENVIRONMENT' ) && 'test' === constant( 'VIP_GO_APP_ENVIRONMENT' );
 	


### PR DESCRIPTION
## Description

Remove hardcoded `wpcomvip` user and instead use `WPCOM_VIP_MACHINE_USER_LOGIN `

Also updated `inactive-users` module to exclude `wpcomvip` user.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR and start dev-env
2. Create a `vipsupport` and `wpcomvip` users 
3. Make sure they are not included in the count of Highlight MFA
```
vip dev-env exec --slug=vip-security-boost --  wp vipsupport create-user vip_katrina vip_katrina@automattic.com password123 --display-name="KT"
vip dev-env exec --slug=vip-security-boost -- wp user create wpcomvip wpcomvip@automattic.com --role=administrator --display_name=wpcomvip --user_pass=password123
```