### PR TITLE
Fix infinite recursion in inactive users activity recording

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -45,7 +45,7 @@ class Inactive_Users {
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );
 
-		add_action( 'set_current_user', [ __CLASS__, 'record_activity' ], 30, 1 );
+		add_action( 'set_current_user', [ __CLASS__, 'record_activity' ], 30 );
 
 		add_action( 'admin_init', [ __CLASS__, 'register_release_date' ] );
 		add_action( 'admin_init', [ __CLASS__, 'maybe_fix_found_users_query' ] );

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -45,7 +45,7 @@ class Inactive_Users {
 		// Use a global cache group since users are shared among network sites.
 		wp_cache_add_global_groups( array( self::LAST_SEEN_CACHE_GROUP ) );
 
-		add_filter( 'determine_current_user', [ __CLASS__, 'record_activity' ], 30, 1 );
+		add_action( 'set_current_user', [ __CLASS__, 'record_activity' ], 30, 1 );
 
 		add_action( 'admin_init', [ __CLASS__, 'register_release_date' ] );
 		add_action( 'admin_init', [ __CLASS__, 'maybe_fix_found_users_query' ] );
@@ -134,32 +134,27 @@ class Inactive_Users {
 		return $data;
 	}
 
-	public static function record_activity( $user_id ) {
+	public static function record_activity() {
+		$user_id = get_current_user_id();
+
 		if ( ! $user_id ) {
-			return $user_id;
+			return;
 		}
 
 		if ( wp_cache_get( $user_id, self::LAST_SEEN_CACHE_GROUP ) ) {
 			// Last seen meta was checked recently
-			return $user_id;
-		}
-
-		$user = get_userdata( $user_id );
-		if ( ! $user ) {
-			return $user_id;
+			return;
 		}
 
 		if ( self::is_considered_inactive( $user_id ) ) {
 			// User needs to be unblocked first
-			return $user_id;
+			return;
 		}
 
 		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
 		if ( wp_cache_add( $user_id, true, self::LAST_SEEN_CACHE_GROUP, self::LAST_SEEN_UPDATE_USER_META_CACHE_TTL ) ) {
 			update_user_meta( $user_id, self::LAST_SEEN_META_KEY, time() );
 		}
-
-		return $user_id;
 	}
 
 	/**

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -59,8 +59,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * Test that record_activity updates the last seen timestamp
 	 */
 	public function test_record_activity() {
-		$result = Inactive_Users::record_activity( $this->user_id );
+		wp_set_current_user( $this->user_id );
 
+		Inactive_Users::record_activity();
 
 		$last_seen = get_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, true );
 


### PR DESCRIPTION
## Description

This PR fixes potential infinite recursion issues in the inactive users module by switching from the `determine_current_user` filter to the `set_current_user` action for recording user activity.

The `set_current_user` action is fired after the current user has already been set and `setup_userdata` has already been called, which helps prevent infinite recursion since we perform capability checks inside that hook.

## Changelog Description

### Fixed
- Fixed potential infinite recursion in inactive users activity recording by using `set_current_user` action instead of `determine_current_user` filter

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR
2. Set up a WordPress environment with the VIP Security Boost plugin
3. Enable the inactive users module
4. Log in as a user and perform various actions that would trigger user activity recording
5. Verify that no infinite recursion occurs and user activity is properly recorded
6. Check that the `wpvip_last_seen` user meta is updated correctly