### PR TITLE
[PLTFRM-1245] fix filters to show all inactive users

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -345,7 +345,7 @@ class Inactive_Users {
 		);
 
 		$release_ts = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
-		if ( $release_ts === false) {
+		if ( false === $release_ts ) {
 			$release_ts = static::get_fallback_release_date_timestamp();
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -345,7 +345,7 @@ class Inactive_Users {
 		);
 
 		$release_ts = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
-		if ( ! $release_ts ) {
+		if ( $release_ts === false) {
 			$release_ts = static::get_fallback_release_date_timestamp();
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -331,6 +331,47 @@ class Inactive_Users {
 	}
 
 	public static function get_inactive_users_query_args() {
+		$inact_ts = self::get_inactivity_timestamp();
+
+		// Users whose last_seen < inactivity cutoff
+		$or_clauses = array(
+			'relation' => 'OR',
+			array(
+				'key'     => self::LAST_SEEN_META_KEY,
+				'value'   => $inact_ts,
+				'type'    => 'NUMERIC',
+				'compare' => '<',
+			),
+		);
+
+		$release_ts = get_option( self::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY );
+		if ( ! $release_ts ) {
+			$release_ts = static::get_fallback_release_date_timestamp();
+		}
+
+		// If release date older than the cutoff, include “NOT EXISTS”
+		if ( $release_ts < $inact_ts ) {
+			$or_clauses[] = array(
+				'key'     => self::LAST_SEEN_META_KEY,
+				'compare' => 'NOT EXISTS',
+			);
+		}
+
+		// Users whose “ignore until” has expired (or was never set)
+		$ignore_clause = array(
+			'relation' => 'OR',
+			array(
+				'key'     => self::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY,
+				'value'   => time(),
+				'type'    => 'NUMERIC',
+				'compare' => '<',
+			),
+			array(
+				'key'     => self::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY,
+				'compare' => 'NOT EXISTS',
+			),
+		);
+
 		$vars = array(
 			// Only consider users that registered before the inactivity threshold
 			'date_query' => array(
@@ -347,19 +388,14 @@ class Inactive_Users {
 			'meta_query' => array(
 				[
 					'relation' => 'AND',
-					[
-						'key'     => self::LAST_SEEN_META_KEY,
-						'value'   => self::get_inactivity_timestamp(),
-						'type'    => 'NUMERIC',
-						'compare' => '<',
-					],
+					$or_clauses,
+					$ignore_clause,
 				],
 			),
 		);
 
 		return $vars;
 	}
-
 	/**
 	 * Filter users list table to show only blocked users, active only when BLOCK mode is enabled
 	 */

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -497,7 +497,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site_1_id );
 		add_user_to_blog( $site_1_id, $site_1_user_1, 'administrator' );
+		delete_user_meta( $site_1_user_1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		add_user_to_blog( $site_1_id, $site_1_user_2, 'administrator' );
+		delete_user_meta( $site_1_user_2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 
 		// Make site 1 users inactive
 		update_user_meta( $site_1_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
@@ -514,8 +516,11 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site_2_id );
 		add_user_to_blog( $site_2_id, $site_2_user_1, 'administrator' );
+		delete_user_meta( $site_2_user_1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		add_user_to_blog( $site_2_id, $site_2_user_2, 'administrator' );
+		delete_user_meta( $site_2_user_2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		add_user_to_blog( $site_2_id, $site_2_user_3, 'administrator' );
+		delete_user_meta( $site_2_user_3, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 
 		// Make site 2 users inactive
 		update_user_meta( $site_2_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -469,24 +469,29 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $site_1_user_1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		$site_1_user_2 = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $site_1_user_2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 
 		// Create users for site 2
 		$site_2_user_1 = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $site_2_user_1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		$site_2_user_2 = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $site_2_user_2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 		$site_2_user_3 = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $site_2_user_3, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 
 		// Switch to site 1 and add users to it
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -407,7 +407,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'vip_security_boost', $filtered_data );
 		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data['vip_security_boost'] );
 		$this->assertIsInt( $filtered_data['vip_security_boost']['inactive_users_count'] );
-		
+
 		// Verify the network-wide count is added only in multisite
 		if ( is_multisite() ) {
 			$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data['vip_security_boost'] );
@@ -427,10 +427,13 @@ class InactiveUsersTest extends WP_UnitTestCase {
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $inactive_user_1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+
 		$inactive_user_2 = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
+		delete_user_meta( $inactive_user_2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
 
 		// Make them inactive by setting old last seen timestamps
 		update_user_meta( $inactive_user_1, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -4,7 +4,8 @@ use Automattic\VIP\Security\InactiveUsers\Inactive_Users;
 
 class InactiveUsersTest extends WP_UnitTestCase {
 	private $user_id;
-	private $elevated_roles = [ 'administrator' ];
+	private $elevated_roles                 = [ 'administrator' ];
+	private $considered_inactive_after_days = 90;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -374,6 +375,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		update_option( 'date_format', $old_date_format );
 		update_option( 'time_format', $old_time_format );
 	}
+
 	/**
 	 * Test that a user is considered inactive if the fallback date is in the past
 	 */
@@ -534,5 +536,72 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		wp_delete_user( $site_2_user_1 );
 		wp_delete_user( $site_2_user_2 );
 		wp_delete_user( $site_2_user_3 );
+	}
+
+	/**
+	 * Test that only inactive are returned for the blocked filter
+	 */
+	public function test_only_inactive_and_release_users_are_returned_blocked_filter(): void {
+		// Simulate a "blocked" user filter request with nonce
+		$_GET['last_seen_filter']       = 'blocked';
+		$_GET['last_seen_filter_nonce'] = wp_create_nonce( 'last_seen_filter' );
+
+		$cutoff = strtotime( '-' . $this->considered_inactive_after_days . ' days' );
+
+		// User #1: Inactive — last seen before cutoff, no ignore meta
+		$u1 = $this->factory()->user->create([
+			'user_registered' => gmdate( 'Y-m-d H:i:s', $cutoff - WEEK_IN_SECONDS ),
+			'role'            => 'administrator',
+		]);
+		update_user_meta( $u1, Inactive_Users::LAST_SEEN_META_KEY, $cutoff - DAY_IN_SECONDS );
+		delete_user_meta( $u1, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		$this->assertTrue( Inactive_Users::is_considered_inactive( $u1 ) );
+
+		// User #2: Active — last seen after cutoff
+		$u2 = $this->factory()->user->create([
+			'role' => 'administrator',
+		]);
+		update_user_meta( $u2, Inactive_Users::LAST_SEEN_META_KEY, $cutoff + DAY_IN_SECONDS );
+		delete_user_meta( $u2, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		$this->assertFalse( Inactive_Users::is_considered_inactive( $u2 ) );
+
+		// User #3: Ignored — last seen before cutoff, but ignore-until is in the future
+		$u3 = $this->factory()->user->create([
+			'user_registered' => gmdate( 'Y-m-d H:i:s', $cutoff - DAY_IN_SECONDS ),
+			'role'            => 'administrator',
+		]);
+		update_user_meta( $u3, Inactive_Users::LAST_SEEN_META_KEY, $cutoff - DAY_IN_SECONDS );
+		update_user_meta( $u3, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY, time() + DAY_IN_SECONDS );
+		$this->assertFalse( Inactive_Users::is_considered_inactive( $u3 ) );
+
+		// User #4: Inactive — no last seen, registered before cutoff, release timestamp forced into past
+		update_option( Inactive_Users::LAST_SEEN_RELEASE_DATE_TIMESTAMP_OPTION_KEY, 0 );
+		$u4 = $this->factory()->user->create([
+			'user_registered' => gmdate( 'Y-m-d H:i:s', $cutoff - DAY_IN_SECONDS ),
+			'role'            => 'administrator',
+		]);
+		delete_user_meta( $u4, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		$this->assertTrue( Inactive_Users::is_considered_inactive( $u4 ) );
+
+		// Run user query using blocked filter args
+		$vars  = Inactive_Users::last_seen_blocked_users_filter_query_args( [] );
+		$q     = new WP_User_Query( $vars );
+		$found = wp_list_pluck( $q->get_results(), 'ID' );
+		sort( $found );
+
+		// Clean up GET globals
+		unset( $_GET['last_seen_filter'], $_GET['last_seen_filter_nonce'] );
+
+		// Assert: only u1 and u4 should be returned
+		$this->assertContains( $u1, $found );
+		$this->assertContains( $u4, $found );
+		$this->assertNotContains( $u2, $found );
+		$this->assertNotContains( $u3, $found );
+
+		// Cleanup created users
+		wp_delete_user( $u1 );
+		wp_delete_user( $u2 );
+		wp_delete_user( $u3 );
+		wp_delete_user( $u4 );
 	}
 }

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -597,7 +597,6 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$vars  = Inactive_Users::last_seen_blocked_users_filter_query_args( [] );
 		$q     = new WP_User_Query( $vars );
 		$found = wp_list_pluck( $q->get_results(), 'ID' );
-		sort( $found );
 
 		// Clean up GET globals
 		unset( $_GET['last_seen_filter'], $_GET['last_seen_filter_nonce'] );


### PR DESCRIPTION
<!--
## For Automatticians!

:wave: Just a quick reminder that this is a public repo. Please don't include any internal links or sensitive data (like PII, private code, customer names, site URLs, etc. Any fixes related to security should be discussed with Platform before opening a PR. If you're not sure if something is safe to share, please just ask!

## For external contributors!

Welcome! We look forward to your contribution! ❤️
-->
## Description
Fixes the blocked filter to show users who have no "last seen" meta but the release date is past the cutoff. Also removes users with a future "ignore" meta from appearing in the filter.

## Changelog Description

<!-- Changelogs are published for our customers. Well-written entries help them stay informed on platform changes and all of the great work that we do! -->

<!-- Write a concise description of changes in the relevant section.
- Add new line items as needed.
- Entries should follow the [Common Changelog Style Guide](https://github.com/vweevers/common-changelog). 
- Remove all unused sections before merging.
- Proof-read.
-->

### Fixed
- Blocked user filter not correctly displaying all inactive users

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR and visit the Users page with `?last_seen_filter=blocked`.

2. Create the following users:

   - **User 1: Inactive (should appear)**
     - Registered before inactivity cutoff
     - Last seen before inactivity cutoff
     - No ignore meta

   - **User 2: Active (should not appear)**
     - Last seen after inactivity cutoff

   - **User 3: Ignored (should not appear)**
     - Last seen before inactivity cutoff
     - Ignore-until meta set to future

   - **User 4: Inactive by registration only (should appear)**
     - Registered before inactivity cutoff
     - No last seen meta
     - Release timestamp set to a date before cutoff

3. Visit the Users page with the blocked filter applied.

4. Verify:
   - ✅ User 1 and User 4 appear in the list
   - ❌ User 2 and User 3 do not appear