### PR TITLE
[PLTFRM-1307] Fix VIP_CONFIG_API_URL error for local env 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -59,9 +59,3 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: utils/class-configs.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: utils/dev-env.php

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Automattic\VIP\Security\Utils;
+
 use Automattic\VIP\Security\Utils\Logger;
 
 function load_integration_configs_from_url() {

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -1,13 +1,23 @@
 <?php
 
 namespace Automattic\VIP\Security\Utils;
+use Automattic\VIP\Security\Utils\Logger;
 
 function load_integration_configs_from_url() {
 	$config_api_url = vip_get_env_var( 'VIP_CONFIG_API_URL', getenv( 'VIP_CONFIG_API_URL' ) );
 
 	if ( ! $config_api_url ) {
-		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
-		trigger_error( 'VIP_CONFIG_API_URL is not defined.', E_USER_ERROR );
+		Logger::info(
+			'sb_dev_env',
+			'VIP_CONFIG_API_URL is not set, skipping loading integration configs from URL.'
+		);
+		// Define default empty configuration for local development
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			define( 'VIP_SECURITY_BOOST_CONFIGS', [
+				'enabled_modules' => [],
+				'module_configs'  => [],
+			] );
+		}
 		return;
 	}
 

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -20,7 +20,7 @@ function load_integration_configs_from_url() {
 			] );
 		}
 		return;
-	}
+	} 
 
 	$endpoint  = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', $config_api_url, constant( 'VIP_GO_APP_ID' ) );
 	$api_error = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );

--- a/utils/dev-env.php
+++ b/utils/dev-env.php
@@ -20,7 +20,7 @@ function load_integration_configs_from_url() {
 			] );
 		}
 		return;
-	} 
+	}
 
 	$endpoint  = sprintf( '%s/integration?slug=security-boost&level=site&site_id=%s&is_vip=true', $config_api_url, constant( 'VIP_GO_APP_ID' ) );
 	$api_error = new \WP_Error( 'config-api-error', 'There was an error while fetching the integration configuration from the API.' );


### PR DESCRIPTION
## Description

Set default config for `VIP_SECURITY_BOOST_CONFIGS` when `VIP_CONFIG_API_URL` is undefined in local env.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Checkout branch
2. `vip dev-env create && vip dev-env start` 
3. Navigate to [wp-admin](http://vip-security-boost.vipdev.lndo.site/wp-admin/users.php?role=administrator) and make sure it does not show any errors