### PR TITLE
Fix infinite loop and OOM on `user_can` call inside `map_meta_cap`

### DIFF
--- a/tests/phpunit/test-capability-utils.php
+++ b/tests/phpunit/test-capability-utils.php
@@ -116,9 +116,9 @@ class Test_Capability_Utils extends WP_UnitTestCase {
 
 		// Track if we're in a potential infinite loop
 		$call_count = 0;
-		$max_calls = 5;
+		$max_calls  = 5;
 
-		add_filter( 'map_meta_cap', function( $caps, $cap, $user_id, $args ) use ( $user, &$call_count, $max_calls ) {
+		add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id, $args ) use ( $user, &$call_count, $max_calls ) {
 			$call_count++;
 			
 			// Prevent actual infinite loop in test
@@ -192,6 +192,72 @@ class Test_Capability_Utils extends WP_UnitTestCase {
 			[ 'administrator', 'editor' ], 
 			Capability_Utils::normalize_roles_input( [ 'administrator', '', 'editor', '   ' ] ),
 			'Should filter out empty values'
+		);
+	}
+
+	/**
+	 * Test user_has_any_capability with corrupted allcaps
+	 */
+	public function test_user_has_any_capability_with_corrupted_allcaps() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Test with non-array allcaps
+		$user->allcaps = null;
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Should return false when allcaps is null'
+		);
+
+		$user->allcaps = 'string';
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Should return false when allcaps is a string'
+		);
+
+		$user->allcaps = new \stdClass();
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Should return false when allcaps is an object'
+		);
+
+		// Test with unset allcaps
+		unset( $user->allcaps );
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Should return false when allcaps is not set'
+		);
+	}
+
+	/**
+	 * Test user_has_any_capability with non-scalar capabilities
+	 */
+	public function test_user_has_any_capability_with_non_scalar_capabilities() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Mix of valid and invalid capability types
+		$capabilities = [
+			'manage_options',  // valid
+			123,              // valid (scalar)
+			null,             // invalid
+			[],               // invalid
+			new \stdClass(),  // invalid
+			'edit_posts',     // valid
+		];
+
+		// Should still return true because valid capabilities exist
+		$this->assertTrue( 
+			Capability_Utils::user_has_any_capability( $user, $capabilities ),
+			'Should skip non-scalar capabilities and still find valid ones'
+		);
+
+		// Only non-scalar capabilities
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ null, [], new \stdClass() ] ),
+			'Should return false when all capabilities are non-scalar'
 		);
 	}
 }

--- a/tests/phpunit/test-capability-utils.php
+++ b/tests/phpunit/test-capability-utils.php
@@ -118,7 +118,7 @@ class Test_Capability_Utils extends WP_UnitTestCase {
 		$call_count = 0;
 		$max_calls  = 5;
 
-		add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id, $args ) use ( $user, &$call_count, $max_calls ) {
+		add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id ) use ( &$call_count, $max_calls ) {
 			$call_count++;
 			
 			// Prevent actual infinite loop in test
@@ -127,16 +127,16 @@ class Test_Capability_Utils extends WP_UnitTestCase {
 			}
 
 			// This should NOT cause infinite loop because we check allcaps directly
-			if ( 'test_capability' === $cap ) {
+			if ( 'upload_files' === $cap ) {
 				$current_user = get_user_by( 'id', $user_id );
 				Capability_Utils::user_has_any_capability( $current_user, [ 'manage_options' ] );
 			}
 
 			return $caps;
-		}, 10, 4 );
+		}, 10, 3 );
 
 		// Trigger map_meta_cap
-		user_can( $user, 'test_capability' );
+		user_can( $user, 'upload_files' );
 
 		// Remove filter
 		remove_all_filters( 'map_meta_cap' );

--- a/tests/phpunit/test-capability-utils.php
+++ b/tests/phpunit/test-capability-utils.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Automattic\VIP\Security\Tests;
+
+use Automattic\VIP\Security\Utils\Capability_Utils;
+use WP_UnitTestCase;
+
+/**
+ * Test Capability_Utils class
+ */
+class Test_Capability_Utils extends WP_UnitTestCase {
+
+	/**
+	 * Test user_has_any_capability with valid capabilities
+	 */
+	public function test_user_has_any_capability_with_valid_caps() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Administrators have 'manage_options' capability
+		$this->assertTrue( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Administrator should have manage_options capability'
+		);
+
+		// Test with multiple capabilities (OR logic)
+		$this->assertTrue( 
+			Capability_Utils::user_has_any_capability( $user, [ 'fake_capability', 'manage_options', 'another_fake' ] ),
+			'Should return true if user has at least one capability'
+		);
+	}
+
+	/**
+	 * Test user_has_any_capability with invalid capabilities
+	 */
+	public function test_user_has_any_capability_with_invalid_caps() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		// Subscriber shouldn't have admin capabilities
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'manage_options' ] ),
+			'Subscriber should not have manage_options capability'
+		);
+
+		// Test with non-existent capabilities
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'fake_capability_1', 'fake_capability_2' ] ),
+			'Should return false for non-existent capabilities'
+		);
+	}
+
+	/**
+	 * Test user_has_any_capability with empty or invalid input
+	 */
+	public function test_user_has_any_capability_with_invalid_input() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Empty capabilities array
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [] ),
+			'Should return false for empty capabilities array'
+		);
+
+		// Null user
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( null, [ 'manage_options' ] ),
+			'Should return false for null user'
+		);
+
+		// Non-existent user
+		$fake_user = new \WP_User( 999999 );
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $fake_user, [ 'manage_options' ] ),
+			'Should return false for non-existent user'
+		);
+	}
+
+	/**
+	 * Test that user_has_any_capability directly checks allcaps array
+	 */
+	public function test_user_has_any_capability_uses_allcaps() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'subscriber',
+		) );
+
+		// Directly add a capability to allcaps without going through WP capability system
+		$user->allcaps['custom_capability'] = true;
+
+		// This should return true because we're checking allcaps directly
+		$this->assertTrue( 
+			Capability_Utils::user_has_any_capability( $user, [ 'custom_capability' ] ),
+			'Should find capability in allcaps array'
+		);
+
+		// Test with falsy capability value
+		$user->allcaps['disabled_capability'] = false;
+		$this->assertFalse( 
+			Capability_Utils::user_has_any_capability( $user, [ 'disabled_capability' ] ),
+			'Should return false for falsy capability value'
+		);
+	}
+
+	/**
+	 * Test that method doesn't trigger infinite loops in map_meta_cap context
+	 * This test simulates the conditions that would cause an infinite loop
+	 */
+	public function test_no_infinite_loop_in_map_meta_cap() {
+		$user = $this->factory->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Track if we're in a potential infinite loop
+		$call_count = 0;
+		$max_calls = 5;
+
+		add_filter( 'map_meta_cap', function( $caps, $cap, $user_id, $args ) use ( $user, &$call_count, $max_calls ) {
+			$call_count++;
+			
+			// Prevent actual infinite loop in test
+			if ( $call_count > $max_calls ) {
+				$this->fail( 'Potential infinite loop detected in map_meta_cap' );
+			}
+
+			// This should NOT cause infinite loop because we check allcaps directly
+			if ( 'test_capability' === $cap ) {
+				$current_user = get_user_by( 'id', $user_id );
+				Capability_Utils::user_has_any_capability( $current_user, [ 'manage_options' ] );
+			}
+
+			return $caps;
+		}, 10, 4 );
+
+		// Trigger map_meta_cap
+		user_can( $user, 'test_capability' );
+
+		// Remove filter
+		remove_all_filters( 'map_meta_cap' );
+
+		// If we got here without failing, the test passed
+		$this->assertLessThanOrEqual( $max_calls, $call_count, 'Should not exceed max calls' );
+	}
+
+	/**
+	 * Test normalize_capabilities_input
+	 */
+	public function test_normalize_capabilities_input() {
+		// String input
+		$this->assertEquals( 
+			[ 'manage_options' ], 
+			Capability_Utils::normalize_capabilities_input( 'manage_options' ),
+			'Should convert string to array'
+		);
+
+		// Array input
+		$this->assertEquals( 
+			[ 'manage_options', 'edit_posts' ], 
+			Capability_Utils::normalize_capabilities_input( [ 'manage_options', 'edit_posts' ] ),
+			'Should return valid array as-is'
+		);
+
+		// Empty values filtered out
+		$this->assertEquals( 
+			[ 'manage_options' ], 
+			Capability_Utils::normalize_capabilities_input( [ 'manage_options', '', '   ', null ] ),
+			'Should filter out empty values'
+		);
+
+		// Invalid input types
+		$this->assertEquals( [], Capability_Utils::normalize_capabilities_input( null ) );
+		$this->assertEquals( [], Capability_Utils::normalize_capabilities_input( 123 ) );
+		$this->assertEquals( [], Capability_Utils::normalize_capabilities_input( new \stdClass() ) );
+	}
+
+	/**
+	 * Test normalize_roles_input
+	 */
+	public function test_normalize_roles_input() {
+		// String input
+		$this->assertEquals( 
+			[ 'administrator' ], 
+			Capability_Utils::normalize_roles_input( 'administrator' ),
+			'Should convert string to array'
+		);
+
+		// Array input with filtering
+		$this->assertEquals( 
+			[ 'administrator', 'editor' ], 
+			Capability_Utils::normalize_roles_input( [ 'administrator', '', 'editor', '   ' ] ),
+			'Should filter out empty values'
+		);
+	}
+}

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -55,8 +55,9 @@ class Capability_Utils {
 			return false;
 		}
 		
-		// Ensure allcaps is an array to prevent fatal errors
-		if ( ! isset( $user->allcaps ) || ! is_array( $user->allcaps ) ) {
+		// Ensure allcaps exists and is an array to prevent fatal errors
+		// Check property_exists first to satisfy PHPStan, then check if it's set and is array
+		if ( ! property_exists( $user, 'allcaps' ) || ! is_array( $user->allcaps ) ) {
 			return false;
 		}
 		

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -56,8 +56,13 @@ class Capability_Utils {
 		}
 		
 		// Ensure allcaps exists and is an array to prevent fatal errors
-		// Check property_exists first to satisfy PHPStan, then check if it's set and is array
+		// phpcs:ignore -- PHPStan thinks allcaps always exists, but it can be unset/corrupted
+		// @phpstan-ignore-next-line
 		if ( ! property_exists( $user, 'allcaps' ) || ! is_array( $user->allcaps ) ) {
+			Logger::error(
+				'Capability_Utils::user_has_any_capability',
+				'allcaps does not exist or is not an array'
+			);
 			return false;
 		}
 		

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -43,6 +43,9 @@ class Capability_Utils {
 	/**
 	 * Check if a user has any of the specified capabilities (OR logic).
 	 * 
+	 * This method directly checks the allcaps array to avoid infinite loops
+	 * when called from within map_meta_cap filters.
+	 * 
 	 * @param \WP_User|false|null $user The user to check.
 	 * @param array $capabilities Array of capabilities to check.
 	 * @return bool True if user has any of the capabilities, false otherwise.
@@ -53,8 +56,8 @@ class Capability_Utils {
 		}
 		
 		foreach ( $capabilities as $capability ) {
-			// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is from configuration
-			if ( user_can( $user, $capability ) ) {
+			// Check if capability exists and is truthy
+			if ( isset( $user->allcaps[ $capability ] ) && $user->allcaps[ $capability ] ) {
 				return true;
 			}
 		}

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -55,7 +55,17 @@ class Capability_Utils {
 			return false;
 		}
 		
+		// Ensure allcaps is an array to prevent fatal errors
+		if ( ! isset( $user->allcaps ) || ! is_array( $user->allcaps ) ) {
+			return false;
+		}
+		
 		foreach ( $capabilities as $capability ) {
+			// Skip non-scalar capabilities to prevent errors
+			if ( ! is_scalar( $capability ) ) {
+				continue;
+			}
+			
 			// Check if capability exists and is truthy
 			if ( isset( $user->allcaps[ $capability ] ) && $user->allcaps[ $capability ] ) {
 				return true;


### PR DESCRIPTION
## Description

This PR updates the `Capability_Utils::user_has_any_capability()` method to directly check the `allcaps` array instead of using `user_can()`, preventing infinite loops when called from within `map_meta_cap` filters.

## Why is this change necessary?

When checking user capabilities inside WordPress's `map_meta_cap` filter, calling `user_can()` creates an infinite loop because:
1. `user_can()` internally calls `map_meta_cap`
2. `map_meta_cap` calls our custom code
3. Our code calls `user_can()` again
4. This creates a recursive loop that never ends

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

To duplicate OOM:
1. Start local env with the code from production
2. Add this to `vip-security-boost.php`
```
function allow_any_user_edit_no_admin( $caps, $cap, $user_id, $args ) {
	if ( in_array( 'administrator', wp_get_current_user()->roles, true ) && in_array( $cap, [ 'edit_user', 'remove_user' ], true ) && ! empty( $args ) ) {
		$user = get_user_by( 'ID', $args[0] );
		if ( is_a( $user, 'WP_User' ) && ! in_array( 'administrator', $user->roles, true ) ) {
			$caps[] = 'manage_options';
			$caps   = array_diff( $caps, [ 'do_not_allow' ] );
		} elseif ( 'remove_user' === $cap && in_array( 'administrator', $user->roles, true ) ) {
			$caps[] = 'do_not_allow';
		}
	}
	return $caps;
}

add_filter( 'map_meta_cap', __NAMESPACE__ . '\\allow_any_user_edit_no_admin', 10, 4 );
```
3. Update `class-inactive-users.php` 
4. Comment out line 142-145
<img width="762" height="253" alt="image" src="https://github.com/user-attachments/assets/1b5516ec-4500-42fb-aa8b-a5f56865d7bb" />
5. Comment out line 801-803
<img width="1059" height="117" alt="image" src="https://github.com/user-attachments/assets/a2e863b9-f111-43ec-9f3c-7adca7a47359" />
6. This should call `self::user_has_elevated_permissions( $user );`
7. Try to login, you should encounter an error

```
php-1  | 2025-08-01T19:03:31.843598387Z [01-Aug-2025 19:03:31] WARNING: [pool www] child 1382 exited on signal 11 (SIGSEGV) after 563.253717 seconds from start
php-1  | 2025-08-01T19:03:31.844248137Z [01-Aug-2025 19:03:31] NOTICE: [pool www] child 1406 started
php-1  | 2025-08-01T19:03:32.789562637Z [01-Aug-2025 19:03:32] WARNING: [pool www] child 1391 exited on signal 11 (SIGSEGV) after 527.341823 seconds from start
php-1  | 2025-08-01T19:03:32.790078804Z [01-Aug-2025 19:03:32] NOTICE: [pool www] child 1408 started
```
<img width="484" height="989" alt="image" src="https://github.com/user-attachments/assets/fe06c14e-0af6-419d-9b77-66ab3e5a7649" />


To test the fix:
1. Pull the changes on this PR 
2. Try to login again there 