### PR TITLE
Add two-factor enforcement status tracking to SDS payload

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -18,6 +18,9 @@ class Forced_MFA_Users {
 		}
 		self::$roles = $forced_mfa_configs['roles'];
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
+
+		// Add SDS hook
+		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'add_two_factor_enforcement_status_to_sds_payload' ] );
 	}
 
 	/**
@@ -59,6 +62,51 @@ class Forced_MFA_Users {
 				}, PHP_INT_MAX );
 			}
 		}
+	}
+
+	/**
+	 * Add the two factor enforcement status to the SDS payload.
+	 *
+	 * @param array $data The SDS payload.
+	 *
+	 * @return array The SDS payload with the two factor enforcement status added.
+	 */
+	public static function add_two_factor_enforcement_status_to_sds_payload( $data ) {
+		// TODO wait for PR #59 and use the SDS_DATA_KEY constant
+		if ( ! isset( $data['vip_security_boost'] ) ) {
+			$data['vip_security_boost'] = array();
+		}
+		$data['vip_security_boost']['two_factor_status_'] = self::get_two_factor_enforcement_status();
+		return $data;
+	}
+
+	/**
+	 * Check if the `wpcom_vip_is_two_factor_forced` filter has been overridden to always return true.
+	 *
+	 * Some codebases might add `add_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' );`
+	 * to enforce Two-Factor globally. This helper allows runtime checks (e.g. within tests)
+	 * to detect that situation without triggering the filter itself.
+	 *
+	 * @return array {
+	 *     'is_enforced_globally': bool,
+	 *     'is_not_enforced_globally': bool,
+	 *     'has_two_factor_forced_filter': bool,
+	 *     'is_entirely_disabled': bool,
+	 *     'has_enable_two_factor_filter': bool
+	 * }
+	 */
+	public static function get_two_factor_enforcement_status(): array {
+		// Explicit global namespace references are required inside namespaced code.
+		$filters = [
+			// return wpcom_vip_is_two_factor_forced status
+			'is_enforced_globally'         => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' ) !== false,
+			'is_not_enforced_globally'     => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' ) !== false,
+			'has_two_factor_forced_filter' => \has_filter( 'wpcom_vip_is_two_factor_forced' ) !== false,
+			// return wpcom_vip_enable_two_factor status
+			'is_entirely_disabled'         => \has_filter( 'wpcom_vip_enable_two_factor', '__return_false' ) !== false || apply_filters( 'wpcom_vip_enable_two_factor', true ) === false,
+			'has_enable_two_factor_filter' => \has_filter( 'wpcom_vip_enable_two_factor' ) !== false,
+		];
+		return $filters;
 	}
 }
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -3,8 +3,11 @@ namespace Automattic\VIP\Security\MFAUsers;
 
 use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Utils\Capability_Utils;
+use Automattic\VIP\Security\Constants;
+use Automattic\VIP\Security\Utils\Logger;
 
 class Forced_MFA_Users {
+	const LOG_FEATURE_NAME = 'sb_forced_mfa_users';
 	/**
 	 * The roles that should have MFA enforced.
 	 *
@@ -21,23 +24,24 @@ class Forced_MFA_Users {
 
 	public static function init() {
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
+
+		// Add SDS hook regardless of the config.
+		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'add_two_factor_enforcement_status_to_sds_payload' ] );
+
 		if ( empty( $forced_mfa_configs ) ) {
 			return;
 		}
-		
+
 		// Normalize capabilities and roles configuration
 		self::$capabilities = Capability_Utils::normalize_capabilities_input( $forced_mfa_configs['capabilities'] ?? [] );
 		self::$roles        = Capability_Utils::normalize_roles_input( $forced_mfa_configs['roles'] ?? [] );
-		
+
 		// Ensure we have either capabilities or roles configured
 		if ( empty( self::$capabilities ) && empty( self::$roles ) ) {
 			return;
 		}
-		
-		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 
-		// Add SDS hook
-		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'add_two_factor_enforcement_status_to_sds_payload' ] );
+		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 	}
 
 	/**
@@ -58,10 +62,10 @@ class Forced_MFA_Users {
 		}
 
 		// Check if user has elevated permissions based on capabilities or roles
-		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions( 
-			$user, 
-			self::$capabilities, 
-			self::$roles 
+		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions(
+			$user,
+			self::$capabilities,
+			self::$roles
 		);
 
 		if ( $user_has_two_factor_enforced ) {
@@ -79,11 +83,17 @@ class Forced_MFA_Users {
 	 * @return array The SDS payload with the two factor enforcement status added.
 	 */
 	public static function add_two_factor_enforcement_status_to_sds_payload( $data ) {
-		// TODO wait for PR #59 and use the SDS_DATA_KEY constant
-		if ( ! isset( $data['vip_security_boost'] ) ) {
-			$data['vip_security_boost'] = array();
+		if ( ! isset( $data[ Constants::SDS_DATA_KEY ] ) ) {
+			$data[ Constants::SDS_DATA_KEY ] = array();
 		}
-		$data['vip_security_boost']['two_factor_status_'] = self::get_two_factor_enforcement_status();
+		try {
+			$data[ Constants::SDS_DATA_KEY ]['two_factor_status'] = self::get_two_factor_enforcement_status();
+		} catch ( \Exception $e ) {
+			Logger::error(
+				self::LOG_FEATURE_NAME,
+				'Error adding two factor enforcement status to SDS payload: ' . $e->getMessage()
+			);
+		}
 		return $data;
 	}
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -130,7 +130,8 @@ class Forced_MFA_Users {
 	 * }
 	 */
 	public static function get_two_factor_enforcement_status(): array {
-		// Explicit global namespace references are required inside namespaced code.
+		// Please note that detecting a filter is no exact science.
+		// SDS data is retrieved during CRON so some of these filters might be added only for logged in users, still we try our best to detect them.
 		$filters = [
 			// return wpcom_vip_is_two_factor_forced status
 			'is_enforced_globally'         => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' ) !== false,

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -69,6 +69,7 @@ class Forced_MFA_Users {
 		);
 
 		if ( $user_has_two_factor_enforced ) {
+			// TODO migrate to wpcom_vip_internal_is_two_factor_forced once PR https://github.com/Automattic/vip-go-mu-plugins/pull/6424 is released
 			add_filter( 'wpcom_vip_is_two_factor_forced', function () {
 				return true;
 			}, PHP_INT_MAX );

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -22,8 +22,6 @@ class Forced_MFA_Users {
 	 */
 	private static $capabilities;
 
-	private static $had_two_factor_enforced_filter = false;
-
 	public static function init() {
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
 
@@ -42,7 +40,6 @@ class Forced_MFA_Users {
 		if ( empty( self::$capabilities ) && empty( self::$roles ) ) {
 			return;
 		}
-		self::$had_two_factor_enforced_filter = has_filter( 'wpcom_vip_is_two_factor_forced' ) !== false; // TODO this might run too early?
 
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 	}
@@ -121,7 +118,7 @@ class Forced_MFA_Users {
 			// return wpcom_vip_is_two_factor_forced status
 			'is_enforced_globally'         => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' ) !== false,
 			'is_not_enforced_globally'     => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' ) !== false,
-			'has_two_factor_forced_filter' => self::$had_two_factor_enforced_filter,
+			'has_two_factor_forced_filter' => has_filter( 'wpcom_vip_is_two_factor_forced' ) !== false,
 			// return wpcom_vip_enable_two_factor status
 			'is_entirely_disabled'         => \has_filter( 'wpcom_vip_enable_two_factor', '__return_false' ) !== false || apply_filters( 'wpcom_vip_enable_two_factor', true ) === false,
 			'has_enable_two_factor_filter' => \has_filter( 'wpcom_vip_enable_two_factor' ) !== false,

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -77,11 +77,27 @@ class Forced_MFA_Users {
 	}
 
 	/**
-	 * Add the two factor enforcement status to the SDS payload.
+	 * Add the two-factor enforcement status details to the Site Details Service (SDS) payload.
 	 *
-	 * @param array $data The SDS payload.
+	 * The function augments the incoming `$data` array by injecting a new element under the
+	 * standard SDS data key (`Constants::SDS_DATA_KEY`). The resulting payload section has the
+	 * following structure:
 	 *
-	 * @return array The SDS payload with the two factor enforcement status added.
+	 * [ Constants::SDS_DATA_KEY ] => [
+	 *     'two_factor_status' => [
+	 *         'is_enforced_globally'         => bool, // `wpcom_vip_is_two_factor_forced` hooked to `__return_true`
+	 *         'is_not_enforced_globally'     => bool, // `wpcom_vip_is_two_factor_forced` hooked to `__return_false`
+	 *         'has_two_factor_forced_filter' => bool, // Any filter present on `wpcom_vip_is_two_factor_forced`
+	 *         'is_entirely_disabled'         => bool, // 2FA disabled via `wpcom_vip_enable_two_factor` returning false
+	 *         'has_enable_two_factor_filter' => bool, // Any filter present on `wpcom_vip_enable_two_factor`
+	 *     ],
+	 * ]
+	 *
+	 * This mirrors the array returned by {@see self::get_two_factor_enforcement_status()} so that
+	 * consumers of the SDS payload can introspect the enforcement configuration without needing to
+	 * call WordPress-level helpers during data processing.
+	 *
+	 * @return array Modified SDS payload including the `two_factor_status` information.
 	 */
 	public static function add_two_factor_enforcement_status_to_sds_payload( $data ) {
 		if ( ! isset( $data[ Constants::SDS_DATA_KEY ] ) ) {

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -22,6 +22,8 @@ class Forced_MFA_Users {
 	 */
 	private static $capabilities;
 
+	private static $had_two_factor_enforced_filter = false;
+
 	public static function init() {
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
 
@@ -40,6 +42,7 @@ class Forced_MFA_Users {
 		if ( empty( self::$capabilities ) && empty( self::$roles ) ) {
 			return;
 		}
+		self::$had_two_factor_enforced_filter = has_filter( 'wpcom_vip_is_two_factor_forced' ) !== false; // TODO this might run too early?
 
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ] );
 	}
@@ -118,7 +121,7 @@ class Forced_MFA_Users {
 			// return wpcom_vip_is_two_factor_forced status
 			'is_enforced_globally'         => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' ) !== false,
 			'is_not_enforced_globally'     => \has_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' ) !== false,
-			'has_two_factor_forced_filter' => \has_filter( 'wpcom_vip_is_two_factor_forced' ) !== false,
+			'has_two_factor_forced_filter' => self::$had_two_factor_enforced_filter,
 			// return wpcom_vip_enable_two_factor status
 			'is_entirely_disabled'         => \has_filter( 'wpcom_vip_enable_two_factor', '__return_false' ) !== false || apply_filters( 'wpcom_vip_enable_two_factor', true ) === false,
 			'has_enable_two_factor_filter' => \has_filter( 'wpcom_vip_enable_two_factor' ) !== false,

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -2,11 +2,17 @@
 
 use Automattic\VIP\Security\MFAUsers\Forced_MFA_Users;
 use Automattic\VIP\Security\Utils\Testable_Logger;
+use Automattic\VIP\Jetpack\Connection_Pilot\Attendant;
 
 class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 		add_action( 'wpcom_vip_is_two_factor_local_testing', '__return_true' ); // Tell the two-factor plugin we're in local testing
+
+		// removing these for the SDS testing part
+		remove_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' );
+		remove_filter( 'wpcom_vip_is_two_factor_forced', [ Attendant::instance(), 'bypass_two_factor_auth' ], PHP_INT_MAX );
+
 		// Loads the Two_Factor_Core class (required for the wpcom_vip_should_force_two_factor to work)
 		require_once WPVIP_MU_PLUGIN_DIR . '/shared-plugins/two-factor/two-factor.php';
 	}
@@ -254,7 +260,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function test_maybe_enforce_two_factor_capabilities_priority() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 
+				'forced-mfa-users' => [
 					'capabilities' => 'manage_options',
 					'roles'        => 'subscriber', // This should be ignored
 				],
@@ -323,7 +329,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		// Grant manage_options capability to editor
 		$user->add_cap( 'manage_options' );
 		wp_set_current_user( $user_id );
-		
+
 		Forced_MFA_Users::maybe_enforce_two_factor();
 		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
 	}
@@ -336,7 +342,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function test_maybe_enforce_two_factor_empty_capabilities_uses_roles() {
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 
+				'forced-mfa-users' => [
 					'capabilities' => [],
 					'roles'        => 'administrator',
 				],
@@ -357,7 +363,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
 		define( 'VIP_SECURITY_BOOST_CONFIGS', [
 			'module_configs' => [
-				'forced-mfa-users' => [ 
+				'forced-mfa-users' => [
 					'capabilities' => [],
 					'roles'        => [],
 				],
@@ -366,5 +372,69 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 		Forced_MFA_Users::init();
 		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
+	}
+	/**
+	 * Test default status when no relevant filters are present.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_two_factor_enforcement_status_defaults() {
+		$expected = [
+			'is_enforced_globally'         => false,
+			'is_not_enforced_globally'     => false,
+			'has_two_factor_forced_filter' => false,
+			'is_entirely_disabled'         => false,
+			'has_enable_two_factor_filter' => false,
+		];
+
+		$this->assertSame( $expected, Forced_MFA_Users::get_two_factor_enforcement_status() );
+	}
+
+	/**
+	 * Test status when filters enforce two-factor globally.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_two_factor_enforcement_status_enforced_globally() {
+		add_filter( 'wpcom_vip_is_two_factor_forced', '__return_true' );
+
+		$status = Forced_MFA_Users::get_two_factor_enforcement_status();
+
+		$this->assertTrue( $status['is_enforced_globally'] );
+		$this->assertTrue( $status['has_two_factor_forced_filter'] );
+	}
+
+	/**
+	 * Test status when filters disable two-factor globally.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_two_factor_enforcement_status_disabled_globally() {
+		add_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' );
+
+		$status = Forced_MFA_Users::get_two_factor_enforcement_status();
+
+		$this->assertTrue( $status['is_not_enforced_globally'] );
+		$this->assertTrue( $status['has_two_factor_forced_filter'] );
+	}
+
+	/**
+	 * Test that two-factor status is added to SDS payload correctly.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_two_factor_enforcement_status_to_sds_payload() {
+		$payload = [];
+
+		$result = Forced_MFA_Users::add_two_factor_enforcement_status_to_sds_payload( $payload );
+
+		$this->assertArrayHasKey( \Automattic\VIP\Security\Constants::SDS_DATA_KEY, $result );
+		$section = $result[ \Automattic\VIP\Security\Constants::SDS_DATA_KEY ];
+		$this->assertArrayHasKey( 'two_factor_status', $section );
+		$this->assertIsArray( $section['two_factor_status'] );
 	}
 }

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -3,6 +3,7 @@
 use Automattic\VIP\Security\MFAUsers\Forced_MFA_Users;
 use Automattic\VIP\Security\Utils\Testable_Logger;
 use Automattic\VIP\Jetpack\Connection_Pilot\Attendant;
+use Automattic\VIP\Security\Constants;
 
 class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	public function setUp(): void {
@@ -373,6 +374,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
 	}
+
 	/**
 	 * Test default status when no relevant filters are present.
 	 *
@@ -428,13 +430,11 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 */
 	public function test_add_two_factor_enforcement_status_to_sds_payload() {
-		$payload = [];
-
-		$result = Forced_MFA_Users::add_two_factor_enforcement_status_to_sds_payload( $payload );
-
-		$this->assertArrayHasKey( \Automattic\VIP\Security\Constants::SDS_DATA_KEY, $result );
-		$section = $result[ \Automattic\VIP\Security\Constants::SDS_DATA_KEY ];
-		$this->assertArrayHasKey( 'two_factor_status', $section );
-		$this->assertIsArray( $section['two_factor_status'] );
+		Forced_MFA_Users::init();
+		$this->assertEquals( 10, has_filter( 'vip_site_details_index_data', [ Forced_MFA_Users::class, 'add_two_factor_enforcement_status_to_sds_payload' ] ) );
+		$site_details = apply_filters( 'vip_site_details_index_data', [] );
+		$data         = Forced_MFA_Users::get_two_factor_enforcement_status();
+		$this->assertArrayHasKey( Constants::SDS_DATA_KEY, $site_details );
+		$this->assertSame( $data, $site_details[ Constants::SDS_DATA_KEY ]['two_factor_status'] );
 	}
 }


### PR DESCRIPTION
## Description

This PR implements detection of filter usage around 2FA and sends the data back to SDS.

I’ve also added a to-do item: once [this PR is merged](https://github.com/Automattic/vip-go-mu-plugins/pull/6424), we want to update the code so that it uses the new internal filter. 

The data is injected into the SDS array as

```
'vip_security_boost' => [
    'two_factor_status' => [
        'is_enforced_globally' => bool,
        'is_not_enforced_globally' => bool,
        'has_two_factor_forced_filter' => bool,
        'is_entirely_disabled' => bool,
        'has_enable_two_factor_filter' => bool,
    ]
]
```

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

* Test passes
* Verify that the SDS data collection includes the 2FA data the vip_site_details_index_data filter (you can simulate it by calling `apply_filters( 'vip_site_details_index_data', array() )` manually)