### PR TITLE
Fix: Include roles hash in MFA highlight cache key to prevent stale cache

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -89,12 +89,17 @@ class Highlight_MFA_Users {
 
 	/**
 	 * Get the site-specific cache key for MFA count.
+	 * Includes a hash of the configured roles to ensure cache invalidation when roles change.
 	 *
 	 * @return string The cache key for the current site.
 	 */
-	private static function get_mfa_count_cache_key() {
-		$blog_id = get_current_blog_id();
-		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id;
+	private static function get_mfa_count_cache_key( $blog_id = null ) {
+		$blog_id = $blog_id ?? get_current_blog_id();
+
+		// Include a hash of the roles configuration to invalidate cache when roles change
+		$roles_hash = md5( wp_json_encode( self::$roles ) );
+
+		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id . '_' . $roles_hash;
 	}
 
 	/**
@@ -177,7 +182,7 @@ class Highlight_MFA_Users {
 
 		// Clear cache for each site where the user has roles
 		foreach ( $user_blogs as $blog ) {
-			$cache_key = self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog->userblog_id;
+			$cache_key = self::get_mfa_count_cache_key( $blog->userblog_id );
 			wp_cache_delete( $cache_key, self::MFA_COUNT_CACHE_GROUP );
 		}
 	}

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -582,6 +582,49 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that cache key includes roles hash and changes when roles configuration changes.
+	 */
+	public function test_cache_key_includes_roles_hash_and_changes_with_roles() {
+		$this->set_admin_screen_users();
+
+		// Get the cache key with default roles
+		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
+		$cache_key_method = $reflection_class->getMethod( 'get_mfa_count_cache_key' );
+		$cache_key_method->setAccessible( true );
+
+		$initial_cache_key = $cache_key_method->invoke( null );
+
+		// Verify the cache key contains the expected components
+		$blog_id = get_current_blog_id();
+		$this->assertStringContainsString( Highlight_MFA_Users::MFA_COUNT_CACHE_KEY_PREFIX, $initial_cache_key );
+		$this->assertStringContainsString( (string) '_' . $blog_id . '_', $initial_cache_key );
+
+		// Change the roles configuration
+		$roles_property = $reflection_class->getProperty( 'roles' );
+		$roles_property->setAccessible( true );
+		$original_roles = $roles_property->getValue( null );
+		$new_roles      = [ 'author', 'contributor' ];
+		$roles_property->setValue( null, $new_roles );
+
+		// Get the cache key with new roles
+		$new_cache_key = $cache_key_method->invoke( null );
+
+		// Verify the cache key has changed
+		$this->assertNotEquals( $initial_cache_key, $new_cache_key, 'Cache key should change when roles configuration changes' );
+
+		// Verify both keys still contain the expected base components
+		$this->assertStringContainsString( Highlight_MFA_Users::MFA_COUNT_CACHE_KEY_PREFIX, $new_cache_key );
+		$this->assertStringContainsString( (string) '_' . $blog_id . '_', $new_cache_key );
+
+		// Restore original roles
+		$roles_property->setValue( null, $original_roles );
+
+		// Verify cache key returns to original value
+		$restored_cache_key = $cache_key_method->invoke( null );
+		$this->assertEquals( $initial_cache_key, $restored_cache_key, 'Cache key should return to original value when roles are restored' );
+	}
+
+	/**
 	 * Test that sorting logic does nothing if orderby is not set.
 	 */
 	public function test_sort_columns_does_nothing_if_orderby_not_set() {

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -597,7 +597,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Verify the cache key contains the expected components
 		$blog_id = get_current_blog_id();
 		$this->assertStringContainsString( Highlight_MFA_Users::MFA_COUNT_CACHE_KEY_PREFIX, $initial_cache_key );
-		$this->assertStringContainsString( (string) '_' . $blog_id . '_', $initial_cache_key );
+		$this->assertStringContainsString( '_' . $blog_id . '_', $initial_cache_key );
 
 		// Change the roles configuration
 		$roles_property = $reflection_class->getProperty( 'roles' );
@@ -614,7 +614,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		// Verify both keys still contain the expected base components
 		$this->assertStringContainsString( Highlight_MFA_Users::MFA_COUNT_CACHE_KEY_PREFIX, $new_cache_key );
-		$this->assertStringContainsString( (string) '_' . $blog_id . '_', $new_cache_key );
+		$this->assertStringContainsString( '_' . $blog_id . '_', $new_cache_key );
 
 		// Restore original roles
 		$roles_property->setValue( null, $original_roles );


### PR DESCRIPTION
## Description

This PR fixes a bug where the MFA highlight count cache doesn't update when the roles configuration changes.

**Problem**: The cache key for MFA disabled user counts only included the blog ID, so when the `highlight-mfa-users` module configuration changed (specifically the `roles` setting), the cached count would remain stale and not reflect the new role configuration.

**Solution**: Modified the `get_mfa_count_cache_key()` method to include a hash of the `self::$roles` configuration. This ensures that when roles change, the cache key changes too, effectively invalidating the old cache and forcing a fresh calculation.

**Changes made**:
- Updated `get_mfa_count_cache_key()` to accept an optional `$blog_id` parameter and include a roles hash
- Used `wp_json_encode()` instead of `serialize()` for better WordPress compatibility
- Refactored `clear_mfa_count_cache_for_user_sites()` to use the centralized cache key generation method
- Added comprehensive test coverage for the new cache key behavior

Fixes: https://linear.app/a8c/issue/PLTFRM-1300/bug-mfa-highlight-count-cache-doesnt-update-when-configs-change

## Changelog Description

### Fixed
- Fixed MFA highlight count cache not updating when roles configuration changes

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
2. Set up a site with the `highlight-mfa-users` module enabled with default roles (`administrator`, `editor`)
3. Navigate to `wp-admin` > `Users` and observe the MFA disabled count notice
4. Change the module configuration to use different roles (e.g., `author`, `contributor`)
5. Refresh the Users page and verify the count updates to reflect users with the new roles
6. Verify that the cache is properly invalidated by checking that the count changes immediately after configuration change

**Before this fix**: The count would remain the same even after changing roles configuration until cache TTL expired.

**After this fix**: The count updates immediately when roles configuration changes.