### PR TITLE
Highlight MFA > Set capabilities as default

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -5,12 +5,13 @@ use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Highlight_MFA_Users {
-	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
-	const ROLE_COLUMN_KEY                 = 'role';
-	const DEFAULT_ADMIN_EDITOR_ROLE_SLUGS = [ 'administrator', 'editor' ];
-	const MFA_COUNT_CACHE_GROUP           = 'vip_security_mfa_count';
-	const MFA_COUNT_CACHE_KEY_PREFIX      = 'mfa_disabled_count';
-	const MFA_COUNT_CACHE_TTL             = HOUR_IN_SECONDS; // Cache for 1 hour
+	const MFA_SKIP_USER_IDS_OPTION_KEY      = 'vip_security_mfa_skip_user_ids';
+	const ROLE_COLUMN_KEY                   = 'role';
+	const DEFAULT_ADMIN_EDITOR_CAPABILITIES = [ 'manage_options', 'edit_others_posts' ];
+	const DEFAULT_ADMIN_EDITOR_ROLE_SLUGS   = [ 'administrator', 'editor' ];
+	const MFA_COUNT_CACHE_GROUP             = 'vip_security_mfa_count';
+	const MFA_COUNT_CACHE_KEY_PREFIX        = 'mfa_disabled_count';
+	const MFA_COUNT_CACHE_TTL               = HOUR_IN_SECONDS; // Cache for 1 hour
 
 	/**
 	 * The roles used to highlight users without MFA.
@@ -45,7 +46,7 @@ class Highlight_MFA_Users {
 		$highlight_mfa_configs = Configs::get_module_configs( 'highlight-mfa-users' );
 		
 		// Normalize capabilities and roles configuration
-		self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? [] );
+		self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? self::DEFAULT_ADMIN_EDITOR_CAPABILITIES );
 		self::$roles        = Capability_Utils::normalize_roles_input( $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
 
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
@@ -240,7 +241,7 @@ class Highlight_MFA_Users {
 
 		// Check if capabilities are configured or using default roles
 		$has_capabilities  = Capability_Utils::are_capabilities_configured( self::$capabilities );
-		$is_default_config = ! $has_capabilities && 
+		$is_default_config = empty( array_diff( self::$capabilities, self::DEFAULT_ADMIN_EDITOR_CAPABILITIES ) ) ||
 								empty( array_diff( self::$roles, self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS ) );
 
 		// Get the cached MFA disabled count

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -224,6 +224,17 @@ class Highlight_MFA_Users {
 		self::clear_mfa_count_cache_for_user_sites( $user_id );
 	}
 
+	/* * Check if two arrays are equal.
+	 * This is a simple utility function to compare two arrays for equality.
+	 *
+	 * @param array $a First array.
+	 * @param array $b Second array.
+	 * @return bool True if arrays are equal, false otherwise.
+	 */
+	public static function arrays_are_equal( $a, $b ) {
+		return empty( array_diff( $a, $b ) ) && empty( array_diff( $b, $a ) );
+	}
+
 	/**
 	* Display an admin notice on the Users page showing the count of users with MFA disabled.
 	*/
@@ -241,8 +252,8 @@ class Highlight_MFA_Users {
 
 		// Check if capabilities are configured or using default roles
 		$has_capabilities  = Capability_Utils::are_capabilities_configured( self::$capabilities );
-		$is_default_config = empty( array_diff( self::$capabilities, self::DEFAULT_ADMIN_EDITOR_CAPABILITIES ) ) ||
-								empty( array_diff( self::$roles, self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS ) );
+		$is_default_config = self::arrays_are_equal( self::$capabilities, self::DEFAULT_ADMIN_EDITOR_CAPABILITIES ) ||
+												self::arrays_are_equal( self::$roles, self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
 
 		// Get the cached MFA disabled count
 		$mfa_disabled_count = self::get_mfa_disabled_count();

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -14,6 +14,7 @@ if ( ! class_exists( 'Two_Factor_Core' ) ) {
 
 use Automattic\VIP\Security\MFAUsers\Highlight_MFA_Users;
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Utils\Capability_Utils;
 
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class HighlightMFAUsersTest extends WP_UnitTestCase {
@@ -145,7 +146,18 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		}
 		$this->assertTrue( $mfa_meta_clause_found, 'MFA status meta query clause not found.' );
 
-		$this->assertEquals( [ 'administrator', 'editor' ], $filtered_args['role__in'] );
+		// Check that either role__in or capability__in is set based on default configuration
+		$this->assertTrue( 
+			isset( $filtered_args['role__in'] ) || isset( $filtered_args['capability__in'] ),
+			'Either role__in or capability__in should be set'
+		);
+		
+		// With default configuration, it should use capability__in since DEFAULT_ADMIN_EDITOR_CAPABILITIES is configured
+		if ( isset( $filtered_args['capability__in'] ) ) {
+			$this->assertEquals( Highlight_MFA_Users::DEFAULT_ADMIN_EDITOR_CAPABILITIES, $filtered_args['capability__in'] );
+		} else {
+			$this->assertEquals( Highlight_MFA_Users::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS, $filtered_args['role__in'] );
+		}
 
 		$this->assertIsArray( $filtered_args['exclude'] );
 		$this->assertContains( $this->admin_user_mfa_skipped_id, $filtered_args['exclude'] );
@@ -186,7 +198,11 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		// Assert that the query parameters were modified when the filter param is set
 		$this->assertArrayHasKey( 'meta_query', $filtered_args );
-		$this->assertArrayHasKey( 'role__in', $filtered_args );
+		// With default configuration, should use capability__in since capabilities are configured
+		$this->assertTrue(
+			isset( $filtered_args['capability__in'] ) || isset( $filtered_args['role__in'] ),
+			'Either capability__in or role__in should be set'
+		);
 		$this->assertArrayHasKey( 'exclude', $filtered_args );
 
 		unset( $_GET['filter_mfa_disabled'] );
@@ -247,16 +263,24 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// We have MFA-disabled users:
 		// - $this->admin_user_mfa_disabled_id (administrator)
 		// - $this->editor_user_id (editor)
-		// - User ID 1 (if exists and is administrator)
+		// - User ID 1 (if exists and is administrator/editor)
 		// The following should be excluded:
 		// - $this->admin_user_mfa_skipped_id (skipped via option)
 		// - $this->admin_wpcomvip_ignored_id (wpcomvip bot user)
 		// - $this->subscriber_user_id (not administrator/editor role)
 		// - $this->admin_user_mfa_enabled_id (has MFA enabled in mock)
 		
-		// With the new implementation using is_user_using_two_factor(), 
-		// we're getting 3 users without MFA
-		$expected_count  = 3;
+		// With capability-based filtering and the new implementation,
+		// calculate expected count dynamically based on actual users
+		$all_users      = get_users( [ 'capability__in' => Highlight_MFA_Users::DEFAULT_ADMIN_EDITOR_CAPABILITIES ] );
+		$expected_count = 0;
+		foreach ( $all_users as $user ) {
+			if ( ! in_array( $user->ID, [ $this->admin_user_mfa_skipped_id, $this->admin_wpcomvip_ignored_id, $this->admin_user_mfa_enabled_id ], true ) ) {
+				if ( ! \Two_Factor_Core::is_user_using_two_factor( $user->ID ) ) {
+					++$expected_count;
+				}
+			}
+		}
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-error"><p>%s <a href="%s">%s</a></p></div>',
@@ -291,8 +315,16 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->set_admin_screen_users();
 		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
 
-		// Same count as the previous test - we have 3 users without MFA
-		$expected_count  = 3;
+		// Calculate expected count dynamically based on actual users
+		$all_users      = get_users( [ 'capability__in' => Highlight_MFA_Users::DEFAULT_ADMIN_EDITOR_CAPABILITIES ] );
+		$expected_count = 0;
+		foreach ( $all_users as $user ) {
+			if ( ! in_array( $user->ID, [ $this->admin_user_mfa_skipped_id, $this->admin_wpcomvip_ignored_id, $this->admin_user_mfa_enabled_id ], true ) ) {
+				if ( ! \Two_Factor_Core::is_user_using_two_factor( $user->ID ) ) {
+					++$expected_count;
+				}
+			}
+		}
 		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
 			'<div class="notice notice-info"><p>%s <a href="%s">%s</a></p></div>', // Notice class is notice-info when filtered
@@ -351,17 +383,16 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Clear the cache to ensure fresh calculation
 		Highlight_MFA_Users::clear_mfa_count_cache();
 		
-		// Get all users in the system
+		// Get all users with elevated capabilities
 		$all_users = get_users( [
-			'fields' => 'all',
+			'capability__in' => Highlight_MFA_Users::DEFAULT_ADMIN_EDITOR_CAPABILITIES,
+			'fields'         => 'all',
 		] );
 		
-		// Enable MFA for all users with administrator or editor roles using the mock
+		// Enable MFA for all users with elevated capabilities using the mock
 		foreach ( $all_users as $user ) {
-			if ( array_intersect( [ 'administrator', 'editor' ], $user->roles ) ) {
-				// Add to the mock's enabled user IDs array
-				Two_Factor_Core::$mock_enabled_user_ids[] = $user->ID;
-			}
+			// Add to the mock's enabled user IDs array
+			Two_Factor_Core::$mock_enabled_user_ids[] = $user->ID;
 		}
 		
 		// Clear cache again to ensure fresh calculation with updated mock data
@@ -382,20 +413,27 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->set_admin_screen_users();
 		$_GET['filter_mfa_disabled'] = '1'; // Activate the filter
 
-		// Set custom roles using reflection
+		// Set custom roles using reflection and clear capabilities to force role-based logic
 		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
-		$roles_property   = $reflection_class->getProperty( 'roles' );
+		
+		$roles_property = $reflection_class->getProperty( 'roles' );
 		$roles_property->setAccessible( true );
 		$custom_roles = [ 'author', 'contributor' ];
 		$roles_property->setValue( null, $custom_roles );
+		
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [] ); // Clear capabilities to use roles
 
 		// Create users with custom roles
 		$author_user_id      = $this->factory()->user->create( [ 'role' => 'author' ] );
 		$contributor_user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
 
-		// Existing users (admin_user_mfa_disabled_id, editor_user_id, user ID 1) should not be counted
-		// as 'administrator' and 'editor' are not in $custom_roles for this test.
+		// Clear cache to ensure fresh calculation with new configuration
+		Highlight_MFA_Users::clear_mfa_count_cache();
 
+		// With custom roles, only the author and contributor created above should be counted
+		// since the roles property has been overridden for this test
 		$expected_count  = 2; // The author and contributor created above.
 		$show_all_url    = remove_query_arg( 'filter_mfa_disabled', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
@@ -429,14 +467,19 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	public function test_display_mfa_disabled_notice_shows_for_custom_roles() {
 		$this->set_admin_screen_users();
 
-		// Set custom roles using reflection
+		// Set custom roles using reflection and clear capabilities to force role-based logic
 		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
-		$roles_property   = $reflection_class->getProperty( 'roles' );
+		
+		$roles_property = $reflection_class->getProperty( 'roles' );
 		$roles_property->setAccessible( true );
 		// Highlight_MFA_Users::init() in setUp already set roles to default.
 		// We are overriding them here for this specific test.
 		$custom_roles = [ 'author', 'contributor' ];
 		$roles_property->setValue( null, $custom_roles );
+		
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$capabilities_property->setValue( null, [] ); // Clear capabilities to use roles
 
 		// Create users with custom roles
 		$author_user_id = $this->factory()->user->create( [ 'role' => 'author' ] );
@@ -445,9 +488,11 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$contributor_user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
 		// Ensure this user is MFA disabled
 
-		// Existing users (admin_user_mfa_disabled_id, editor_user_id, user ID 1) should not be counted
-		// as 'administrator' and 'editor' are not in $custom_roles for this test.
+		// Clear cache to ensure fresh calculation with new configuration
+		Highlight_MFA_Users::clear_mfa_count_cache();
 
+		// With custom roles, only the author and contributor created above should be counted
+		// since the roles property has been overridden for this test
 		$expected_count  = 2; // The author and contributor created above.
 		$filter_url      = add_query_arg( 'filter_mfa_disabled', '1', admin_url( 'users.php' ) );
 		$expected_output = sprintf(
@@ -482,6 +527,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	public function test_init_hooks_actions_correctly() {
 		remove_all_actions( 'admin_notices' );
 		remove_all_filters( 'users_list_table_query_args' );
+		remove_all_actions( 'admin_enqueue_scripts' );
 
 		Highlight_MFA_Users::init();
 
@@ -490,6 +536,9 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->assertNotFalse( has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status_args' ] ) );
 		$this->assertEquals( 10, has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'filter_users_by_mfa_status_args' ] ) );
+
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', [ Highlight_MFA_Users::class, 'enqueue_tracking_scripts' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', [ Highlight_MFA_Users::class, 'enqueue_tracking_scripts' ] ) );
 
 		$this->assertNotFalse( has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'sort_columns' ] ) );
 		$this->assertEquals( 10, has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'sort_columns' ] ) );
@@ -513,6 +562,13 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 			$this->assertNotFalse( has_action( 'remove_user_from_blog', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 			$this->assertNotFalse( has_action( 'add_user_to_blog', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache' ] ) );
 		}
+
+		// Test column management hooks
+		$this->assertNotFalse( has_filter( 'manage_users_columns', [ Highlight_MFA_Users::class, 'add_columns' ] ) );
+		$this->assertNotFalse( has_filter( 'wpmu_users_columns', [ Highlight_MFA_Users::class, 'add_columns' ] ) );
+		$this->assertNotFalse( has_filter( 'manage_users_custom_column', [ Highlight_MFA_Users::class, 'manage_columns' ] ) );
+		$this->assertNotFalse( has_filter( 'manage_users_sortable_columns', [ Highlight_MFA_Users::class, 'make_columns_sortable' ] ) );
+		$this->assertNotFalse( has_filter( 'manage_users-network_sortable_columns', [ Highlight_MFA_Users::class, 'make_columns_sortable' ] ) );
 	}
 
 	/**
@@ -629,12 +685,12 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that cache key includes roles hash and changes when roles configuration changes.
+	 * Test that cache key includes roles and capabilities hash and changes when configuration changes.
 	 */
 	public function test_cache_key_includes_roles_hash_and_changes_with_roles() {
 		$this->set_admin_screen_users();
 
-		// Get the cache key with default roles
+		// Get the cache key with default configuration
 		$reflection_class = new \ReflectionClass( Highlight_MFA_Users::class );
 		$cache_key_method = $reflection_class->getMethod( 'get_mfa_count_cache_key' );
 		$cache_key_method->setAccessible( true );
@@ -663,12 +719,26 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( Highlight_MFA_Users::MFA_COUNT_CACHE_KEY_PREFIX, $new_cache_key );
 		$this->assertStringContainsString( '_' . $blog_id . '_', $new_cache_key );
 
-		// Restore original roles
+		// Change the capabilities configuration and test that it also affects the cache key
+		$capabilities_property = $reflection_class->getProperty( 'capabilities' );
+		$capabilities_property->setAccessible( true );
+		$original_capabilities = $capabilities_property->getValue( null );
+		$new_capabilities      = [ 'publish_posts', 'edit_posts' ];
+		$capabilities_property->setValue( null, $new_capabilities );
+
+		// Get the cache key with new capabilities
+		$capabilities_cache_key = $cache_key_method->invoke( null );
+
+		// Verify the cache key has changed due to capabilities change
+		$this->assertNotEquals( $new_cache_key, $capabilities_cache_key, 'Cache key should change when capabilities configuration changes' );
+
+		// Restore original configuration
 		$roles_property->setValue( null, $original_roles );
+		$capabilities_property->setValue( null, $original_capabilities );
 
 		// Verify cache key returns to original value
 		$restored_cache_key = $cache_key_method->invoke( null );
-		$this->assertEquals( $initial_cache_key, $restored_cache_key, 'Cache key should return to original value when roles are restored' );
+		$this->assertEquals( $initial_cache_key, $restored_cache_key, 'Cache key should return to original value when configuration is restored' );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Now that we have capabilities UI in production we can set the default capabilities in `highlight-mfa-users`

Before 
<img width="719" height="210" alt="image" src="https://github.com/user-attachments/assets/019b4a75-a8c0-4212-bc5e-3332e75670db" />

After
<img width="797" height="147" alt="image" src="https://github.com/user-attachments/assets/85fc3fe8-fe32-47b1-9f38-d5021f6e9b63" />

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
Prerequisite: Run local GOOP
1. Check out PR.
2. Start local dev-env
3. Set the config to the default settings
```
```
3.  