### PR TITLE
PLTFRM-1078 Add SDS filter for users without MFA count

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -89,6 +89,20 @@ class Highlight_MFA_Users {
 		add_action( 'set_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
 		add_action( 'add_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
 		add_action( 'remove_user_role', [ __CLASS__, 'clear_mfa_count_cache_for_user_role_change' ], 10, 1 );
+
+		// Add SDS hook
+		add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_users_without_2fa_count_to_sds_payload' ] );
+	}
+
+	public static function add_users_without_2fa_count_to_sds_payload( $data ) {
+		// Add fix for unreliable FOUND_ROWS() query
+		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+
+		$users_without_2fa_count = self::get_mfa_disabled_count();
+
+		$data['users_without_2fa_count'] = $users_without_2fa_count;
+
+		return $data;
 	}
 
 	/**

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -102,6 +102,9 @@ class Highlight_MFA_Users {
 
 		$data['users_without_2fa_count'] = $users_without_2fa_count;
 
+		// Remove fix for unreliable FOUND_ROWS() query
+		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+
 		return $data;
 	}
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -108,6 +108,14 @@ class Highlight_MFA_Users {
 
 		$data['users_without_2fa_count'] = $users_without_2fa_count;
 
+		if ( is_multisite() ) {
+			// Get number of users without 2FA for all blogs (network-wide with blog_id = 0)
+			$users_without_2fa_count_all_blogs = self::get_mfa_disabled_count( 0 );
+
+			// Add network-wide users without 2FA count to the SDS payload
+			$data['users_without_2fa_count_all_blogs'] = $users_without_2fa_count_all_blogs;
+		}
+
 		// Remove fix for unreliable FOUND_ROWS() query
 		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10 );
 

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -103,7 +103,7 @@ class Highlight_MFA_Users {
 		$data['users_without_2fa_count'] = $users_without_2fa_count;
 
 		// Remove fix for unreliable FOUND_ROWS() query
-		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10 );
 
 		return $data;
 	}

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -94,6 +94,12 @@ class Highlight_MFA_Users {
 		add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_users_without_2fa_count_to_sds_payload' ] );
 	}
 
+	/**
+	 * Add the users_without_2fa_count to the SDS payload.
+	 *
+	 * @param array $data The SDS payload data.
+	 * @return array The modified SDS payload data.
+	 */
 	public static function add_users_without_2fa_count_to_sds_payload( $data ) {
 		// Add fix for unreliable FOUND_ROWS() query
 		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -132,7 +132,7 @@ class Inactive_Users {
 		do_action( 'vip_security_inactive_users_query_time', $timer );
 
 		// Remove fix for unreliable FOUND_ROWS() query
-		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10 );
 
 		return $data;
 	}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -131,6 +131,9 @@ class Inactive_Users {
 		// Register query time metric
 		do_action( 'vip_security_inactive_users_query_time', $timer );
 
+		// Remove fix for unreliable FOUND_ROWS() query
+		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
+
 		return $data;
 	}
 

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -723,4 +723,124 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		// Should return the original SQL unchanged
 		$this->assertEquals( $original_sql, $result_sql );
 	}
+
+	/**
+	 * Test that the vip_site_details_index_security_boost_data filter is added and works correctly
+	 */
+	public function test_vip_site_details_index_security_boost_data_filter_is_added() {
+		// Verify the filter is added during init
+		$this->assertNotFalse( has_filter( 'vip_site_details_index_security_boost_data', [ 'Automattic\VIP\Security\MFAUsers\Highlight_MFA_Users', 'add_users_without_2fa_count_to_sds_payload' ] ) );
+
+		// Test that the filter works by applying it
+		$initial_data  = [ 'some_key' => 'some_value' ];
+		$filtered_data = apply_filters( 'vip_site_details_index_security_boost_data', $initial_data );
+
+		// Should preserve existing data
+		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
+		// Should add MFA count data
+		$this->assertArrayHasKey( 'users_without_2fa_count', $filtered_data );
+		$this->assertIsInt( $filtered_data['users_without_2fa_count'] );
+	}
+
+	/**
+	 * Test add_users_without_2fa_count_to_sds_payload method directly
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_users_without_2fa_count_to_sds_payload() {
+		// Clear cache to ensure fresh calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		$initial_data = [ 'existing_key' => 'existing_value' ];
+		$result_data  = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( $initial_data );
+
+		// Should preserve existing data
+		$this->assertEquals( 'existing_value', $result_data['existing_key'] );
+
+		// Should add users_without_2fa_count
+		$this->assertArrayHasKey( 'users_without_2fa_count', $result_data );
+		$this->assertIsInt( $result_data['users_without_2fa_count'] );
+
+		// Should count exactly 3 users without MFA:
+		// - admin_user_mfa_disabled_id (admin without MFA)
+		// - editor_user_id (editor without MFA)
+		// - Default WordPress user (ID 1, admin without MFA)
+		// Excluded: admin_user_mfa_skipped_id (skipped), admin_wpcomvip_ignored_id (bot user)
+		$this->assertEquals( 3, $result_data['users_without_2fa_count'] );
+	}
+
+	/**
+	 * Test that SDS payload respects skipped user IDs
+	 */
+	public function test_sds_payload_respects_skipped_user_ids() {
+		// Clear cache to ensure fresh calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// First, remove the skipped user from skip list to get baseline
+		delete_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY );
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		$result_without_skip = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+		$count_without_skip  = $result_without_skip['users_without_2fa_count'];
+
+		// Now add the user back to skip list
+		update_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY, [ $this->admin_user_mfa_skipped_id ] );
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		$result_with_skip = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+		$count_with_skip  = $result_with_skip['users_without_2fa_count'];
+
+		// Should be 1 less with skip list (the skipped admin should be excluded)
+		$this->assertEquals( $count_without_skip - 1, $count_with_skip );
+
+		// Restore original skip list for other tests
+		update_option( Highlight_MFA_Users::MFA_SKIP_USER_IDS_OPTION_KEY, [ $this->admin_user_mfa_skipped_id ] );
+	}
+
+	/**
+	 * Test that SDS payload excludes wpcomvip bot user
+	 */
+	public function test_sds_payload_excludes_wpcomvip_bot() {
+		// Clear cache to ensure fresh calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// Get the current count (should exclude the bot user)
+		$result_data = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+
+		// Should count exactly 3 users without MFA:
+		// - admin_user_mfa_disabled_id (admin without MFA)
+		// - editor_user_id (editor without MFA)
+		// - Default WordPress user (ID 1, admin without MFA)
+		// Excluded: admin_user_mfa_skipped_id (skipped), admin_wpcomvip_ignored_id (bot user)
+		$this->assertEquals( 3, $result_data['users_without_2fa_count'] );
+
+		// Verify the bot user exists but is not counted
+		$bot_user = get_user_by( 'ID', $this->admin_wpcomvip_ignored_id );
+		$this->assertNotFalse( $bot_user );
+		$this->assertEquals( Configs::get_bot_login(), $bot_user->user_login );
+	}
+
+	/**
+	 * Test that SDS payload returns zero when all eligible users have MFA enabled
+	 */
+	public function test_sds_payload_zero_when_all_users_have_mfa() {
+		// Clear cache to ensure fresh calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// Enable MFA for ALL eligible users (including the default WordPress user)
+		// Get all admin and editor users to ensure we enable MFA for all of them
+		$all_admin_editor_users = get_users( [ 'role__in' => [ 'administrator', 'editor' ] ] );
+		$all_user_ids           = wp_list_pluck( $all_admin_editor_users, 'ID' );
+
+		Two_Factor_Core::$mock_enabled_user_ids = $all_user_ids;
+
+		// Clear cache after enabling MFA for all users
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		$initial_data = [];
+		$result_data  = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( $initial_data );
+
+		// Should return zero since all eligible users have MFA
+		$this->assertEquals( 0, $result_data['users_without_2fa_count'] );
+	}
 }

--- a/tests/phpunit/test-highlight-mfa-users.php
+++ b/tests/phpunit/test-highlight-mfa-users.php
@@ -739,6 +739,10 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
 		// Should add MFA count data
 		$this->assertArrayHasKey( 'users_without_2fa_count', $filtered_data );
+		// Should add network-wide MFA count data in multisite
+		if ( is_multisite() ) {
+			$this->assertArrayHasKey( 'users_without_2fa_count_all_blogs', $filtered_data );
+		}
 		$this->assertIsInt( $filtered_data['users_without_2fa_count'] );
 	}
 
@@ -761,12 +765,23 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'users_without_2fa_count', $result_data );
 		$this->assertIsInt( $result_data['users_without_2fa_count'] );
 
+		// Should add network-wide MFA count data in multisite
+		if ( is_multisite() ) {
+			$this->assertArrayHasKey( 'users_without_2fa_count_all_blogs', $result_data );
+			$this->assertIsInt( $result_data['users_without_2fa_count_all_blogs'] );
+		}
+
 		// Should count exactly 3 users without MFA:
 		// - admin_user_mfa_disabled_id (admin without MFA)
 		// - editor_user_id (editor without MFA)
 		// - Default WordPress user (ID 1, admin without MFA)
 		// Excluded: admin_user_mfa_skipped_id (skipped), admin_wpcomvip_ignored_id (bot user)
 		$this->assertEquals( 3, $result_data['users_without_2fa_count'] );
+
+		// Should count exactly 3 users without MFA across the network
+		if ( is_multisite() ) {
+			$this->assertEquals( 3, $result_data['users_without_2fa_count_all_blogs'] );
+		}
 	}
 
 	/**
@@ -842,5 +857,103 @@ class HighlightMFAUsersTest extends WP_UnitTestCase {
 
 		// Should return zero since all eligible users have MFA
 		$this->assertEquals( 0, $result_data['users_without_2fa_count'] );
+	}
+
+	/**
+	 * Test that network-wide counts are correct with users across different blogs
+	 */
+	public function test_network_wide_counts_across_different_blogs() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Clear cache to ensure fresh calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// Create two additional sites
+		$site_1_id = $this->factory()->blog->create();
+		$site_2_id = $this->factory()->blog->create();
+
+		// Create users for site 1 with different roles
+		$site_1_admin_user      = $this->factory()->user->create([
+			'role' => 'administrator',
+		]);
+		$site_1_editor_user     = $this->factory()->user->create([
+			'role' => 'editor',
+		]);
+		$site_1_subscriber_user = $this->factory()->user->create([
+			'role' => 'subscriber',
+		]);
+
+		// Create users for site 2 with different roles
+		$site_2_admin_user  = $this->factory()->user->create([
+			'role' => 'administrator',
+		]);
+		$site_2_editor_user = $this->factory()->user->create([
+			'role' => 'editor',
+		]);
+		$site_2_author_user = $this->factory()->user->create([
+			'role' => 'author',
+		]);
+
+		// Switch to site 1 and add users to it
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_1_id );
+		add_user_to_blog( $site_1_id, $site_1_admin_user, 'administrator' );
+		add_user_to_blog( $site_1_id, $site_1_editor_user, 'editor' );
+		add_user_to_blog( $site_1_id, $site_1_subscriber_user, 'subscriber' );
+
+		// Enable MFA for site 1 admin user only
+		Two_Factor_Core::$mock_enabled_user_ids[] = $site_1_admin_user;
+
+		// Test site 1 count - should count 1 user without MFA (editor)
+		// Subscriber should be excluded as it's not in the target roles
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		$site_1_result = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+		$this->assertEquals( 1, $site_1_result['users_without_2fa_count'], 'Site 1 should count 1 user without MFA (editor only)' );
+
+		restore_current_blog();
+
+		// Switch to site 2 and add users to it
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_2_id );
+		add_user_to_blog( $site_2_id, $site_2_admin_user, 'administrator' );
+		add_user_to_blog( $site_2_id, $site_2_editor_user, 'editor' );
+		add_user_to_blog( $site_2_id, $site_2_author_user, 'author' );
+
+		// Enable MFA for site 2 editor user only
+		Two_Factor_Core::$mock_enabled_user_ids[] = $site_2_editor_user;
+
+		// Test site 2 count - should count 1 user without MFA (admin)
+		// Author should be excluded as it's not in the target roles (administrator, editor)
+		Highlight_MFA_Users::clear_mfa_count_cache();
+		$site_2_result = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+		$this->assertEquals( 1, $site_2_result['users_without_2fa_count'], 'Site 2 should count 1 user without MFA (admin only)' );
+
+		restore_current_blog();
+
+		// Clear cache to ensure fresh network-wide calculation
+		Highlight_MFA_Users::clear_mfa_count_cache();
+
+		// Test network-wide count - should count users without MFA across all sites
+		// Expected:
+		// - Original test users: admin_user_mfa_disabled_id (admin), editor_user_id (editor), default user ID 1 (admin) = 3
+		// - Site 1: site_1_editor_user (editor without MFA) = 1
+		// - Site 2: site_2_admin_user (admin without MFA) = 1
+		// Total: 5 users without MFA across the network
+		$network_result = Highlight_MFA_Users::add_users_without_2fa_count_to_sds_payload( [] );
+		$this->assertEquals( 5, $network_result['users_without_2fa_count_all_blogs'], 'Network-wide should count 5 users without MFA across all sites' );
+
+		// Verify that users with MFA enabled are not counted
+		$this->assertContains( $site_1_admin_user, Two_Factor_Core::$mock_enabled_user_ids );
+		$this->assertContains( $site_2_editor_user, Two_Factor_Core::$mock_enabled_user_ids );
+
+		// Clean up users
+		wp_delete_user( $site_1_admin_user );
+		wp_delete_user( $site_1_editor_user );
+		wp_delete_user( $site_1_subscriber_user );
+		wp_delete_user( $site_2_admin_user );
+		wp_delete_user( $site_2_editor_user );
+		wp_delete_user( $site_2_author_user );
 	}
 }


### PR DESCRIPTION
## Description

This PR implements SDS (Site Details Service) integration to track the count of users without Multi-Factor Authentication (MFA) enabled. 

## Changelog Description

### Added
- Added SDS filter for users without MFA count to enable monitoring of 2FA adoption across VIP environments
- Added comprehensive test coverage for SDS payload integration including edge cases for skipped users and bot exclusions

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out the PR branch
2. Ensure the WordPress environment has the Two-Factor plugin active
3. Create test users with different roles (admin, editor) and MFA configurations
4. Apply the `vip_site_details_index_security_boost_data` filter:
   ```php
   $test_data = apply_filters('vip_site_details_index_security_boost_data', []);
   ```
5. Verify that `$test_data['users_without_2fa_count']` contains the correct count of users without MFA
6. Run the unit tests to verify all edge cases work correctly:
   ```bash
   composer test -- --filter=test_vip_site_details_index_security_boost_data
   ```
7. Verify that skipped users and bot users are properly excluded from the count