### PR TITLE
Move PHP base version from 8.2 to 8.1 and update test matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,11 +12,20 @@ jobs:
       fail-fast: false
       matrix:
         config:
+          # PHP 8.1
+          - { wp: 6.5, ms: "0", php: "8.1" }
+          - { wp: 6.5, ms: "1", php: "8.1" }
+          - { wp: 6.6, ms: "0", php: "8.1" }
+          - { wp: 6.6, ms: "1", php: "8.1" }
+          - { wp: 6.7, ms: "0", php: "8.1" }
+          - { wp: 6.7, ms: "1", php: "8.1" }
+          - { wp: 6.8, ms: "0", php: "8.1" }
+          - { wp: 6.8, ms: "1", php: "8.1" }
+          - { wp: latest, ms: "0", php: "8.1" }
+          - { wp: latest, ms: "1", php: "8.1" }
+          - { wp: nightly, ms: "0", php: "8.1" }
+          - { wp: nightly, ms: "1", php: "8.1" }
           # PHP 8.2
-          - { wp: 6.6, ms: "0", php: "8.2" }
-          - { wp: 6.6, ms: "1", php: "8.2" }
-          - { wp: 6.7, ms: "0", php: "8.2" }
-          - { wp: 6.7, ms: "1", php: "8.2" }
           - { wp: 6.8, ms: "0", php: "8.2" }
           - { wp: 6.8, ms: "1", php: "8.2" }
           - { wp: latest, ms: "0", php: "8.2" }

--- a/.wpvip/vip-dev-env.yml.ejs
+++ b/.wpvip/vip-dev-env.yml.ejs
@@ -1,7 +1,7 @@
 configuration-version: 1
 slug: vip-security-boost
 title: VIP WordPress Security Controls
-php: 8.2
+php: 8.1
 wordpress: 6.8
 app-code: image
 mu-plugins: image

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/automattic/vip-security-boost-integration",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.2",
+		"php": ">=8.1",
 		"spatie/mjml-php": "^1.2"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"config": {
 		"sort-packages": true,
 		"platform": {
-			"php": "8.2"
+			"php": "8.1"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
@@ -38,9 +38,9 @@
 		"analyze": "./vendor/bin/phpstan analyse --memory-limit=1024M",
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
 		"phpcs": "./vendor/bin/phpcs",
-		"test": "./bin/test.sh --php 8.2 --wp 6.8",
+		"test": "./bin/test.sh --php 8.1 --wp 6.8",
 		"test-ci": "./bin/test.sh ",
-		"test:multisite": "./bin/test.sh --php 8.2 --wp 6.8 --multisite 1",
+		"test:multisite": "./bin/test.sh --php 8.1 --wp 6.8 --multisite 1",
 		"test:integration": "./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/",
 		"build-mjml": "./scripts/build-mjml.sh"
 	}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "fde78a4fc6b1bbc2834c25f1da8d1973",
+	"content-hash": "523bb8df61284b1d71833a238d7fc8d8",
 	"packages": [
 		{
 			"name": "spatie/mjml-php",
@@ -69,20 +69,20 @@
 		},
 		{
 			"name": "symfony/process",
-			"version": "v7.3.0",
+			"version": "v6.4.20",
 			"source": {
 				"type": "git",
 				"url": "https://github.com/symfony/process.git",
-				"reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
+				"reference": "e2a61c16af36c9a07e5c9906498b73e091949a20"
 			},
 			"dist": {
 				"type": "zip",
-				"url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
-				"reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+				"url": "https://api.github.com/repos/symfony/process/zipball/e2a61c16af36c9a07e5c9906498b73e091949a20",
+				"reference": "e2a61c16af36c9a07e5c9906498b73e091949a20",
 				"shasum": ""
 			},
 			"require": {
-				"php": ">=8.2"
+				"php": ">=8.1"
 			},
 			"type": "library",
 			"autoload": {
@@ -110,7 +110,7 @@
 			"description": "Executes commands in sub-processes",
 			"homepage": "https://symfony.com",
 			"support": {
-				"source": "https://github.com/symfony/process/tree/v7.3.0"
+				"source": "https://github.com/symfony/process/tree/v6.4.20"
 			},
 			"funding": [
 				{
@@ -126,7 +126,7 @@
 					"type": "tidelift"
 				}
 			],
-			"time": "2025-04-17T09:11:12+00:00"
+			"time": "2025-03-10T17:11:00+00:00"
 		}
 	],
 	"packages-dev": [
@@ -3545,11 +3545,11 @@
 	"prefer-stable": false,
 	"prefer-lowest": false,
 	"platform": {
-		"php": ">=8.2"
+		"php": ">=8.1"
 	},
 	"platform-dev": {},
 	"platform-overrides": {
-		"php": "8.2"
+		"php": "8.1"
 	},
 	"plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description
This PR downgrades the supported PHP version from 8.2 to 8.1, mostly because some customers might still be on the previous version.

Through this change, we will be able to catch possible type errors that might arise from using functions and features available only in future PHP versions. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->