### PR TITLE
[PLTFRM-1283] Add back support for `capabilities`

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -2,6 +2,7 @@
 namespace Automattic\VIP\Security\MFAUsers;
 
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Forced_MFA_Users {
 	/**
@@ -11,17 +12,33 @@ class Forced_MFA_Users {
 	 */
 	private static $roles;
 
+	/**
+	 * The capabilities that should have MFA enforced.
+	 *
+	 * @var array An array of capability slugs.
+	 */
+	private static $capabilities;
+
 	public static function init() {
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
-		if ( empty( $forced_mfa_configs ) || empty( $forced_mfa_configs['roles'] ) ) {
+		if ( empty( $forced_mfa_configs ) ) {
 			return;
 		}
-		self::$roles = $forced_mfa_configs['roles'];
+		
+		// Normalize capabilities and roles configuration
+		self::$capabilities = Capability_Utils::normalize_capabilities_input( $forced_mfa_configs['capabilities'] ?? [] );
+		self::$roles        = Capability_Utils::normalize_roles_input( $forced_mfa_configs['roles'] ?? [] );
+		
+		// Ensure we have either capabilities or roles configured
+		if ( empty( self::$capabilities ) && empty( self::$roles ) ) {
+			return;
+		}
+		
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 	}
 
 	/**
-	 * Require 2FA based on roles set in config
+	 * Require 2FA based on capabilities or roles set in config
 	 */
 	public static function maybe_enforce_two_factor() {
 		if ( ! is_user_logged_in() ) {
@@ -32,32 +49,22 @@ class Forced_MFA_Users {
 			return;
 		}
 
-		$required_roles = self::$roles;
-
-		if ( empty( $required_roles ) ) {
+		$user = wp_get_current_user();
+		if ( ! $user ) {
 			return;
 		}
 
-		if ( is_string( $required_roles ) ) {
-			$required_roles = [ $required_roles ];
-		}
+		// Check if user has elevated permissions based on capabilities or roles
+		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions( 
+			$user, 
+			self::$capabilities, 
+			self::$roles 
+		);
 
-		$user_has_two_factor_enforced = false;
-
-		$user = wp_get_current_user();
-		if ( is_array( $required_roles ) && $user ) {
-			foreach ( $required_roles as $role ) {
-				if ( is_string( $role ) && ! empty( $role ) && in_array( $role, (array) $user->roles, true ) ) {
-					$user_has_two_factor_enforced = true;
-					break;
-				}
-			}
-
-			if ( $user_has_two_factor_enforced ) {
-				add_filter( 'wpcom_vip_is_two_factor_forced', function () {
-					return true;
-				}, PHP_INT_MAX );
-			}
+		if ( $user_has_two_factor_enforced ) {
+			add_filter( 'wpcom_vip_is_two_factor_forced', function () {
+				return true;
+			}, PHP_INT_MAX );
 		}
 	}
 }

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -8,7 +8,7 @@ class Forced_MFA_Users {
 	/**
 	 * The roles that should have MFA enforced.
 	 *
-	 * @var string|array The role slug or an array of role slugs.
+	 * @var array An array of role slugs.
 	 */
 	private static $roles;
 
@@ -50,7 +50,7 @@ class Forced_MFA_Users {
 		}
 
 		$user = wp_get_current_user();
-		if ( ! $user ) {
+		if ( ! $user->exists() ) {
 			return;
 		}
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -399,7 +399,12 @@ class Highlight_MFA_Users {
 				],
 			];
 
-			$query->set( 'role__in', self::$roles ); // Set the configured roles
+			// Use capability__in if capabilities are configured, otherwise use role__in
+			if ( Capability_Utils::are_capabilities_configured( self::$capabilities ) ) {
+				$query->set( 'capability__in', self::$capabilities );
+			} else {
+				$query->set( 'role__in', self::$roles );
+			}
 			$query->set( 'meta_query', $meta_query );
 
 			// Exclude skipped users AND always exclude User wpcomvip

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -229,13 +229,10 @@ class Highlight_MFA_Users {
 			return;
 		}
 
-		// Determine notice text based on role configuration
-		// self::$roles is already an array and populated from init().
-		$configured_roles_for_comparison = self::$roles;
-		\sort( $configured_roles_for_comparison ); // Use global sort
-
-		// unordered array check with ==
-		$is_default_config = ( self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS === $configured_roles_for_comparison || empty( $configured_roles_for_comparison ) );
+		// Check if capabilities are configured or using default roles
+		$has_capabilities = Capability_Utils::are_capabilities_configured( self::$capabilities );
+		$is_default_config = ! $has_capabilities && 
+								empty( array_diff( self::$roles, self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS ) );
 
 		// Get the cached MFA disabled count
 		$mfa_disabled_count = self::get_mfa_disabled_count();

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -100,8 +100,9 @@ class Highlight_MFA_Users {
 
 		// Include a hash of the roles configuration to invalidate cache when roles change
 		$roles_hash = md5( wp_json_encode( self::$roles ) );
+		$capabilities_hash = md5( wp_json_encode( self::$capabilities ) );
 
-		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id . '_' . $roles_hash;
+		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id . '_' . $roles_hash . '_' . $capabilities_hash;
 	}
 
 	/**

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -44,29 +44,9 @@ class Highlight_MFA_Users {
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = Configs::get_module_configs( 'highlight-mfa-users' );
 		
-		// Check if Capability_Utils is available
-		if ( ! class_exists( '\\Automattic\\VIP\\Security\\Utils\\Capability_Utils' ) ) {
-			// Fallback to old role-based configuration
-			self::$roles = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
-
-			if ( ! is_array( self::$roles ) ) {
-				self::$roles = [ self::$roles ];
-			}
-			self::$roles = array_filter( self::$roles );
-			if ( empty( self::$roles ) ) {
-				self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
-			}
-			self::$capabilities = [];
-		} else {
-			// Normalize capabilities and roles configuration
-			self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? [] );
-			self::$roles        = Capability_Utils::normalize_roles_input( $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
-			
-			// If no capabilities and no roles configured, default to administrator and editor
-			if ( ! Capability_Utils::are_capabilities_configured( self::$capabilities ) && empty( self::$roles ) ) {
-				self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
-			}
-		}
+		// Normalize capabilities and roles configuration
+		self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? [] );
+		self::$roles        = Capability_Utils::normalize_roles_input( $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
 		add_action( 'pre_get_users', [ __CLASS__, 'filter_users_by_mfa_status' ] );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -2,6 +2,7 @@
 namespace Automattic\VIP\Security\MFAUsers;
 
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
@@ -17,6 +18,13 @@ class Highlight_MFA_Users {
 	 * @var array An array of role slugs.
 	 */
 	private static $roles;
+
+	/**
+	 * The capabilities used to highlight users without MFA.
+	 *
+	 * @var array An array of capability slugs.
+	 */
+	private static $capabilities;
 
 	public static function init() {
 		// If plugins_loaded has already fired (e.g., in tests), register hooks immediately
@@ -35,15 +43,29 @@ class Highlight_MFA_Users {
 
 		// Feature is always active unless specific users are skipped via option.
 		$highlight_mfa_configs = Configs::get_module_configs( 'highlight-mfa-users' );
-		self::$roles           = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS; // Default to administrator and editor if not configured
+		
+		// Check if Capability_Utils is available
+		if ( ! class_exists( '\\Automattic\\VIP\\Security\\Utils\\Capability_Utils' ) ) {
+			// Fallback to old role-based configuration
+			self::$roles = $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
 
-		if ( ! is_array( self::$roles ) ) {
-			self::$roles = [ self::$roles ];
-		}
-		self::$roles = array_filter( self::$roles );
-		// If after filtering, the array is empty, default back to administrator and editor
-		if ( empty( self::$roles ) ) {
-			self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
+			if ( ! is_array( self::$roles ) ) {
+				self::$roles = [ self::$roles ];
+			}
+			self::$roles = array_filter( self::$roles );
+			if ( empty( self::$roles ) ) {
+				self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
+			}
+			self::$capabilities = [];
+		} else {
+			// Normalize capabilities and roles configuration
+			self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? [] );
+			self::$roles        = Capability_Utils::normalize_roles_input( $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
+			
+			// If no capabilities and no roles configured, default to administrator and editor
+			if ( ! Capability_Utils::are_capabilities_configured( self::$capabilities ) && empty( self::$roles ) ) {
+				self::$roles = self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS;
+			}
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
@@ -122,14 +144,21 @@ class Highlight_MFA_Users {
 		}
 		$skipped_user_ids = array_unique( array_filter( array_map( 'intval', $skipped_user_ids ) ) );
 
-		// Cache miss - calculate the count
-		$args       = [
-			'role__in' => self::$roles,
-			'fields'   => 'ID',
+		// Build query args - use capabilities if configured, otherwise fall back to roles
+		$args = [
+			'fields'  => 'ID',
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding a potentially small, known set of users (skipped + ID 1)
-			'exclude'  => $skipped_user_ids,
-			'number'   => -1, // Get all relevant users
+			'exclude' => $skipped_user_ids,
+			'number'  => -1, // Get all relevant users
 		];
+		
+		// Use native capability filtering if capabilities are configured
+		if ( Capability_Utils::are_capabilities_configured( self::$capabilities ) ) {
+			$args['capability__in'] = self::$capabilities;
+		} else {
+			$args['role__in'] = self::$roles;
+		}
+		
 		$user_query = new \WP_User_Query( $args );
 		$user_ids   = $user_query->get_results();
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -230,7 +230,7 @@ class Highlight_MFA_Users {
 		}
 
 		// Check if capabilities are configured or using default roles
-		$has_capabilities = Capability_Utils::are_capabilities_configured( self::$capabilities );
+		$has_capabilities  = Capability_Utils::are_capabilities_configured( self::$capabilities );
 		$is_default_config = ! $has_capabilities && 
 								empty( array_diff( self::$roles, self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS ) );
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -99,7 +99,7 @@ class Highlight_MFA_Users {
 		$blog_id = $blog_id ?? get_current_blog_id();
 
 		// Include a hash of the roles configuration to invalidate cache when roles change
-		$roles_hash = md5( wp_json_encode( self::$roles ) );
+		$roles_hash        = md5( wp_json_encode( self::$roles ) );
 		$capabilities_hash = md5( wp_json_encode( self::$capabilities ) );
 
 		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id . '_' . $roles_hash . '_' . $capabilities_hash;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -280,10 +280,12 @@ class Inactive_Users {
 			// Track blocked users view
 			do_action( 'vip_security_blocked_users_view' );
 
-			// Note: This filter only works with roles, not capabilities, due to WP_User_Query limitations
-			// Users with elevated capabilities but not elevated roles won't appear in this filtered view
-			// However, they are still tracked and blocked correctly
-			$vars['role__in'] = Capability_Utils::normalize_roles_input( self::$elevated_roles );
+			// Use capability__in if capabilities are configured, otherwise use role__in
+			if ( ! empty( self::$elevated_capabilities ) ) {
+				$vars['capability__in'] = self::$elevated_capabilities;
+			} else {
+				$vars['role__in'] = Capability_Utils::normalize_roles_input( self::$elevated_roles );
+			}
 
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$vars['meta_query'] = [
@@ -385,22 +387,26 @@ class Inactive_Users {
 		$has_blocked_users = wp_cache_get( $cache_key, self::LAST_SEEN_CACHE_GROUP );
 
 		if ( false === $has_blocked_users ) {
-			$users_query = new \WP_User_Query(
-				array(
-					'blog_id'      => $blog_id,
-					'fields'       => 'ID',
-					'meta_key'     => self::LAST_SEEN_META_KEY,
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-					'meta_value'   => self::get_inactivity_timestamp(),
-					'meta_type'    => 'NUMERIC',
-					'meta_compare' => '<',
-					'count_total'  => false,
-					'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
-					// Note: role__in only filters by roles, not capabilities
-				// Users with elevated capabilities but not elevated roles won't be counted here
-					'role__in'     => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
-				),
+			$query_args = array(
+				'blog_id'      => $blog_id,
+				'fields'       => 'ID',
+				'meta_key'     => self::LAST_SEEN_META_KEY,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'meta_value'   => self::get_inactivity_timestamp(),
+				'meta_type'    => 'NUMERIC',
+				'meta_compare' => '<',
+				'count_total'  => false,
+				'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
 			);
+			
+			// Use capability__in if capabilities are configured, otherwise use role__in
+			if ( ! empty( self::$elevated_capabilities ) ) {
+				$query_args['capability__in'] = self::$elevated_capabilities;
+			} else {
+				$query_args['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
+			}
+			
+			$users_query = new \WP_User_Query( $query_args );
 
 			$has_blocked_users = ! empty( $users_query->get_results() ) ? 1 : 0;
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -283,7 +283,7 @@ class Inactive_Users {
 			// Note: This filter only works with roles, not capabilities, due to WP_User_Query limitations
 			// Users with elevated capabilities but not elevated roles won't appear in this filtered view
 			// However, they are still tracked and blocked correctly
-			$vars['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
+			$vars['role__in'] = Capability_Utils::normalize_roles_input( self::$elevated_roles );
 
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			$vars['meta_query'] = [

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -674,17 +674,6 @@ class Inactive_Users {
 
 		return Capability_Utils::user_has_elevated_permissions( $user, $elevated_capabilities, $elevated_roles );
 	}
-	
-	/**
-	 * Check if user has elevated roles (deprecated, use user_has_elevated_permissions instead)
-	 * 
-	 * @deprecated Use user_has_elevated_permissions() instead
-	 * @param \WP_User $user The user to check.
-	 * @return bool True if user has elevated roles, false otherwise.
-	 */
-	private static function user_with_elevated_roles( $user ) {
-		return self::user_has_elevated_permissions( $user );
-	}
 }
 
 Inactive_Users::init();

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -334,12 +334,6 @@ class Inactive_Users {
 	}
 
 	public static function get_inactive_users_query_args() {
-		// Use capability__in if capabilities are configured, otherwise use role__in
-		// if ( ! empty( self::$elevated_capabilities ) ) {
-		// 	$vars['capability__in'] = self::$elevated_capabilities;
-		// } else {
-		// 	$vars['role__in'] = Capability_Utils::normalize_roles_input( self::$elevated_roles );
-		// }
 		$vars = array(
 			// Only consider users that registered before the inactivity threshold
 			'date_query' => array(
@@ -347,9 +341,6 @@ class Inactive_Users {
 					'before' => gmdate( 'Y-m-d H:i:s', self::get_inactivity_timestamp() ),
 				),
 			),
-
-			// Only consider users with roles we want to target
-			'role__in'   => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
 
 			// Only consider users that have not been active since the inactivity threshold
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -365,7 +356,12 @@ class Inactive_Users {
 				],
 			),
 		);
-
+		// Use capability__in if capabilities are configured, otherwise use role__in
+		if ( ! empty( self::$elevated_capabilities ) ) {
+			$vars['capability__in'] = self::$elevated_capabilities;
+		} else {
+			$vars['role__in'] = Capability_Utils::normalize_roles_input( self::$elevated_roles );
+		}
 		return $vars;
 	}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -398,7 +398,7 @@ class Inactive_Users {
 					'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
 					// Note: role__in only filters by roles, not capabilities
 				// Users with elevated capabilities but not elevated roles won't be counted here
-				'role__in'     => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
+					'role__in'     => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
 				),
 			);
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -4,11 +4,13 @@ namespace Automattic\VIP\Security\InactiveUsers;
 use Automattic\VIP\Utils\Context;
 use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Inactive_Users {
-	private static $considered_inactive_after_days;
-	private static $elevated_roles;
-	private static $mode;
+	protected static $considered_inactive_after_days;
+	protected static $elevated_roles;
+	protected static $elevated_capabilities;
+	protected static $mode;
 	public static $release_date;
 
 	const LOG_FEATURE_NAME = 'sb_inactive_users';
@@ -33,6 +35,7 @@ class Inactive_Users {
 		self::$mode                           = $inactive_user_configs['mode'] ?? 'REPORT';
 		self::$considered_inactive_after_days = $inactive_user_configs['considered_inactive_after_days'] ?? 90;
 		self::$elevated_roles                 = $inactive_user_configs['roles'] ?? [ 'administrator' ];
+		self::$elevated_capabilities          = $inactive_user_configs['capabilities'] ?? [];
 
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );
@@ -259,6 +262,9 @@ class Inactive_Users {
 			// Track blocked users view
 			do_action( 'vip_security_blocked_users_view' );
 
+			// Note: This filter only works with roles, not capabilities, due to WP_User_Query limitations
+			// Users with elevated capabilities but not elevated roles won't appear in this filtered view
+			// However, they are still tracked and blocked correctly
 			$vars['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
 
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -357,6 +363,8 @@ class Inactive_Users {
 				'meta_compare' => '<',
 				'count_total'  => false,
 				'number'       => 1, // To minimize the query time, we only need to know if there are any blocked users to show the link
+				// Note: role__in only filters by roles, not capabilities
+				// Users with elevated capabilities but not elevated roles won't be counted here
 				'role__in'     => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
 			),
 		);
@@ -461,7 +469,7 @@ class Inactive_Users {
 			throw new \Exception( 'User not found' );
 		}
 
-		if ( ! self::user_with_elevated_roles( $user ) ) {
+		if ( ! self::user_has_elevated_permissions( $user ) ) {
 			return;
 		}
 
@@ -535,10 +543,17 @@ class Inactive_Users {
 			return false;
 		}
 
-		return self::user_with_elevated_roles( $user );
+		return self::user_has_elevated_permissions( $user );
 	}
 
-	private static function user_with_elevated_roles( $user ) {
+	protected static function user_has_elevated_permissions( $user ) {
+		/**
+		 * Filters the last seen elevated capabilities that are used to determine if the last seen should be checked.
+		 *
+		 * @param array $elevated_capabilities The elevated capabilities.
+		 */
+		$elevated_capabilities = apply_filters( 'vip_security_boost_inactive_users_elevated_capabilities', self::$elevated_capabilities );
+		
 		/**
 		 * Filters the last seen elevated roles that are used to determine if the last seen should be checked.
 		 *
@@ -546,17 +561,18 @@ class Inactive_Users {
 		 */
 		$elevated_roles = apply_filters( 'vip_security_boost_inactive_users_elevated_roles', self::$elevated_roles );
 
-		// Prevent infinite loops inside user_can() due to other security logic.
-		if ( is_automattician( $user->ID ) ) {
-			return true;
-		}
-
-		// Ensure $user->roles is defined and is an array before using it.
-		if ( isset( $user->roles ) && is_array( $user->roles ) && array_intersect( $elevated_roles, $user->roles ) ) {
-			return true;
-		}
-
-		return false;
+		return Capability_Utils::user_has_elevated_permissions( $user, $elevated_capabilities, $elevated_roles );
+	}
+	
+	/**
+	 * Check if user has elevated roles (deprecated, use user_has_elevated_permissions instead)
+	 * 
+	 * @deprecated Use user_has_elevated_permissions() instead
+	 * @param \WP_User $user The user to check.
+	 * @return bool True if user has elevated roles, false otherwise.
+	 */
+	private static function user_with_elevated_roles( $user ) {
+		return self::user_has_elevated_permissions( $user );
 	}
 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,18 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to function is_array\(\) with non\-empty\-array will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: modules/forced-mfa-users/class-forced-mfa-users.php
-
-		-
-			message: '#^Right side of && is always true\.$#'
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: modules/forced-mfa-users/class-forced-mfa-users.php
-
-		-
 			message: '#^Left side of && is always true\.$#'
 			identifier: booleanAnd.leftAlwaysTrue
 			count: 1

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,12 +3,13 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../utils/configs.php';
 require_once __DIR__ . '/../utils/class-configs.php';
-require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 require_once __DIR__ . '/../utils/class-constants.php';
-require_once __DIR__ . '/../email/class-email.php';
-require_once __DIR__ . '/../utils/class-logger.php';
-require_once __DIR__ . '/class-testable-logger.php';
 require_once __DIR__ . '/../utils/class-capability-utils.php';
+require_once __DIR__ . '/../utils/class-logger.php';
+require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
+require_once __DIR__ . '/../email/class-email.php';
+require_once __DIR__ . '/class-testable-logger.php';
+
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../utils/class-constants.php';
 require_once __DIR__ . '/../email/class-email.php';
 require_once __DIR__ . '/../utils/class-logger.php';
 require_once __DIR__ . '/class-testable-logger.php';
+require_once __DIR__ . '/../utils/class-capability-utils.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -15,7 +15,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		// Remove actions/filters added by the class
 		remove_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] );
 
-		// Reset the static capability property using reflection
+		// Reset the static properties using reflection
 		if ( class_exists( Forced_MFA_Users::class ) ) {
 			try {
 				$reflection = new ReflectionClass( Forced_MFA_Users::class );
@@ -23,6 +23,11 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 					$roles_prop = $reflection->getProperty( 'roles' );
 					$roles_prop->setAccessible( true );
 					$roles_prop->setValue( null, null ); // Reset to initial state
+				}
+				if ( $reflection->hasProperty( 'capabilities' ) ) {
+					$capabilities_prop = $reflection->getProperty( 'capabilities' );
+					$capabilities_prop->setAccessible( true );
+					$capabilities_prop->setValue( null, null ); // Reset to initial state
 				}
 				// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			} catch ( ReflectionException $e ) {
@@ -239,5 +244,127 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 		$this->setup_user_and_filter( 'administrator' );
 		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_should_force_two_factor returns false even if the user has the required capability.' );
+	}
+
+	/**
+	 * Test that capabilities take priority over roles
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_capabilities_priority() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 
+					'capabilities' => 'manage_options',
+					'roles'        => 'subscriber', // This should be ignored
+				],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		// Create administrator user (has manage_options capability but not subscriber role)
+		$this->setup_user_and_filter( 'administrator' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the required capability.' );
+	}
+
+	/**
+	 * Test single capability enforcement
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_single_capability() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'capabilities' => 'edit_posts' ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		// Administrator has edit_posts capability
+		$this->setup_user_and_filter( 'administrator' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the single required capability.' );
+	}
+
+	/**
+	 * Test user without required capability
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_user_lacks_capability() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'capabilities' => 'manage_options' ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		// Subscriber doesn't have manage_options capability
+		$this->setup_user_and_filter( 'subscriber' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks the required capability.' );
+	}
+
+	/**
+	 * Test multiple capabilities - user has one
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_array_capabilities_user_has_one() {
+		$capabilities = [ 'manage_options', 'edit_themes' ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 'capabilities' => $capabilities ],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		// Editor has edit_posts but not manage_options or edit_themes
+		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$user    = get_user_by( 'id', $user_id );
+		// Grant manage_options capability to editor
+		$user->add_cap( 'manage_options' );
+		wp_set_current_user( $user_id );
+		
+		Forced_MFA_Users::maybe_enforce_two_factor();
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
+	}
+
+	/**
+	 * Test empty capabilities array falls back to roles
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_empty_capabilities_uses_roles() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 
+					'capabilities' => [],
+					'roles'        => 'administrator',
+				],
+			],
+		] );
+		Forced_MFA_Users::init();
+
+		$this->setup_user_and_filter( 'administrator' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should use roles when capabilities array is empty.' );
+	}
+
+	/**
+	 * Test both capabilities and roles empty
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_init_does_not_add_action_when_both_capabilities_and_roles_empty() {
+		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [ 
+					'capabilities' => [],
+					'roles'        => [],
+				],
+			],
+		] );
+
+		Forced_MFA_Users::init();
+		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
 	}
 }

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -592,4 +592,206 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$sorted_args   = Highlight_MFA_Users::sort_columns( $args );
 		$this->assertEquals( $original_args, $sorted_args );
 	}
+
+	/**
+	 * Test that capabilities are used when configured instead of roles.
+	 */
+	public function test_capabilities_override_roles_when_configured() {
+		// Create users with different capabilities
+		$manage_options_user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$edit_posts_user_id     = $this->factory()->user->create( [ 'role' => 'editor' ] );
+		$author_user_id         = $this->factory()->user->create( [ 'role' => 'author' ] );
+		
+		// Set capabilities configuration using reflection
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [ 'manage_options' ] );
+		
+		// Clear the cache to force recalculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		
+		// Use reflection to access the private method
+		$method = $reflection_class->getMethod( 'get_mfa_disabled_count' );
+		$method->setAccessible( true );
+		$count = $method->invoke( null );
+		
+		// Only the users with manage_options capability should be counted
+		// This includes the admin user created above and the default admin (ID 1)
+		// Plus the admin_user_mfa_disabled_id from setUp
+		$expected_count = 3;
+		$this->assertEquals( $expected_count, $count );
+		
+		// Clean up
+		wp_delete_user( $manage_options_user_id );
+		wp_delete_user( $edit_posts_user_id );
+		wp_delete_user( $author_user_id );
+		
+		// Reset capabilities
+		$capabilities_property->setValue( null, [] );
+	}
+
+	/**
+	 * Test that roles are used as fallback when no capabilities are configured.
+	 */
+	public function test_roles_used_as_fallback_when_no_capabilities() {
+		// Ensure capabilities are empty
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [] );
+		
+		// Clear the cache to force recalculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		
+		// Use reflection to access the private method
+		$method = $reflection_class->getMethod( 'get_mfa_disabled_count' );
+		$method->setAccessible( true );
+		$count = $method->invoke( null );
+		
+		// Should count users with administrator and editor roles (default)
+		// admin_user_mfa_disabled_id, editor_user_id from setUp, plus default admin (ID 1)
+		$expected_count = 3;
+		$this->assertEquals( $expected_count, $count );
+	}
+
+	/**
+	 * Test admin notice displays correctly when using capabilities.
+	 */
+	public function test_display_mfa_disabled_notice_with_capabilities() {
+		$this->set_admin_screen_users();
+		
+		// Set capabilities configuration
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [ 'manage_options' ] );
+		
+		// Clear cache to ensure fresh count
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		
+		$expected_count  = 3; // Users with manage_options capability
+		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
+		$expected_output = sprintf(
+			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
+			sprintf(
+				/* translators: %d: Number of users. */
+				_n(
+					'There is %d user with high-privileges capabilities with Two-Factor Authentication disabled.',
+					'There are %d users with high-privileges capabilities with Two-Factor Authentication disabled.',
+					$expected_count,
+					'wpvip'
+				),
+				number_format_i18n( $expected_count )
+			),
+			esc_url( $filter_url ),
+			esc_html__( 'Filter list to show these users.', 'wpvip' )
+		);
+		
+		ob_start();
+		Highlight_MFA_Users::display_mfa_disabled_notice();
+		$output = ob_get_clean();
+		
+		$this->assertEquals( $expected_output, $output );
+		
+		// Reset capabilities
+		$capabilities_property->setValue( null, [] );
+	}
+
+	/**
+	 * Test filtering users by capabilities in the admin list.
+	 */
+	public function test_filter_users_by_capabilities_pre_query() {
+		$this->set_admin_screen_users();
+		$_GET['filter_mfa_disabled'] = '1';
+		
+		// Set capabilities configuration
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [ 'edit_posts' ] );
+		
+		$query = new \WP_User_Query();
+		
+		// Simulate the pre_get_users action
+		Highlight_MFA_Users::filter_users_by_mfa_status( $query );
+		
+		// The query should have meta_query set but NOT role__in
+		$meta_query = $query->get( 'meta_query' );
+		$role_in    = $query->get( 'role__in' );
+		
+		$this->assertIsArray( $meta_query );
+		$this->assertEmpty( $role_in ); // Should be empty when using capabilities
+		
+		// Reset
+		unset( $_GET['filter_mfa_disabled'] );
+		$capabilities_property->setValue( null, [] );
+	}
+
+	/**
+	 * Test capability-based SQL filtering.
+	 */
+	public function test_filter_users_by_capabilities_sql_modification() {
+		$this->set_admin_screen_users();
+		$_GET['filter_mfa_disabled'] = '1';
+		
+		// Set capabilities configuration
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [ 'manage_options', 'edit_posts' ] );
+		
+		// Create a mock query object
+		$query          = new \WP_User_Query();
+		$query->request = 'SELECT * FROM wp_users WHERE 1=1 ORDER BY user_login ASC';
+		
+		// Call the filter method
+		$result = Highlight_MFA_Users::filter_users_by_capabilities( null, $query );
+		
+		// Check that the SQL was modified to include capability checks
+		$this->assertStringContainsString( 'manage_options', $query->request );
+		$this->assertStringContainsString( 'edit_posts', $query->request );
+		$this->assertStringContainsString( 'capabilities', $query->request );
+		
+		// Reset
+		unset( $_GET['filter_mfa_disabled'] );
+		$capabilities_property->setValue( null, [] );
+	}
+
+	/**
+	 * Test that multiple capabilities work with OR logic.
+	 */
+	public function test_multiple_capabilities_use_or_logic() {
+		// Create users with different capabilities
+		$admin_user      = $this->factory()->user->create( [ 'role' => 'administrator' ] ); // has manage_options
+		$editor_user     = $this->factory()->user->create( [ 'role' => 'editor' ] ); // has edit_posts but not manage_options
+		$author_user     = $this->factory()->user->create( [ 'role' => 'author' ] ); // has edit_posts but not manage_options
+		$subscriber_user = $this->factory()->user->create( [ 'role' => 'subscriber' ] ); // has neither
+		
+		// Set multiple capabilities
+		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [ 'manage_options', 'edit_posts' ] );
+		
+		// Clear cache
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		
+		// Get count
+		$method = $reflection_class->getMethod( 'get_mfa_disabled_count' );
+		$method->setAccessible( true );
+		$count = $method->invoke( null );
+		
+		// Should include users with either manage_options OR edit_posts
+		// This includes: admin_user, editor_user, author_user, plus existing admin users
+		// But NOT subscriber_user
+		$this->assertGreaterThan( 3, $count ); // At least the new users plus existing admins
+		
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+		wp_delete_user( $author_user );
+		wp_delete_user( $subscriber_user );
+		$capabilities_property->setValue( null, [] );
+	}
 }

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -729,36 +729,6 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test capability-based SQL filtering.
-	 */
-	public function test_filter_users_by_capabilities_sql_modification() {
-		$this->set_admin_screen_users();
-		$_GET['filter_mfa_disabled'] = '1';
-		
-		// Set capabilities configuration
-		$reflection_class      = new \ReflectionClass( Highlight_MFA_Users::class );
-		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
-		$capabilities_property->setAccessible( true );
-		$capabilities_property->setValue( null, [ 'manage_options', 'edit_posts' ] );
-		
-		// Create a mock query object
-		$query          = new \WP_User_Query();
-		$query->request = 'SELECT * FROM wp_users WHERE 1=1 ORDER BY user_login ASC';
-		
-		// Call the filter method
-		$result = Highlight_MFA_Users::filter_users_by_capabilities( null, $query );
-		
-		// Check that the SQL was modified to include capability checks
-		$this->assertStringContainsString( 'manage_options', $query->request );
-		$this->assertStringContainsString( 'edit_posts', $query->request );
-		$this->assertStringContainsString( 'capabilities', $query->request );
-		
-		// Reset
-		unset( $_GET['filter_mfa_disabled'] );
-		$capabilities_property->setValue( null, [] );
-	}
-
-	/**
 	 * Test that multiple capabilities work with OR logic.
 	 */
 	public function test_multiple_capabilities_use_or_logic() {

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -670,15 +670,15 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Clear cache to ensure fresh count
 		Highlight_MFA_Users::clear_mfa_count_cache();
 		
-		$expected_count  = 3; // Users with manage_options capability
+		$expected_count  = 2; // Users with manage_options capability (admin_user_mfa_disabled_id + default admin ID 1)
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
 			sprintf(
 				/* translators: %d: Number of users. */
 				_n(
-					'There is %d user with high-privileges capabilities with Two-Factor Authentication disabled.',
-					'There are %d users with high-privileges capabilities with Two-Factor Authentication disabled.',
+					'There is %d user with Administrator or Editor roles with Two-Factor Authentication disabled.',
+					'There are %d users with Administrator or Editor roles with Two-Factor Authentication disabled.',
 					$expected_count,
 					'wpvip'
 				),

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -677,8 +677,8 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 			sprintf(
 				/* translators: %d: Number of users. */
 				_n(
-					'There is %d user with Administrator or Editor roles with Two-Factor Authentication disabled.',
-					'There are %d users with Administrator or Editor roles with Two-Factor Authentication disabled.',
+					'There is %d user with high-privileges with Two-Factor Authentication disabled.',
+					'There are %d users with high-privileges with Two-Factor Authentication disabled.',
 					$expected_count,
 					'wpvip'
 				),

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -266,6 +266,117 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that user with elevated capabilities is tracked
+	 */
+	public function test_user_with_elevated_capabilities_is_tracked() {
+		// Create a new instance with capability configuration
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function reset_for_test() {
+				self::$elevated_capabilities          = [ 'manage_options' ];
+				self::$elevated_roles                 = [];
+				self::$mode                           = 'BLOCK';
+				self::$considered_inactive_after_days = 90;
+			}
+			
+			public static function test_user_has_elevated_permissions( $user ) {
+				return parent::user_has_elevated_permissions( $user );
+			}
+		};
+		
+		$inactive_users_class::reset_for_test();
+		
+		// Create user with manage_options capability
+		$cap_user_id = $this->factory->user->create([
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$cap_user    = new WP_User( $cap_user_id );
+		$cap_user->add_cap( 'manage_options' );
+		
+		// User should have elevated permissions due to capability
+		$this->assertTrue( $inactive_users_class::test_user_has_elevated_permissions( $cap_user ) );
+		
+		wp_delete_user( $cap_user_id );
+	}
+
+	/**
+	 * Test that capabilities take priority over roles
+	 */
+	public function test_capabilities_take_priority_over_roles() {
+		// Create a new instance with both capability and role configuration
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function reset_for_test() {
+				self::$elevated_capabilities          = [ 'edit_posts' ];
+				self::$elevated_roles                 = [ 'administrator' ];
+				self::$mode                           = 'BLOCK';
+				self::$considered_inactive_after_days = 90;
+			}
+			
+			public static function test_user_has_elevated_permissions( $user ) {
+				return parent::user_has_elevated_permissions( $user );
+			}
+		};
+		
+		$inactive_users_class::reset_for_test();
+		
+		// Create user with only the capability, not the role
+		$cap_user_id = $this->factory->user->create([
+			'role'            => 'subscriber',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$cap_user    = new WP_User( $cap_user_id );
+		$cap_user->add_cap( 'edit_posts' );
+		
+		// User should have elevated permissions due to capability even without admin role
+		$this->assertTrue( $inactive_users_class::test_user_has_elevated_permissions( $cap_user ) );
+		
+		wp_delete_user( $cap_user_id );
+	}
+
+	/**
+	 * Test backward compatibility - roles still work when no capabilities configured
+	 */
+	public function test_backward_compatibility_roles_work_without_capabilities() {
+		// Create a new instance with only role configuration (no capabilities)
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function reset_for_test() {
+				self::$elevated_capabilities          = [];
+				self::$elevated_roles                 = [ 'editor' ];
+				self::$mode                           = 'BLOCK';
+				self::$considered_inactive_after_days = 90;
+			}
+			
+			public static function test_user_has_elevated_permissions( $user ) {
+				return parent::user_has_elevated_permissions( $user );
+			}
+		};
+		
+		$inactive_users_class::reset_for_test();
+		
+		// Create user with editor role
+		$editor_user_id = $this->factory->user->create([
+			'role'            => 'editor',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$editor_user    = new WP_User( $editor_user_id );
+		
+		// User should have elevated permissions due to role
+		$this->assertTrue( $inactive_users_class::test_user_has_elevated_permissions( $editor_user ) );
+		
+		// Create user without elevated role
+		$subscriber_user_id = $this->factory->user->create([
+			'role'            => 'subscriber',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$subscriber_user    = new WP_User( $subscriber_user_id );
+		
+		// User should not have elevated permissions
+		$this->assertFalse( $inactive_users_class::test_user_has_elevated_permissions( $subscriber_user ) );
+		
+		wp_delete_user( $editor_user_id );
+		wp_delete_user( $subscriber_user_id );
+	}
+
+	/**
 	 * Test that modify_users_list_table_items works with WP_MS_Users_List_Table for multisite
 	 */
 	public function test_modify_users_list_table_items_works_with_multisite_table() {
@@ -306,6 +417,32 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '.inactive-user-badge--inactive', $output );
 		$this->assertStringContainsString( 'background: #d63638', $output );
 		$this->assertStringContainsString( 'background: #f0b849', $output );
+	}
+
+	/**
+	 * Test capability filter
+	 */
+	public function test_capability_filter() {
+		// Create a test to verify the filter works
+		$test_capabilities = [ 'custom_capability', 'another_capability' ];
+		
+		add_filter( 'vip_security_boost_inactive_users_elevated_capabilities', function () use ( $test_capabilities ) {
+			return $test_capabilities;
+		});
+		
+		// Create instance to test filter application
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function get_test_capabilities() {
+				$capabilities = self::$elevated_capabilities ?? [];
+				return apply_filters( 'vip_security_boost_inactive_users_elevated_capabilities', $capabilities );
+			}
+		};
+		
+		$filtered_caps = $inactive_users_class::get_test_capabilities();
+		$this->assertEquals( $test_capabilities, $filtered_caps );
+		
+		// Clean up
+		remove_all_filters( 'vip_security_boost_inactive_users_elevated_capabilities' );
 	}
 
 	/**

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -74,11 +74,7 @@ class Capability_Utils {
 			return false;
 		}
 		
-		if ( ! is_array( $user->roles ) ) {
-			return false;
-		}
-		
-		return ! empty( array_intersect( $roles, $user->roles ) );
+		return ! empty( array_intersect( $roles, $user->roles ?? [] ) );
 	}
 	
 	/**

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -26,7 +26,7 @@ class Capability_Utils {
 			return false;
 		}
 		
-		if ( is_automattician( $user->ID ) ) {
+		if ( function_exists( 'is_automattician' ) && is_automattician( $user->ID ) ) {
 			return true;
 		}
 		

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Automattic\VIP\Security\Utils;
+
+/**
+ * Utility class for handling capability-based user permission checks.
+ * 
+ * This class provides a centralized way to check user permissions using
+ * capabilities with role fallback across all VIP Security Boost modules.
+ * 
+ * Pattern: Capabilities take priority over roles. If capabilities are configured,
+ * roles are ignored. If no capabilities are configured, roles are used as fallback.
+ */
+class Capability_Utils {
+	
+	/**
+	 * Check if a user has elevated permissions based on capabilities or roles.
+	 * 
+	 * @param \WP_User $user The user to check.
+	 * @param array $capabilities Array of capabilities to check (OR logic).
+	 * @param array $roles Array of roles to check if no capabilities configured.
+	 * @return bool True if user has elevated permissions, false otherwise.
+	 */
+	public static function user_has_elevated_permissions( $user, $capabilities = [], $roles = [] ): bool {
+		if ( ! $user || ! $user->exists() ) {
+			return false;
+		}
+		
+		if ( is_automattician( $user->ID ) ) {
+			return true;
+		}
+		
+		$capabilities = self::normalize_capabilities_input( $capabilities );
+		$roles        = self::normalize_roles_input( $roles );
+		
+		if ( ! empty( $capabilities ) ) {
+			return self::user_has_any_capability( $user, $capabilities );
+		}
+		
+		return self::user_has_any_role( $user, $roles );
+	}
+	
+	/**
+	 * Check if a user has any of the specified capabilities (OR logic).
+	 * 
+	 * @param \WP_User $user The user to check.
+	 * @param array $capabilities Array of capabilities to check.
+	 * @return bool True if user has any of the capabilities, false otherwise.
+	 */
+	public static function user_has_any_capability( $user, $capabilities ): bool {
+		if ( ! $user || ! $user->exists() || empty( $capabilities ) ) {
+			return false;
+		}
+		
+		foreach ( $capabilities as $capability ) {
+			// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is from configuration
+			if ( user_can( $user, $capability ) ) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Check if a user has any of the specified roles (OR logic).
+	 * 
+	 * @param \WP_User $user The user to check.
+	 * @param array $roles Array of roles to check.
+	 * @return bool True if user has any of the roles, false otherwise.
+	 */
+	public static function user_has_any_role( $user, $roles ): bool {
+		if ( ! $user || ! $user->exists() || empty( $roles ) ) {
+			return false;
+		}
+		
+		if ( ! isset( $user->roles ) || ! is_array( $user->roles ) ) {
+			return false;
+		}
+		
+		return ! empty( array_intersect( $roles, $user->roles ) );
+	}
+	
+	/**
+	 * Normalize capabilities input to ensure it's a filtered array.
+	 * 
+	 * @param mixed $capabilities Input capabilities (string, array, or other).
+	 * @return array Normalized capabilities array.
+	 */
+	public static function normalize_capabilities_input( $capabilities ): array {
+		if ( empty( $capabilities ) ) {
+			return [];
+		}
+		
+		if ( is_string( $capabilities ) ) {
+			$capabilities = [ $capabilities ];
+		}
+		
+		if ( ! is_array( $capabilities ) ) {
+			return [];
+		}
+		
+		return array_filter( $capabilities, function ( $cap ) {
+			return is_string( $cap ) && ! empty( trim( $cap ) );
+		} );
+	}
+	
+	/**
+	 * Normalize roles input to ensure it's a filtered array.
+	 * 
+	 * @param mixed $roles Input roles (string, array, or other).
+	 * @return array Normalized roles array.
+	 */
+	public static function normalize_roles_input( $roles ): array {
+		if ( empty( $roles ) ) {
+			return [];
+		}
+		
+		if ( is_string( $roles ) ) {
+			$roles = [ $roles ];
+		}
+		
+		if ( ! is_array( $roles ) ) {
+			return [];
+		}
+		
+		return array_filter( $roles, function ( $role ) {
+			return is_string( $role ) && ! empty( trim( $role ) );
+		} );
+	}
+	
+	/**
+	 * Get a user-friendly description of the privilege type being used.
+	 * 
+	 * @param array $capabilities Configured capabilities.
+	 * @param array $roles Configured roles.
+	 * @return string Description like "elevated capabilities" or "elevated roles".
+	 */
+	public static function get_privilege_type_description( $capabilities, $roles ): string {
+		$capabilities = self::normalize_capabilities_input( $capabilities );
+		$roles        = self::normalize_roles_input( $roles );
+		
+		if ( ! empty( $capabilities ) ) {
+			return count( $capabilities ) === 1 ? 'elevated capability' : 'elevated capabilities';
+		}
+		
+		if ( ! empty( $roles ) ) {
+			return count( $roles ) === 1 ? 'elevated role' : 'elevated roles';
+		}
+		
+		return 'elevated permissions';
+	}
+	
+	/**
+	 * Get a comma-separated list of the configured capabilities or roles.
+	 * 
+	 * @param array $capabilities Configured capabilities.
+	 * @param array $roles Configured roles.
+	 * @return string Comma-separated list of capabilities or roles.
+	 */
+	public static function get_privilege_list( $capabilities, $roles ): string {
+		$capabilities = self::normalize_capabilities_input( $capabilities );
+		$roles        = self::normalize_roles_input( $roles );
+		
+		if ( ! empty( $capabilities ) ) {
+			return implode( ', ', $capabilities );
+		}
+		
+		if ( ! empty( $roles ) ) {
+			return implode( ', ', $roles );
+		}
+		
+		return '';
+	}
+	
+	/**
+	 * Check if capabilities are configured (not empty after normalization).
+	 * 
+	 * @param mixed $capabilities Input capabilities to check.
+	 * @return bool True if capabilities are configured, false otherwise.
+	 */
+	public static function are_capabilities_configured( $capabilities ): bool {
+		return ! empty( self::normalize_capabilities_input( $capabilities ) );
+	}
+	
+	/**
+	 * Apply filters to capabilities and roles for a specific module.
+	 * 
+	 * @param string $module_name The module name (e.g., 'highlight_mfa_users').
+	 * @param array $capabilities Default capabilities.
+	 * @param array $roles Default roles.
+	 * @return array Associative array with 'capabilities' and 'roles' keys.
+	 */
+	public static function apply_module_filters( $module_name, $capabilities, $roles ): array {
+		$capabilities = self::normalize_capabilities_input( $capabilities );
+		$roles        = self::normalize_roles_input( $roles );
+		
+		$capabilities = apply_filters( 
+			"vip_security_boost_{$module_name}_elevated_capabilities", 
+			$capabilities 
+		);
+		
+		$roles = apply_filters( 
+			"vip_security_boost_{$module_name}_elevated_roles", 
+			$roles 
+		);
+		
+		return [
+			'capabilities' => self::normalize_capabilities_input( $capabilities ),
+			'roles'        => self::normalize_roles_input( $roles ),
+		];
+	}
+}

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -74,7 +74,7 @@ class Capability_Utils {
 			return false;
 		}
 		
-		return ! empty( array_intersect( $roles, $user->roles ?? [] ) );
+		return ! empty( array_intersect( $roles, $user->roles ) );
 	}
 	
 	/**

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -16,13 +16,13 @@ class Capability_Utils {
 	/**
 	 * Check if a user has elevated permissions based on capabilities or roles.
 	 * 
-	 * @param \WP_User $user The user to check.
+	 * @param \WP_User|false|null $user The user to check.
 	 * @param array $capabilities Array of capabilities to check (OR logic).
 	 * @param array $roles Array of roles to check if no capabilities configured.
 	 * @return bool True if user has elevated permissions, false otherwise.
 	 */
 	public static function user_has_elevated_permissions( $user, $capabilities = [], $roles = [] ): bool {
-		if ( ! $user || ! $user->exists() ) {
+		if ( ! ( $user instanceof \WP_User ) || ! $user->exists() ) {
 			return false;
 		}
 		
@@ -43,12 +43,12 @@ class Capability_Utils {
 	/**
 	 * Check if a user has any of the specified capabilities (OR logic).
 	 * 
-	 * @param \WP_User $user The user to check.
+	 * @param \WP_User|false|null $user The user to check.
 	 * @param array $capabilities Array of capabilities to check.
 	 * @return bool True if user has any of the capabilities, false otherwise.
 	 */
 	public static function user_has_any_capability( $user, $capabilities ): bool {
-		if ( ! $user || ! $user->exists() || empty( $capabilities ) ) {
+		if ( ! ( $user instanceof \WP_User ) || ! $user->exists() || empty( $capabilities ) ) {
 			return false;
 		}
 		
@@ -65,16 +65,16 @@ class Capability_Utils {
 	/**
 	 * Check if a user has any of the specified roles (OR logic).
 	 * 
-	 * @param \WP_User $user The user to check.
+	 * @param \WP_User|false|null $user The user to check.
 	 * @param array $roles Array of roles to check.
 	 * @return bool True if user has any of the roles, false otherwise.
 	 */
 	public static function user_has_any_role( $user, $roles ): bool {
-		if ( ! $user || ! $user->exists() || empty( $roles ) ) {
+		if ( ! ( $user instanceof \WP_User ) || ! $user->exists() || empty( $roles ) ) {
 			return false;
 		}
 		
-		if ( ! isset( $user->roles ) || ! is_array( $user->roles ) ) {
+		if ( ! is_array( $user->roles ) ) {
 			return false;
 		}
 		

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -17,6 +17,7 @@ declare(strict_types = 1);
 
 require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/utils/class-configs.php';
+require_once __DIR__ . '/utils/class-capability-utils.php';
 require_once __DIR__ . '/email/class-email.php';
 require_once __DIR__ . '/utils/class-constants.php';
 require_once __DIR__ . '/utils/class-logger.php';


### PR DESCRIPTION
## Description

This PR implements `capabilities` support across VIP Security Boost modules.

The implementation follows a consistent pattern where _capabilities take priority over roles when both are configured_. If no capabilities are specified, the modules fall back to using roles as before, ensuring backward compatibility.

We will deprecate Roles once we have migrated all Beta customers to capabilities.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Set capabilities to lowest privilege: `read`

```bash
curl -X POST "http://localhost:2999/v1/vip-integrations/backend/integration" -H "Content-Type: application/json" --data '{
  "slug": "security-boost",
  "level": "site",
  "site_id": 101,
  "status": "enabled",
  "config": {
  "enabled_modules": ["highlight-mfa-users","forced-mfa-users", "inactive-users", "notify-privileged-activity"],
  "module_configs": {
    "forced-mfa-users": {
      "capabilities": ["read"]
      },
    "highlight-mfa-users": {
      "capabilities": ["read"]
      },
    "inactive-users": {
      "mode": "BLOCK",
      "considered_inactive_after_days": 14,
      "capabilities": ["read"]
      }
    }
  }
}' | jq
```

2. Test highlight-mfa-users

- Expected: **3 users** should be highlighted (`VIP Support` and `wpcomvip` users are excluded)

```bash
#admin user
vip dev-env exec --slug=vip-security-boost -- wp user generate --role=administrator --count=1 --format=ids
# subscriber user
vip dev-env exec --slug=vip-security-boost -- wp user create subscriber subscriber@automattic.com --role=subscriber --display_name=subscriber --user_pass=password
# vip support user
vip dev-env exec --slug=vip-security-boost -- wp vipsupport create-user vip_katrina vip_katrina@automattic.com password123 --display-name="KT"
# wpcomvip user
vip dev-env exec --slug=vip-security-boost -- wp user create wpcomvip wpcomvip@automattic.com --role=administrator --display_name=wpcomvip --user_pass=password
```

3. Test forced-mfa-users

- Add this in `vip-security-boost.php`

```
add_filter( 'wpcom_vip_is_two_factor_local_testing', '__return_true' );
```

- Login as username: `subscriber` and password: `password`
- Verify that 2FA is required

4. Test inactive-users

- Run the following command

```bash
#set last seen
vip dev-env exec -- wp user meta set 2 wpvip_last_seen 1699459200
vip dev-env exec -- wp user meta set 2 wpvip_last_seen_ignore_inactivity_check_until 1699459200
vip dev-env exec -- wp user update 2 --user_registered='2024-01-15 10:00:00'
```

- Refresh users list
- Verify that subscriber user is blocked
