### PR TITLE
Fix inactive users count query reliability

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -3,6 +3,7 @@ namespace Automattic\VIP\Security\MFAUsers;
 
 use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Utils\Capability_Utils;
+use Automattic\VIP\Security\Utils\Users_Query_Utils;
 
 class Highlight_MFA_Users {
 	const MFA_SKIP_USER_IDS_OPTION_KEY    = 'vip_security_mfa_skip_user_ids';
@@ -48,6 +49,7 @@ class Highlight_MFA_Users {
 		self::$capabilities = Capability_Utils::normalize_capabilities_input( $highlight_mfa_configs['capabilities'] ?? [] );
 		self::$roles        = Capability_Utils::normalize_roles_input( $highlight_mfa_configs['roles'] ?? self::DEFAULT_ADMIN_EDITOR_ROLE_SLUGS );
 
+		add_action( 'admin_init', [ __CLASS__, 'maybe_fix_found_users_query' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'display_mfa_disabled_notice' ] );
 		add_filter( 'users_list_table_query_args', [ __CLASS__, 'filter_users_by_mfa_status_args' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_tracking_scripts' ] );
@@ -66,9 +68,6 @@ class Highlight_MFA_Users {
 
 		// Handle sorting
 		add_filter( 'users_list_table_query_args', [ __CLASS__, 'sort_columns' ] );
-
-		// Hook into found_users_query to fix the count query for pagination
-		add_filter( 'found_users_query', [ __CLASS__, 'fix_found_users_query' ], 10, 2 );
 
 		// Clear cache when users are created or deleted
 		add_action( 'user_register', [ __CLASS__, 'clear_mfa_count_cache' ] );
@@ -90,6 +89,18 @@ class Highlight_MFA_Users {
 		add_action( 'set_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
 		add_action( 'add_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
 		add_action( 'remove_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
+	}
+
+	/**
+	 * Add filter to fix found_users_query when filtering for MFA disabled users.
+	 */
+	public static function maybe_fix_found_users_query() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! is_admin() || ! isset( $_GET['filter_mfa_disabled'] ) || '1' !== $_GET['filter_mfa_disabled'] ) {
+			return;
+		}
+
+		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
 	}
 
 	/**
@@ -354,10 +365,10 @@ class Highlight_MFA_Users {
 	}
 
 	/**
- * Filter users by MFA status using the correct hook for the user list table.
- * @param array $args The query arguments.
- * @return array The modified query arguments.
- */
+	 * Filter users by MFA status using the correct hook for the user list table.
+	 * @param array $args The query arguments.
+	 * @return array The modified query arguments.
+	 */
 	public static function filter_users_by_mfa_status_args( $args ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce is not required for this check
 		if ( is_admin() && isset( $_GET['filter_mfa_disabled'] ) && '1' === $_GET['filter_mfa_disabled'] ) {
@@ -493,39 +504,6 @@ class Highlight_MFA_Users {
 		}
 
 		return $args;
-	}
-
-	/**
-	 * This function replaces WordPress's potentially unreliable `SELECT FOUND_ROWS()`
-	 * with a direct `SELECT COUNT(DISTINCT ID)` query. It dynamically uses the
-	 * exact same `FROM` and `WHERE` clauses that the main `WP_User_Query` is using,
-	 * ensuring the total user count is always accurate for pagination.
-	 *
-	 * @param string         $sql   The original SQL query (usually 'SELECT FOUND_ROWS()').
-	 * @param \WP_User_Query $query The WP_User_Query instance.
-	 * @return string The corrected SQL query for counting users.
-	 */
-	public static function fix_found_users_query( $sql, $query ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! is_admin() || ! isset( $_GET['filter_mfa_disabled'] ) || '1' !== $_GET['filter_mfa_disabled'] ) {
-			return $sql;
-		}
-
-		// The WP_User_Query object ($query) has already prepared its SQL clauses for the main query.
-		// We can reuse them to build a reliable COUNT query.
-		// These properties are populated by the prepare_query() method.
-		if ( empty( $query->query_from ) || empty( $query->query_where ) ) {
-			// This is unexpected, but as a fallback, return the original SQL to avoid errors.
-			return $sql;
-		}
-
-		global $wpdb;
-
-		// Build the reliable count query using the same FROM and WHERE clauses as the main query.
-		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$count_sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$query->query_from} {$query->query_where}";
-
-		return $count_sql;
 	}
 
 	/**

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -6,6 +6,7 @@ use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Constants;
 use Automattic\VIP\Security\Utils\Capability_Utils;
+use Automattic\VIP\Security\Utils\Users_Query_Utils;
 
 class Inactive_Users {
 	protected static $considered_inactive_after_days;
@@ -48,6 +49,7 @@ class Inactive_Users {
 		add_filter( 'determine_current_user', [ __CLASS__, 'record_activity' ], 30, 1 );
 
 		add_action( 'admin_init', [ __CLASS__, 'register_release_date' ] );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_fix_found_users_query' ] );
 
 		// skipping inactivity checks for new users
 		if ( is_multisite() ) {
@@ -93,10 +95,23 @@ class Inactive_Users {
 		add_filter( 'vip_site_details_index_data', [ __CLASS__, 'add_inactive_users_count_to_sds_payload' ] );
 	}
 
+	public static function maybe_fix_found_users_query() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! is_admin() || ! isset( $_GET['last_seen_filter'] ) || 'blocked' !== $_GET['last_seen_filter'] ) {
+			// Not in admin or not filtering for blocked users, nothing to do
+			return;
+		}
+
+		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+	}
+
 	public static function add_inactive_users_count_to_sds_payload( $data ) {
 		if ( ! isset( $data[ Constants::SDS_DATA_KEY ] ) ) {
 			$data[ Constants::SDS_DATA_KEY ] = array();
 		}
+
+		// Add fix for unreliable FOUND_ROWS() query
+		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
 
 		// Start timer to measure query time
 		$timer = microtime( true );
@@ -323,20 +338,8 @@ class Inactive_Users {
 			'count_total' => true,
 		], self::get_inactive_users_query_args() );
 
-		// 1. Instantiate WP_User_Query but don't run its main query
-		// We have found issues with unreliable FOUND_ROWS() when counting users,
-		// so we're using a custom COUNT query instead
-		$users_query = new \WP_User_Query();
-
-		// 2. Prepare the query object with given filters
-		$users_query->prepare_query( $args );
-
-		// 3. Execute the count query
-		global $wpdb;
-		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-		$sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$users_query->query_from} {$users_query->query_where}";
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
-		$count = (int) $wpdb->get_var( $sql );
+		$users_query = new \WP_User_Query( $args );
+		$count       = $users_query->get_total();
 
 		// Cache the result for global queries (blog_id = 0)
 		if ( 0 === $blog_id ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -323,8 +323,20 @@ class Inactive_Users {
 			'count_total' => true,
 		], self::get_inactive_users_query_args() );
 
-		$users_query = new \WP_User_Query( $args );
-		$count       = $users_query->get_total();
+		// 1. Instantiate WP_User_Query but don't run its main query
+		// We have found issues with unreliable FOUND_ROWS() when counting users,
+		// so we're using a custom COUNT query instead
+		$users_query = new \WP_User_Query();
+
+		// 2. Prepare the query object with given filters
+		$users_query->prepare_query( $args );
+
+		// 3. Execute the count query
+		global $wpdb;
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$users_query->query_from} {$users_query->query_where}";
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$count = (int) $wpdb->get_var( $sql );
 
 		// Cache the result for global queries (blog_id = 0)
 		if ( 0 === $blog_id ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../utils/configs.php';
 require_once __DIR__ . '/../utils/class-configs.php';
 require_once __DIR__ . '/../utils/class-constants.php';
 require_once __DIR__ . '/../utils/class-capability-utils.php';
+require_once __DIR__ . '/../utils/class-users-query-utils.php';
 require_once __DIR__ . '/../utils/class-logger.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 require_once __DIR__ . '/../email/class-email.php';

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -14,6 +14,7 @@ if ( ! class_exists( 'Two_Factor_Core' ) ) {
 
 use Automattic\VIP\Security\MFAUsers\Highlight_MFA_Users;
 use Automattic\VIP\Security\Utils\Configs;
+use Automattic\VIP\Security\Utils\Users_Query_Utils;
 
 // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
 class HighlightMFAUsersTest extends WP_UnitTestCase {
@@ -485,6 +486,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		Highlight_MFA_Users::init();
 
+		$this->assertNotFalse( has_action( 'admin_init', [ Highlight_MFA_Users::class, 'maybe_fix_found_users_query' ] ) );
 		$this->assertNotFalse( has_action( 'admin_notices', [ Highlight_MFA_Users::class, 'display_mfa_disabled_notice' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', [ Highlight_MFA_Users::class, 'display_mfa_disabled_notice' ] ) );
 
@@ -493,9 +495,6 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$this->assertNotFalse( has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'sort_columns' ] ) );
 		$this->assertEquals( 10, has_filter( 'users_list_table_query_args', [ Highlight_MFA_Users::class, 'sort_columns' ] ) );
-
-		$this->assertNotFalse( has_filter( 'found_users_query', [ Highlight_MFA_Users::class, 'fix_found_users_query' ] ) );
-		$this->assertEquals( 10, has_filter( 'found_users_query', [ Highlight_MFA_Users::class, 'fix_found_users_query' ] ) );
 
 		// Test that cache clearing actions are hooked
 		$this->assertNotFalse( has_action( 'updated_user_meta', [ Highlight_MFA_Users::class, 'clear_mfa_count_cache_on_meta_update' ] ) );
@@ -700,7 +699,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$query->query_where = 'WHERE 1=1';
 
 		$original_sql = 'SELECT FOUND_ROWS()';
-		$fixed_sql    = Highlight_MFA_Users::fix_found_users_query( $original_sql, $query );
+		$fixed_sql    = Users_Query_Utils::fix_found_users_query( $original_sql, $query );
 
 		// The fixed SQL should be a COUNT query
 		$this->assertStringContainsString( 'SELECT COUNT(DISTINCT', $fixed_sql );
@@ -719,7 +718,7 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		$query        = new \WP_User_Query();
 		$original_sql = 'SELECT FOUND_ROWS()';
-		$result_sql   = Highlight_MFA_Users::fix_found_users_query( $original_sql, $query );
+		$result_sql   = Users_Query_Utils::fix_found_users_query( $original_sql, $query );
 
 		// Should return the original SQL unchanged
 		$this->assertEquals( $original_sql, $result_sql );

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Automattic\VIP\Security\Utils;
+
+class Users_Query_Utils {
+	/**
+	 * This function replaces WordPress's potentially unreliable `SELECT FOUND_ROWS()`
+	 * with a direct `SELECT COUNT(DISTINCT ID)` query. It dynamically uses the
+	 * exact same `FROM` and `WHERE` clauses that the main `WP_User_Query` is using,
+	 * ensuring the total user count is always accurate for pagination.
+	 *
+	 * @param string         $sql   The original SQL query (usually 'SELECT FOUND_ROWS()').
+	 * @param \WP_User_Query $query The WP_User_Query instance.
+	 * @return string The corrected SQL query for counting users.
+	 */
+	public static function fix_found_users_query( $sql, $query ) {
+		// The WP_User_Query object ($query) has already prepared its SQL clauses for the main query.
+		// We can reuse them to build a reliable COUNT query.
+		// These properties are populated by the prepare_query() method.
+		if ( empty( $query->query_from ) || empty( $query->query_where ) ) {
+			// This is unexpected, but as a fallback, return the original SQL to avoid errors.
+			return $sql;
+		}
+
+		global $wpdb;
+
+		// Build the reliable count query using the same FROM and WHERE clauses as the main query.
+        // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		$count_sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$query->query_from} {$query->query_where}";
+
+		return $count_sql;
+	}
+}

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -25,7 +25,7 @@ class Users_Query_Utils {
 		global $wpdb;
 
 		// Build the reliable count query using the same FROM and WHERE clauses as the main query.
-        // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
 		$count_sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$query->query_from} {$query->query_where}";
 
 		return $count_sql;

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -18,6 +18,7 @@ declare(strict_types = 1);
 require_once __DIR__ . '/utils/configs.php';
 require_once __DIR__ . '/utils/class-configs.php';
 require_once __DIR__ . '/utils/class-capability-utils.php';
+require_once __DIR__ . '/utils/class-users-query-utils.php';
 require_once __DIR__ . '/email/class-email.php';
 require_once __DIR__ . '/utils/class-constants.php';
 require_once __DIR__ . '/utils/class-logger.php';


### PR DESCRIPTION
## Description

This PR fixes reliability issues with the inactive users count query by replacing WP_User_Query's get_total() method with a custom COUNT query to avoid problems with unreliable FOUND_ROWS() when counting users.

The implementation maintains all existing functionality while improving query reliability by:
1. Using WP_User_Query to prepare the query with proper filters
2. Executing a direct COUNT query using the prepared WHERE clause
3. Adding proper phpcs ignores for the direct database query

## Changelog Description

### Fixed
- Fixed inactive users count query reliability by replacing unreliable FOUND_ROWS() with direct COUNT query

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Check out PR
2. Navigate to a WordPress admin with the VIP Security Boost plugin active
3. Go to the inactive users module
4. Verify that the user count is displayed correctly and consistently
5. Test with different filter combinations to ensure the count remains accurate