### PR TITLE
Fix XML-RPC hook priority to ensure server exits as soon as possible

### DIFF
--- a/modules/xml-rpc/class-xml-rpc.php
+++ b/modules/xml-rpc/class-xml-rpc.php
@@ -56,7 +56,7 @@ class Xml_Rpc {
 			exit( 'Access to XML-RPC is disabled on this site.' );
 			// phpcs:ignore Squiz.PHP.NonExecutableCode.Unreachable
 			return $server_class;
-		});
+		}, PHP_INT_MIN, 1 );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR fixes the XML-RPC hook priority to ensure the server exits as soon as possible when XML-RPC is disabled. The change uses `PHP_INT_MIN` as the priority value, which ensures this hook runs before any other hooks that might interfere with the XML-RPC blocking functionality.

## Changelog Description

### Fixed
- Fixed XML-RPC hook priority to ensure server exits as soon as possible when XML-RPC is disabled

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Enable the XML-RPC module in the VIP Security Boost plugin.
3. Make a request:

```bash
curl -i \
  -H 'Content-Type: text/xml' \
  http://vip-security-boost.vipdev.lndo.site/xmlrpc.php
```

4. Verify that the request is blocked immediately with the "Access to XML-RPC is disabled on this site." message:

```
HTTP/1.1 200 OK
Content-Type: text/html; charset=UTF-8
Date: Thu, 03 Jul 2025 17:20:19 GMT
Server: nginx/1.29.0
X-Powered-By: PHP/8.2.28
Transfer-Encoding: chunked

Access to XML-RPC is disabled on this site.%   
```