### PR TITLE
[PLTFRM-1297] Add inactive users count to Site Details Service (SDS)

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -20,6 +20,8 @@ class Inactive_Users {
 	const LAST_SEEN_UPDATE_USER_META_CACHE_TTL             = MINUTE_IN_SECONDS * 5; // Store last seen once every five minute to avoid too many write DB operations
 	const BLOCKED_USERS_CACHE_KEY                          = 'wpvip_blocked_users_';
 	const BLOCKED_USERS_CACHE_TTL                          = MINUTE_IN_SECONDS * 5;
+	const INACTIVE_USERS_COUNT_CACHE_KEY                   = 'wpvip_inactive_users_count_';
+	const INACTIVE_USERS_COUNT_CACHE_TTL                   = MINUTE_IN_SECONDS * 5;
 	const LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY      = 'wpvip_last_seen_release_date_timestamp';
 
 	/**
@@ -301,14 +303,31 @@ class Inactive_Users {
 	public static function get_inactive_users_count( $blog_id = null ) {
 		$blog_id = $blog_id ?? get_current_blog_id();
 
+		// Use global cache for network-wide queries (blog_id = 0)
+		if ( 0 === $blog_id ) {
+			$cache_key    = self::get_inactive_users_count_cache_key( $blog_id );
+			$cached_count = wp_cache_get( $cache_key, self::LAST_SEEN_CACHE_GROUP );
+
+			if ( false !== $cached_count ) {
+				return $cached_count;
+			}
+		}
+
 		$args = array_merge( [
 			'blog_id'     => $blog_id,
 			'count_total' => true,
 		], self::get_inactive_users_query_args() );
 
 		$users_query = new \WP_User_Query( $args );
+		$count       = $users_query->get_total();
 
-		return $users_query->get_total();
+		// Cache the result for global queries (blog_id = 0)
+		if ( 0 === $blog_id ) {
+			$cache_key = self::get_inactive_users_count_cache_key( $blog_id );
+			wp_cache_set( $cache_key, $count, self::LAST_SEEN_CACHE_GROUP, self::INACTIVE_USERS_COUNT_CACHE_TTL ); // phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		}
+
+		return $count;
 	}
 
 	public static function get_inactive_users_query_args() {
@@ -432,6 +451,24 @@ class Inactive_Users {
 		return self::BLOCKED_USERS_CACHE_KEY . ( is_network_admin() ? null : get_current_blog_id() );
 	}
 
+	public static function get_inactive_users_count_cache_key( $blog_id ) {
+		return self::INACTIVE_USERS_COUNT_CACHE_KEY . $blog_id;
+	}
+
+	public static function flush_cache() {
+		// Clear blocked users cache
+		$cache_key = self::get_blocked_users_cache_key();
+		wp_cache_delete( $cache_key, self::LAST_SEEN_CACHE_GROUP );
+
+		// Clear inactive users count cache for current blog
+		$inactive_users_cache_key = self::get_inactive_users_count_cache_key( get_current_blog_id() );
+		wp_cache_delete( $inactive_users_cache_key, self::LAST_SEEN_CACHE_GROUP );
+
+		// Clear inactive users count cache for global queries
+		$inactive_users_cache_key = self::get_inactive_users_count_cache_key( 0 );
+		wp_cache_delete( $inactive_users_cache_key, self::LAST_SEEN_CACHE_GROUP );
+	}
+
 	/**
 	 * Add blocked users filter to users list table, active only when BLOCK mode is enabled
 	 *
@@ -531,9 +568,7 @@ class Inactive_Users {
 			$user_role = $user && ! empty( $user->roles ) ? $user->roles[0] : '';
 			do_action( 'vip_security_user_unblock', $user_id, $user_role );
 
-			$cache_key = self::get_blocked_users_cache_key();
-			// clearing the cache
-			wp_cache_delete( $cache_key, self::LAST_SEEN_CACHE_GROUP );
+			self::flush_cache();
 		}
 
 		if ( $error ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -85,10 +85,10 @@ class Inactive_Users {
 		}
 
 		// Add SDS hook
-		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'get_site_details_index_data' ] );
+		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'add_inactive_users_count_to_sds_payload' ] );
 	}
 
-	public static function get_site_details_index_data( $data ) {
+	public static function add_inactive_users_count_to_sds_payload( $data ) {
 		if ( ! isset( $data[ Constants::SDS_DATA_KEY ] ) ) {
 			$data[ Constants::SDS_DATA_KEY ] = array();
 		}
@@ -96,17 +96,25 @@ class Inactive_Users {
 		// Start timer to measure query time
 		$timer = microtime( true );
 
-		// Get number of inactive users
+		// Get number of inactive users for current blog
 		$inactive_users_count = self::get_inactive_users_count();
+
+		// Add inactive users count for the current blog to the SDS payload
+		$data[ Constants::SDS_DATA_KEY ]['inactive_users_count'] = $inactive_users_count;
+
+		if ( is_multisite() ) {
+			// Get number of inactive users for all blogs (network-wide with blog_id = 0)
+			$inactive_users_count_all_blogs = self::get_inactive_users_count( 0 );
+
+			// Add network-wide inactive users count to the SDS payload
+			$data[ Constants::SDS_DATA_KEY ]['inactive_users_count_all_blogs'] = $inactive_users_count_all_blogs;
+		}
 
 		// Stop timer
 		$timer = microtime( true ) - $timer;
 
 		// Register query time metric
 		do_action( 'vip_security_inactive_users_query_time', $timer );
-
-		// Add inactive users count to SDS data
-		$data[ Constants::SDS_DATA_KEY ]['inactive_users_count'] = $inactive_users_count;
 
 		return $data;
 	}
@@ -290,8 +298,11 @@ class Inactive_Users {
 		return $vars;
 	}
 
-	public static function get_inactive_users_count() {
+	public static function get_inactive_users_count( $blog_id = null ) {
+		$blog_id = $blog_id ?? get_current_blog_id();
+
 		$args = array_merge( [
+			'blog_id'     => $blog_id,
 			'count_total' => true,
 		], self::get_inactive_users_query_args() );
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -4,6 +4,7 @@ namespace Automattic\VIP\Security\InactiveUsers;
 use Automattic\VIP\Utils\Context;
 use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Constants;
 
 class Inactive_Users {
 	private static $considered_inactive_after_days;
@@ -82,6 +83,32 @@ class Inactive_Users {
 
 			add_action( 'admin_init', [ __CLASS__, 'last_seen_unblock_action' ] );
 		}
+
+		// Add SDS hook
+		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'get_site_details_index_data' ] );
+	}
+
+	public static function get_site_details_index_data( $data ) {
+		if ( ! isset( $data[ Constants::SDS_DATA_KEY ] ) ) {
+			$data[ Constants::SDS_DATA_KEY ] = array();
+		}
+
+		// Start timer to measure query time
+		$timer = microtime( true );
+
+		// Get number of inactive users
+		$inactive_users_count = self::get_inactive_users_count();
+
+		// Stop timer
+		$timer = microtime( true ) - $timer;
+
+		// Register query time metric
+		do_action( 'vip_security_inactive_users_query_time', $timer );
+
+		// Add inactive users count to SDS data
+		$data[ Constants::SDS_DATA_KEY ]['inactive_users_count'] = $inactive_users_count;
+
+		return $data;
 	}
 
 	public static function record_activity( $user_id ) {
@@ -263,6 +290,46 @@ class Inactive_Users {
 		return $vars;
 	}
 
+	public static function get_inactive_users_count() {
+		$args = array_merge( [
+			'count_total' => true,
+		], self::get_inactive_users_query_args() );
+
+		$users_query = new \WP_User_Query( $args );
+
+		return $users_query->get_total();
+	}
+
+	public static function get_inactive_users_query_args() {
+		$vars = array(
+			// Only consider users that registered before the inactivity threshold
+			'date_query' => array(
+				array(
+					'before' => gmdate( 'Y-m-d H:i:s', self::get_inactivity_timestamp() ),
+				),
+			),
+
+			// Only consider users with roles we want to target
+			'role__in'   => ! empty( self::$elevated_roles ) ? self::$elevated_roles : array(),
+
+			// Only consider users that have not been active since the inactivity threshold
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query' => array(
+				[
+					'relation' => 'AND',
+					[
+						'key'     => self::LAST_SEEN_META_KEY,
+						'value'   => self::get_inactivity_timestamp(),
+						'type'    => 'NUMERIC',
+						'compare' => '<',
+					],
+				],
+			),
+		);
+
+		return $vars;
+	}
+
 	/**
 	 * Filter users list table to show only blocked users, active only when BLOCK mode is enabled
 	 */
@@ -277,18 +344,7 @@ class Inactive_Users {
 			// Track blocked users view
 			do_action( 'vip_security_blocked_users_view' );
 
-			$vars['role__in'] = ! empty( self::$elevated_roles ) ? self::$elevated_roles : array();
-
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-			$vars['meta_query'] = [
-				'relation' => 'AND',
-				[
-					'key'     => self::LAST_SEEN_META_KEY,
-					'value'   => self::get_inactivity_timestamp(),
-					'type'    => 'NUMERIC',
-					'compare' => '<',
-				],
-			];
+			return array_merge( $vars, self::get_inactive_users_query_args() );
 		}
 
 		return $vars;
@@ -629,11 +685,6 @@ class Inactive_Users {
 					'user_id' => $user_id,
 				)
 			);
-			return false;
-		}
-
-		// Exclude wpcomvip user from inactivity checks
-		if ( Configs::get_bot_login() === $user->user_login ) {
 			return false;
 		}
 

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -439,4 +439,84 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		wp_delete_user( $inactive_user_1 );
 		wp_delete_user( $inactive_user_2 );
 	}
+
+	/**
+	 * Test that get_site_details_index_data returns correct counts for multisite networks
+	 * Each site should have its own count of inactive users
+	 */
+	public function test_get_site_details_index_data_multisite_counts() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create two additional sites
+		$site_1_id = $this->factory->blog->create();
+		$site_2_id = $this->factory->blog->create();
+
+		// Create users for site 1
+		$site_1_user_1 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$site_1_user_2 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+
+		// Create users for site 2
+		$site_2_user_1 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$site_2_user_2 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$site_2_user_3 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+
+		// Switch to site 1 and add users to it
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_1_id );
+		add_user_to_blog( $site_1_id, $site_1_user_1, 'administrator' );
+		add_user_to_blog( $site_1_id, $site_1_user_2, 'administrator' );
+
+		// Make site 1 users inactive
+		update_user_meta( $site_1_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		update_user_meta( $site_1_user_2, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Test site 1 count - role__in in WP_User_Query filters by current site roles,
+		// so only users with administrator role on site 1 are counted
+		$site_1_result = Inactive_Users::get_site_details_index_data( [] );
+		$this->assertEquals( 2, $site_1_result['vip_security_boost']['inactive_users_count'], 'Site 1 should count 2 inactive users with roles on this site' );
+
+		restore_current_blog();
+
+		// Switch to site 2 and add users to it
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_2_id );
+		add_user_to_blog( $site_2_id, $site_2_user_1, 'administrator' );
+		add_user_to_blog( $site_2_id, $site_2_user_2, 'administrator' );
+		add_user_to_blog( $site_2_id, $site_2_user_3, 'administrator' );
+
+		// Make site 2 users inactive
+		update_user_meta( $site_2_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		update_user_meta( $site_2_user_2, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		update_user_meta( $site_2_user_3, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Test site 2 count - only users with administrator role on site 2 are counted
+		$site_2_result = Inactive_Users::get_site_details_index_data( [] );
+		$this->assertEquals( 3, $site_2_result['vip_security_boost']['inactive_users_count'], 'Site 2 should count 3 inactive users with roles on this site' );
+
+		restore_current_blog();
+
+		// Clean up users
+		wp_delete_user( $site_1_user_1 );
+		wp_delete_user( $site_1_user_2 );
+		wp_delete_user( $site_2_user_1 );
+		wp_delete_user( $site_2_user_2 );
+		wp_delete_user( $site_2_user_3 );
+	}
 }

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -397,7 +397,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 */
 	public function test_vip_site_details_index_data_filter_is_added() {
 		// Verify the filter is added during init
-		$this->assertNotFalse( has_filter( 'vip_site_details_index_data', [ 'Automattic\VIP\Security\InactiveUsers\Inactive_Users', 'get_site_details_index_data' ] ) );
+		$this->assertNotFalse( has_filter( 'vip_site_details_index_data', [ 'Automattic\VIP\Security\InactiveUsers\Inactive_Users', 'add_inactive_users_count_to_sds_payload' ] ) );
 
 		// Test that the filter works by applying it
 		$initial_data  = [ 'some_key' => 'some_value' ];
@@ -406,16 +406,18 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Verify the filter was applied and our data was added
 		$this->assertArrayHasKey( 'vip_security_boost', $filtered_data );
 		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data['vip_security_boost'] );
+		$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data['vip_security_boost'] );
 		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count'] );
+		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count_all_blogs'] );
 
 		// Verify original data is preserved
 		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
 	}
 
 	/**
-	 * Test that get_site_details_index_data returns correct count for inactive users
+	 * Test that add_inactive_users_count_to_sds_payload returns correct count for inactive users
 	 */
-	public function test_get_site_details_index_data_returns_correct_count() {
+	public function test_add_inactive_users_count_to_sds_payload_returns_correct_count() {
 		// Create additional inactive users
 		$inactive_user_1 = $this->factory->user->create([
 			'role'            => 'administrator',
@@ -430,7 +432,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		update_user_meta( $inactive_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 		update_user_meta( $inactive_user_2, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 
-		$result = Inactive_Users::get_site_details_index_data( [] );
+		$result = Inactive_Users::add_inactive_users_count_to_sds_payload( [] );
 
 		// Should have 3 inactive users (the ones we created)
 		$this->assertEquals( 2, $result['vip_security_boost']['inactive_users_count'] );
@@ -441,10 +443,10 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_site_details_index_data returns correct counts for multisite networks
+	 * Test that add_inactive_users_count_to_sds_payload returns correct counts for multisite networks
 	 * Each site should have its own count of inactive users
 	 */
-	public function test_get_site_details_index_data_multisite_counts() {
+	public function test_add_inactive_users_count_to_sds_payload_multisite_counts() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'This test requires multisite to be enabled' );
 		}
@@ -489,7 +491,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		// Test site 1 count - role__in in WP_User_Query filters by current site roles,
 		// so only users with administrator role on site 1 are counted
-		$site_1_result = Inactive_Users::get_site_details_index_data( [] );
+		$site_1_result = Inactive_Users::add_inactive_users_count_to_sds_payload( [] );
 		$this->assertEquals( 2, $site_1_result['vip_security_boost']['inactive_users_count'], 'Site 1 should count 2 inactive users with roles on this site' );
 
 		restore_current_blog();
@@ -507,10 +509,14 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		update_user_meta( $site_2_user_3, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 
 		// Test site 2 count - only users with administrator role on site 2 are counted
-		$site_2_result = Inactive_Users::get_site_details_index_data( [] );
+		$site_2_result = Inactive_Users::add_inactive_users_count_to_sds_payload( [] );
 		$this->assertEquals( 3, $site_2_result['vip_security_boost']['inactive_users_count'], 'Site 2 should count 3 inactive users with roles on this site' );
 
 		restore_current_blog();
+
+		// Test network-wide count - all users with administrator role are counted
+		$network_result = Inactive_Users::add_inactive_users_count_to_sds_payload( [] );
+		$this->assertEquals( 5, $network_result['vip_security_boost']['inactive_users_count_all_blogs'], 'Network-wide should count 5 inactive users with roles on any site' );
 
 		// Clean up users
 		wp_delete_user( $site_1_user_1 );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -406,9 +406,13 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Verify the filter was applied and our data was added
 		$this->assertArrayHasKey( 'vip_security_boost', $filtered_data );
 		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data['vip_security_boost'] );
-		$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data['vip_security_boost'] );
 		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count'] );
-		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count_all_blogs'] );
+		
+		// Verify the network-wide count is added only in multisite
+		if ( is_multisite() ) {
+			$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data['vip_security_boost'] );
+			$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count_all_blogs'] );
+		}
 
 		// Verify original data is preserved
 		$this->assertEquals( 'some_value', $filtered_data['some_key'] );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -518,6 +518,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		restore_current_blog();
 
+		// Flush cache to ensure accurate counts
+		Inactive_Users::flush_cache();
+
 		// Test network-wide count - all users with administrator role are counted
 		$network_result = Inactive_Users::add_inactive_users_count_to_sds_payload( [] );
 		$this->assertEquals( 5, $network_result['vip_security_boost']['inactive_users_count_all_blogs'], 'Network-wide should count 5 inactive users with roles on any site' );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -391,4 +391,52 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertTrue( Inactive_Users::is_considered_inactive( $new_user_id ) );
 		wp_delete_user( $new_user_id );
 	}
+
+	/**
+	 * Test that the vip_site_details_index_data filter is added and works correctly
+	 */
+	public function test_vip_site_details_index_data_filter_is_added() {
+		// Verify the filter is added during init
+		$this->assertNotFalse( has_filter( 'vip_site_details_index_data', [ 'Automattic\VIP\Security\InactiveUsers\Inactive_Users', 'get_site_details_index_data' ] ) );
+
+		// Test that the filter works by applying it
+		$initial_data  = [ 'some_key' => 'some_value' ];
+		$filtered_data = apply_filters( 'vip_site_details_index_data', $initial_data );
+
+		// Verify the filter was applied and our data was added
+		$this->assertArrayHasKey( 'vip_security_boost', $filtered_data );
+		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data['vip_security_boost'] );
+		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count'] );
+
+		// Verify original data is preserved
+		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
+	}
+
+	/**
+	 * Test that get_site_details_index_data returns correct count for inactive users
+	 */
+	public function test_get_site_details_index_data_returns_correct_count() {
+		// Create additional inactive users
+		$inactive_user_1 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		$inactive_user_2 = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+
+		// Make them inactive by setting old last seen timestamps
+		update_user_meta( $inactive_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		update_user_meta( $inactive_user_2, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		$result = Inactive_Users::get_site_details_index_data( [] );
+
+		// Should have 3 inactive users (the ones we created)
+		$this->assertEquals( 2, $result['vip_security_boost']['inactive_users_count'] );
+
+		// Clean up
+		wp_delete_user( $inactive_user_1 );
+		wp_delete_user( $inactive_user_2 );
+	}
 }

--- a/utils/class-collector.php
+++ b/utils/class-collector.php
@@ -19,7 +19,7 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 	private Counter $blocked_users_view_counter;
 	private Counter $user_unblock_counter;
 	private Counter $privileged_email_sent_counter;
-	private Gauge $inactive_users_query_time_ms;
+	private Gauge $inactive_users_query_time;
 
 	public function initialize( RegistryInterface $registry ): void {
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(
@@ -64,9 +64,9 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 			[ 'email_type', 'recipient_role' ]
 		);
 
-		$this->inactive_users_query_time_ms = $registry->getOrRegisterGauge(
+		$this->inactive_users_query_time = $registry->getOrRegisterGauge(
 			'vip_security_boost',
-			'inactive_users_query_time_ms',
+			'inactive_users_query_time',
 			'Query time for inactive users count in milliseconds',
 			[]
 		);
@@ -78,7 +78,7 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 		add_action( 'vip_security_blocked_users_view', [ $this, 'blocked_users_view' ] );
 		add_action( 'vip_security_user_unblock', [ $this, 'user_unblock' ], 10, 2 );
 		add_action( 'vip_security_privileged_email_sent', [ $this, 'privileged_email_sent' ], 10, 2 );
-		add_action( 'vip_security_inactive_users_query_time', [ $this, 'inactive_users_query_time' ], 10, 1 );
+		add_action( 'vip_security_inactive_users_query_time', [ $this, 'set_inactive_users_query_time' ], 10, 1 );
 	}
 
 	public function mfa_display( bool $filter_enabled ): void {
@@ -105,8 +105,8 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 		$this->privileged_email_sent_counter->inc( [ $email_type, $recipient_role ] );
 	}
 
-	public function inactive_users_query_time( float $query_time_ms ): void {
-		$this->inactive_users_query_time_ms->set( $query_time_ms );
+	public function set_inactive_users_query_time( float $query_time_ms ): void {
+		$this->inactive_users_query_time->set( $query_time_ms );
 	}
 
 	public function collect_metrics(): void {

--- a/utils/class-collector.php
+++ b/utils/class-collector.php
@@ -6,6 +6,7 @@
 namespace Automattic\VIP\Security\Utils;
 
 use Prometheus\Counter;
+use Prometheus\Gauge;
 use Prometheus\RegistryInterface;
 
 /**
@@ -18,6 +19,7 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 	private Counter $blocked_users_view_counter;
 	private Counter $user_unblock_counter;
 	private Counter $privileged_email_sent_counter;
+	private Gauge $inactive_users_query_time_ms;
 
 	public function initialize( RegistryInterface $registry ): void {
 		$this->mfa_display_counter = $registry->getOrRegisterCounter(
@@ -62,6 +64,13 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 			[ 'email_type', 'recipient_role' ]
 		);
 
+		$this->inactive_users_query_time_ms = $registry->getOrRegisterGauge(
+			'vip_security_boost',
+			'inactive_users_query_time_ms',
+			'Query time for inactive users count in milliseconds',
+			[]
+		);
+
 		// Set up action hooks for automatic metric collection
 		add_action( 'vip_security_mfa_display', [ $this, 'mfa_display' ], 10, 1 );
 		add_action( 'vip_security_mfa_filter_click', [ $this, 'mfa_filter_click' ], 10, 1 );
@@ -69,6 +78,7 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 		add_action( 'vip_security_blocked_users_view', [ $this, 'blocked_users_view' ] );
 		add_action( 'vip_security_user_unblock', [ $this, 'user_unblock' ], 10, 2 );
 		add_action( 'vip_security_privileged_email_sent', [ $this, 'privileged_email_sent' ], 10, 2 );
+		add_action( 'vip_security_inactive_users_query_time', [ $this, 'inactive_users_query_time' ], 10, 1 );
 	}
 
 	public function mfa_display( bool $filter_enabled ): void {
@@ -93,6 +103,10 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 
 	public function privileged_email_sent( string $email_type, string $recipient_role ): void {
 		$this->privileged_email_sent_counter->inc( [ $email_type, $recipient_role ] );
+	}
+
+	public function inactive_users_query_time( float $query_time_ms ): void {
+		$this->inactive_users_query_time_ms->set( $query_time_ms );
 	}
 
 	public function collect_metrics(): void {

--- a/utils/class-collector.php
+++ b/utils/class-collector.php
@@ -105,8 +105,8 @@ class Collector implements \Automattic\VIP\Prometheus\CollectorInterface {
 		$this->privileged_email_sent_counter->inc( [ $email_type, $recipient_role ] );
 	}
 
-	public function set_inactive_users_query_time( float $query_time_ms ): void {
-		$this->inactive_users_query_time->set( $query_time_ms );
+	public function set_inactive_users_query_time( float $query_time ): void {
+		$this->inactive_users_query_time->set( $query_time );
 	}
 
 	public function collect_metrics(): void {

--- a/utils/class-constants.php
+++ b/utils/class-constants.php
@@ -4,4 +4,6 @@ namespace Automattic\VIP\Security;
 
 class Constants {
 	const LOG_PLUGIN_NAME = 'vip-security-boost';
+
+	const SDS_DATA_KEY = 'vip_security_boost';
 }


### PR DESCRIPTION
## Description

This PR adds functionality to send the count of inactive users to the Site Details Service (SDS). This enables monitoring and tracking of inactive user metrics across VIP sites.

The implementation:
- Adds a new filter hook `vip_site_details_index_data` to collect inactive users count
- Refactors existing inactive users query logic into reusable methods
- Adds performance monitoring with query time metrics
- Integrates with the existing Prometheus metrics collection system

## Changelog Description

### Added
- Added inactive users count to Site Details Service (SDS) data collection
- Added performance monitoring for inactive users count queries with Prometheus metrics

### Changed
- Refactored inactive users query logic into reusable `get_inactive_users_query_args()` and `get_inactive_users_count()` methods

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Check out PR branch
2. Set up test environment with inactive users:
   ```bash
   vip dev-env exec -- wp option set wpvip_last_seen_release_date_timestamp 1708528298
   vip dev-env exec -- wp user update test2 --user_registered='2023-01-15 10:00:00'
   vip dev-env exec -- wp user meta set test2 wpvip_last_seen 1699459200
   vip dev-env exec -- wp user meta set test2 wpvip_last_seen_ignore_inactivity_check_until 1599459200a
   ```
3. Verify that the SDS data collection includes inactive users count by checking the `vip_site_details_index_data` filter (you can simulate it by calling `apply_filters( 'vip_site_details_index_data', array() )`  manually)
4. Verify that existing inactive users functionality (blocking/unblocking) continues to work as expected