### PR TITLE
Fix network-wide user queries with capability filtering

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -124,7 +124,9 @@ class Highlight_MFA_Users {
 	 *
 	 * @return int The number of users with MFA disabled.
 	 */
-	private static function get_mfa_disabled_count() {
+	private static function get_mfa_disabled_count( $blog_id = null ) {
+		$blog_id = $blog_id ?? get_current_blog_id();
+
 		// Try to get from cache first
 		$cached_count = wp_cache_get( self::get_mfa_count_cache_key(), self::MFA_COUNT_CACHE_GROUP );
 		if ( false !== $cached_count ) {
@@ -151,16 +153,20 @@ class Highlight_MFA_Users {
 			'exclude' => $skipped_user_ids,
 			'number'  => -1, // Get all relevant users
 		];
-		
+
 		// Use native capability filtering if capabilities are configured
 		if ( Capability_Utils::are_capabilities_configured( self::$capabilities ) ) {
 			$args['capability__in'] = self::$capabilities;
 		} else {
 			$args['role__in'] = self::$roles;
 		}
-		
-		$user_query = new \WP_User_Query( $args );
-		$user_ids   = $user_query->get_results();
+
+		// Use our utility method that properly handles network-wide capability filtering
+		$user_ids = \Automattic\VIP\Security\Utils\Users_Query_Utils::query_users_with_capability_filtering(
+			$args,
+			$blog_id,
+			false // return user IDs, not count
+		);
 
 		$mfa_disabled_count = 0;
 		foreach ( $user_ids as $user_id ) {

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -328,13 +328,12 @@ class Inactive_Users {
 			}
 		}
 
-		$args = array_merge( [
-			'blog_id'     => $blog_id,
-			'count_total' => true,
-		], self::get_inactive_users_query_args() );
-
-		$users_query = new \WP_User_Query( $args );
-		$count       = $users_query->get_total();
+		// Use our utility method that properly handles network-wide capability filtering
+		$count = \Automattic\VIP\Security\Utils\Users_Query_Utils::query_users_with_capability_filtering(
+			self::get_inactive_users_query_args(),
+			$blog_id,
+			true // count only
+		);
 
 		// Cache the result for global queries (blog_id = 0)
 		if ( 0 === $blog_id ) {

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -685,6 +685,122 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the new Users_Query_Utils::query_users_with_capability_filtering method
+	 */
+	public function test_users_query_utils_capability_filtering() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create a site and users with different roles
+		$site_id = $this->factory->blog->create();
+
+		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
+
+		// Add users to the site
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_id );
+		add_user_to_blog( $site_id, $admin_user, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		restore_current_blog();
+
+		// Test 1: Site-specific query with capability filtering
+		$site_count = \Automattic\VIP\Security\Utils\Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			$site_id,
+			true // count only
+		);
+
+		$this->assertEquals( 1, $site_count, 'Site-specific query should return 1 user with manage_options capability' );
+
+		// Test our new utility method with capability filtering
+		$network_user_ids = \Automattic\VIP\Security\Utils\Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			0, // network-wide
+			false // return user IDs
+		);
+
+		// Our utility should properly filter by capabilities
+		$this->assertContains( $admin_user, $network_user_ids, 'Network-wide query should include our admin user' );
+		$this->assertNotContains( $editor_user, $network_user_ids, 'Network-wide query should not include editor user' );
+
+		// Test count as well
+		$network_count = \Automattic\VIP\Security\Utils\Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			0, // network-wide
+			true // count only
+		);
+
+		// Should be at least 1 (our admin user), but may include other admin users from test setup
+		$this->assertGreaterThanOrEqual( 1, $network_count, 'Network-wide count should include at least our admin user' );
+		$this->assertEquals( count( $network_user_ids ), $network_count, 'Count should match array length' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+	}
+
+	/**
+	 * Test that the integrated get_inactive_users_count method now works correctly with network-wide queries
+	 */
+	public function test_integrated_get_inactive_users_count_network_wide() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create a site and users with different roles
+		$site_id = $this->factory->blog->create();
+
+		$admin_user = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+
+		$editor_user = $this->factory->user->create([
+			'role'            => 'editor',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+
+		// Add users to the site with their respective roles
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_id );
+		add_user_to_blog( $site_id, $admin_user, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		restore_current_blog();
+
+		// Make all users inactive
+		update_user_meta( $admin_user, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		update_user_meta( $editor_user, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Remove ignore flags
+		delete_user_meta( $admin_user, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		delete_user_meta( $editor_user, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+
+		// Flush cache to ensure fresh counts
+		Inactive_Users::flush_cache();
+
+		// Test the integrated method with network-wide query (blog_id=0)
+		$network_count = Inactive_Users::get_inactive_users_count( 0 );
+
+		// The integrated method should now properly filter by capabilities/roles
+		// It should include admin users but not editor users (based on the default config)
+		$this->assertGreaterThanOrEqual( 1, $network_count, 'Network-wide count should include at least our admin user' );
+
+		// Test site-specific query still works
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_id );
+		$site_count = Inactive_Users::get_inactive_users_count( $site_id );
+		restore_current_blog();
+
+		$this->assertEquals( 1, $site_count, 'Site-specific count should only include administrator users' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+	}
+
+	/**
 	 * Test that only inactive are returned for the blocked filter
 	 */
 	public function test_only_inactive_and_release_users_are_returned_blocked_filter(): void {

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -1,0 +1,323 @@
+<?php
+
+use Automattic\VIP\Security\Utils\Users_Query_Utils;
+
+/**
+ * Tests for Automattic\VIP\Security\Utils\Users_Query_Utils
+ */
+class UsersQueryUtilsTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		
+		// Ensure we have a clean cache state
+		wp_cache_flush();
+	}
+
+	public function tearDown(): void {
+		// Clean up any test data
+		wp_cache_flush();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that our utility method works correctly for site-specific queries
+	 */
+	public function test_site_specific_query_with_capability_filtering() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create a site and users with different roles
+		$site_id = $this->factory->blog->create();
+		
+		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
+		
+		// Add users to the site
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_id );
+		add_user_to_blog( $site_id, $admin_user, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		restore_current_blog();
+
+		// Test site-specific query with capability filtering
+		$site_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			$site_id,
+			true // count only
+		);
+		
+		$this->assertEquals( 1, $site_count, 'Site-specific query should return 1 user with manage_options capability' );
+
+		// Test site-specific query with role filtering
+		$site_role_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'role__in' => [ 'administrator' ] ],
+			$site_id,
+			true // count only
+		);
+		
+		$this->assertEquals( 1, $site_role_count, 'Site-specific query should return 1 user with administrator role' );
+
+		// Test getting user IDs instead of count
+		$site_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			$site_id,
+			false // return user IDs
+		);
+		
+		$this->assertCount( 1, $site_user_ids, 'Should return array with 1 user ID' );
+		$this->assertEquals( $admin_user, $site_user_ids[0], 'Should return the admin user ID' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+	}
+
+	/**
+	 * Test that WordPress core WP_User_Query fails with network-wide capability filtering
+	 * and that our utility method succeeds
+	 */
+	public function test_network_wide_capability_filtering_core_vs_utility() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create a site and users with different roles
+		$site_id = $this->factory->blog->create();
+		
+		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
+		
+		// Add users to the site
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site_id );
+		add_user_to_blog( $site_id, $admin_user, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		restore_current_blog();
+
+		// Test 1: WordPress core WP_User_Query with blog_id=0 (should fail to filter properly)
+		$core_query   = new \WP_User_Query([
+			'blog_id'        => 0, // network-wide
+			'capability__in' => [ 'manage_options' ],
+			'fields'         => 'ID',
+		]);
+		$core_results = $core_query->get_results();
+		
+		// WordPress core ignores capability filtering with blog_id=0
+		// This assertion demonstrates the core issue
+		$this->assertGreaterThan( 1, count( $core_results ), 
+		'WordPress core WP_User_Query with blog_id=0 ignores capability filtering and returns too many users' );
+		
+		// Test 2: Our utility method with network-wide query (should work correctly)
+		$utility_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			0, // network-wide
+			false // return user IDs
+		);
+		
+		// Our utility should properly filter by capabilities
+		$this->assertContains( $admin_user, $utility_user_ids, 'Our utility should include the admin user' );
+		$this->assertNotContains( $editor_user, $utility_user_ids, 'Our utility should not include the editor user' );
+		
+		// Test 3: Compare counts - our utility should return fewer users than core
+		$utility_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			0, // network-wide
+			true // count only
+		);
+		
+		$this->assertLessThan( count( $core_results ), $utility_count,
+		'Our utility should return fewer users than WordPress core (which ignores filtering)' );
+		$this->assertEquals( count( $utility_user_ids ), $utility_count, 
+		'Count should match array length from our utility' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+	}
+
+	/**
+	 * Test network-wide role filtering
+	 */
+	public function test_network_wide_role_filtering() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create multiple sites with different users
+		$site1_id = $this->factory->blog->create();
+		$site2_id = $this->factory->blog->create();
+		
+		$admin_user      = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user     = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$subscriber_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		
+		// Add admin to site 1
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site1_id );
+		add_user_to_blog( $site1_id, $admin_user, 'administrator' );
+		restore_current_blog();
+		
+		// Add editor to site 2
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+		switch_to_blog( $site2_id );
+		add_user_to_blog( $site2_id, $editor_user, 'editor' );
+		add_user_to_blog( $site2_id, $subscriber_user, 'subscriber' );
+		restore_current_blog();
+
+		// Test network-wide role filtering for administrators
+		$admin_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'role__in' => [ 'administrator' ] ],
+			0, // network-wide
+			true // count only
+		);
+		
+		$this->assertGreaterThanOrEqual( 1, $admin_count, 'Should find at least our admin user across the network' );
+
+		// Test network-wide role filtering for editors
+		$editor_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'role__in' => [ 'editor' ] ],
+			0, // network-wide
+			true // count only
+		);
+		
+		$this->assertGreaterThanOrEqual( 1, $editor_count, 'Should find at least our editor user across the network' );
+
+		// Test multiple roles
+		$admin_editor_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'role__in' => [ 'administrator', 'editor' ] ],
+			0, // network-wide
+			true // count only
+		);
+		
+		$this->assertGreaterThanOrEqual( 2, $admin_editor_count, 'Should find both admin and editor users across the network' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+		wp_delete_user( $subscriber_user );
+	}
+
+	/**
+	 * Test that the utility method handles additional query arguments correctly
+	 */
+	public function test_utility_with_additional_query_args() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		// Create users with different registration dates
+		$old_admin = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		
+		$new_admin = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ),
+		]);
+
+		// Test with date_query to filter by registration date
+		$old_admin_count = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options' ],
+			'date_query'     => [
+				[
+					'column' => 'user_registered',
+					'before' => '50 days ago',
+				],
+			],
+		], 0, true);
+		
+		$this->assertGreaterThanOrEqual( 1, $old_admin_count, 'Should find old admin users' );
+
+		// Test with exclude parameter
+		$excluded_count = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options' ],
+			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Testing exclude functionality in controlled test environment
+			'exclude'        => [ $old_admin ],
+		], 0, true);
+		
+		// Should find fewer users when excluding the old admin
+		$total_count = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options' ],
+		], 0, true);
+		
+		$this->assertLessThan( $total_count, $excluded_count, 'Excluding users should reduce the count' );
+
+		// Clean up
+		wp_delete_user( $old_admin );
+		wp_delete_user( $new_admin );
+	}
+
+	/**
+	 * Test single site behavior (non-multisite)
+	 */
+	public function test_single_site_behavior() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'This test is for single site installations only' );
+		}
+
+		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
+
+		// Test that blog_id=0 falls back to current site behavior
+		$count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options' ] ],
+			0, // should fall back to current site
+			true // count only
+		);
+		
+		$this->assertGreaterThanOrEqual( 1, $count, 'Should find admin users on single site' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+		wp_delete_user( $editor_user );
+	}
+
+	/**
+	 * Test that duplicate capability/role conditions are properly deduplicated
+	 */
+	public function test_capability_role_deduplication() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires multisite to be enabled' );
+		}
+
+		$admin_user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		// Test with overlapping capabilities and roles
+		// 'manage_options' capability maps to 'administrator' role, so this should be deduplicated
+		$count_with_overlap = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options' ],
+			'role__in'       => [ 'administrator' ], // This should be deduplicated since admin has manage_options
+		], 0, true);
+
+		// Test with just capability
+		$count_capability_only = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options' ],
+		], 0, true);
+
+		// Test with just role
+		$count_role_only = Users_Query_Utils::query_users_with_capability_filtering([
+			'role__in' => [ 'administrator' ],
+		], 0, true);
+
+		// All three queries should return the same count since they're targeting the same users
+		// This verifies that deduplication doesn't affect the results
+		$this->assertEquals( $count_capability_only, $count_with_overlap,
+		'Overlapping capability and role should return same count as capability alone (deduplication working)' );
+		$this->assertEquals( $count_role_only, $count_with_overlap,
+		'Overlapping capability and role should return same count as role alone (deduplication working)' );
+
+		// Test with multiple capabilities that map to the same role
+		$count_multiple_caps = Users_Query_Utils::query_users_with_capability_filtering([
+			'capability__in' => [ 'manage_options', 'edit_users', 'delete_users' ], // All map to administrator
+		], 0, true);
+
+		$this->assertEquals( $count_role_only, $count_multiple_caps,
+		'Multiple capabilities mapping to same role should return same count as role alone' );
+
+		// Clean up
+		wp_delete_user( $admin_user );
+	}
+}

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -28,27 +28,41 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'This test requires multisite to be enabled' );
 		}
 
-		// Create a site and users with different roles
+		// Create a site and multiple users with different roles
 		$site_id = $this->factory->blog->create();
-		
-		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
-		
+
+		// Create multiple users per role to test counting accuracy
+		$admin_user1  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$admin_user2  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user1 = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$editor_user2 = $this->factory->user->create( [ 'role' => 'editor' ] );
+
 		// Add users to the site
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site_id );
-		add_user_to_blog( $site_id, $admin_user, 'administrator' );
-		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		add_user_to_blog( $site_id, $admin_user1, 'administrator' );
+		add_user_to_blog( $site_id, $admin_user2, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user1, 'editor' );
+		add_user_to_blog( $site_id, $editor_user2, 'editor' );
 		restore_current_blog();
 
-		// Test site-specific query with capability filtering
+		// Test site-specific query with single capability filtering
 		$site_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[ 'capability__in' => [ 'manage_options' ] ],
 			$site_id,
 			true // count only
 		);
-		
-		$this->assertEquals( 1, $site_count, 'Site-specific query should return 1 user with manage_options capability' );
+
+		$this->assertEquals( 2, $site_count, 'Site-specific query should return exactly 2 users with manage_options capability' );
+
+		// Test site-specific query with multiple capabilities
+		$site_multi_cap_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options', 'edit_posts' ] ],
+			$site_id,
+			true // count only
+		);
+
+		$this->assertEquals( 4, $site_multi_cap_count, 'Site-specific query should return exactly 4 users with manage_options OR edit_posts capabilities' );
 
 		// Test site-specific query with role filtering
 		$site_role_count = Users_Query_Utils::query_users_with_capability_filtering(
@@ -56,8 +70,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			$site_id,
 			true // count only
 		);
-		
-		$this->assertEquals( 1, $site_role_count, 'Site-specific query should return 1 user with administrator role' );
+
+		$this->assertEquals( 2, $site_role_count, 'Site-specific query should return exactly 2 users with administrator role' );
 
 		// Test getting user IDs instead of count
 		$site_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
@@ -65,13 +79,16 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			$site_id,
 			false // return user IDs
 		);
-		
-		$this->assertCount( 1, $site_user_ids, 'Should return array with 1 user ID' );
-		$this->assertEquals( $admin_user, $site_user_ids[0], 'Should return the admin user ID' );
+
+		$this->assertCount( 2, $site_user_ids, 'Should return array with exactly 2 user IDs' );
+		$this->assertContains( $admin_user1, $site_user_ids, 'Should contain first admin user ID' );
+		$this->assertContains( $admin_user2, $site_user_ids, 'Should contain second admin user ID' );
 
 		// Clean up
-		wp_delete_user( $admin_user );
-		wp_delete_user( $editor_user );
+		wp_delete_user( $admin_user1 );
+		wp_delete_user( $admin_user2 );
+		wp_delete_user( $editor_user1 );
+		wp_delete_user( $editor_user2 );
 	}
 
 	/**
@@ -83,17 +100,22 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'This test requires multisite to be enabled' );
 		}
 
-		// Create a site and users with different roles
+		// Create a site and multiple users with different roles
 		$site_id = $this->factory->blog->create();
-		
-		$admin_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		$editor_user = $this->factory->user->create( [ 'role' => 'editor' ] );
-		
+
+		// Create multiple users per role to test counting accuracy
+		$admin_user1  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$admin_user2  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user1 = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$editor_user2 = $this->factory->user->create( [ 'role' => 'editor' ] );
+
 		// Add users to the site
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site_id );
-		add_user_to_blog( $site_id, $admin_user, 'administrator' );
-		add_user_to_blog( $site_id, $editor_user, 'editor' );
+		add_user_to_blog( $site_id, $admin_user1, 'administrator' );
+		add_user_to_blog( $site_id, $admin_user2, 'administrator' );
+		add_user_to_blog( $site_id, $editor_user1, 'editor' );
+		add_user_to_blog( $site_id, $editor_user2, 'editor' );
 		restore_current_blog();
 
 		// Test 1: WordPress core WP_User_Query with blog_id=0 (should fail to filter properly)
@@ -103,38 +125,43 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			'fields'         => 'ID',
 		]);
 		$core_results = $core_query->get_results();
-		
+
 		// WordPress core ignores capability filtering with blog_id=0
 		// This assertion demonstrates the core issue
-		$this->assertGreaterThan( 1, count( $core_results ), 
+		$this->assertGreaterThan( 2, count( $core_results ),
 		'WordPress core WP_User_Query with blog_id=0 ignores capability filtering and returns too many users' );
-		
-		// Test 2: Our utility method with network-wide query (should work correctly)
+
+		// Test 2: method with network-wide query (should work correctly)
 		$utility_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
 			[ 'capability__in' => [ 'manage_options' ] ],
 			0, // network-wide
 			false // return user IDs
 		);
-		
-		// Our utility should properly filter by capabilities
-		$this->assertContains( $admin_user, $utility_user_ids, 'Our utility should include the admin user' );
-		$this->assertNotContains( $editor_user, $utility_user_ids, 'Our utility should not include the editor user' );
-		
+
+		// should properly filter by capabilities
+		$this->assertContains( $admin_user1, $utility_user_ids, 'should include the first admin user' );
+		$this->assertContains( $admin_user2, $utility_user_ids, 'should include the second admin user' );
+		$this->assertNotContains( $editor_user1, $utility_user_ids, 'should not include the first editor user' );
+		$this->assertNotContains( $editor_user2, $utility_user_ids, 'should not include the second editor user' );
+
 		// Test 3: Compare counts - our utility should return fewer users than core
 		$utility_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[ 'capability__in' => [ 'manage_options' ] ],
 			0, // network-wide
 			true // count only
 		);
-		
+
 		$this->assertLessThan( count( $core_results ), $utility_count,
-		'Our utility should return fewer users than WordPress core (which ignores filtering)' );
-		$this->assertEquals( count( $utility_user_ids ), $utility_count, 
+		'should return fewer users than WordPress core (which ignores filtering)' );
+		$this->assertEquals( count( $utility_user_ids ), $utility_count,
 		'Count should match array length from our utility' );
+		$this->assertEquals( 2, $utility_count, 'should return exactly 2 admin users' );
 
 		// Clean up
-		wp_delete_user( $admin_user );
-		wp_delete_user( $editor_user );
+		wp_delete_user( $admin_user1 );
+		wp_delete_user( $admin_user2 );
+		wp_delete_user( $editor_user1 );
+		wp_delete_user( $editor_user2 );
 	}
 
 	/**
@@ -148,21 +175,26 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		// Create multiple sites with different users
 		$site1_id = $this->factory->blog->create();
 		$site2_id = $this->factory->blog->create();
-		
-		$admin_user      = $this->factory->user->create( [ 'role' => 'administrator' ] );
-		$editor_user     = $this->factory->user->create( [ 'role' => 'editor' ] );
+
+		// Create multiple users per role to test counting accuracy
+		$admin_user1     = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$admin_user2     = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$editor_user1    = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$editor_user2    = $this->factory->user->create( [ 'role' => 'editor' ] );
 		$subscriber_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		
-		// Add admin to site 1
+
+		// Add admins to site 1
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site1_id );
-		add_user_to_blog( $site1_id, $admin_user, 'administrator' );
+		add_user_to_blog( $site1_id, $admin_user1, 'administrator' );
+		add_user_to_blog( $site1_id, $admin_user2, 'administrator' );
 		restore_current_blog();
-		
-		// Add editor to site 2
+
+		// Add editors and subscriber to site 2
 		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
 		switch_to_blog( $site2_id );
-		add_user_to_blog( $site2_id, $editor_user, 'editor' );
+		add_user_to_blog( $site2_id, $editor_user1, 'editor' );
+		add_user_to_blog( $site2_id, $editor_user2, 'editor' );
 		add_user_to_blog( $site2_id, $subscriber_user, 'subscriber' );
 		restore_current_blog();
 
@@ -172,8 +204,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			0, // network-wide
 			true // count only
 		);
-		
-		$this->assertGreaterThanOrEqual( 1, $admin_count, 'Should find at least our admin user across the network' );
+
+		$this->assertEquals( 2, $admin_count, 'Should find exactly 2 admin users across the network' );
 
 		// Test network-wide role filtering for editors
 		$editor_count = Users_Query_Utils::query_users_with_capability_filtering(
@@ -181,8 +213,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			0, // network-wide
 			true // count only
 		);
-		
-		$this->assertGreaterThanOrEqual( 1, $editor_count, 'Should find at least our editor user across the network' );
+
+		$this->assertEquals( 2, $editor_count, 'Should find exactly 2 editor users across the network' );
 
 		// Test multiple roles
 		$admin_editor_count = Users_Query_Utils::query_users_with_capability_filtering(
@@ -190,12 +222,23 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			0, // network-wide
 			true // count only
 		);
-		
-		$this->assertGreaterThanOrEqual( 2, $admin_editor_count, 'Should find both admin and editor users across the network' );
+
+		$this->assertEquals( 4, $admin_editor_count, 'Should find exactly 4 users (2 admins + 2 editors) across the network' );
+
+		// Test multiple capabilities
+		$multi_cap_count = Users_Query_Utils::query_users_with_capability_filtering(
+			[ 'capability__in' => [ 'manage_options', 'edit_posts' ] ],
+			0, // network-wide
+			true // count only
+		);
+
+		$this->assertEquals( 4, $multi_cap_count, 'Should find exactly 4 users with manage_options OR edit_posts capabilities' );
 
 		// Clean up
-		wp_delete_user( $admin_user );
-		wp_delete_user( $editor_user );
+		wp_delete_user( $admin_user1 );
+		wp_delete_user( $admin_user2 );
+		wp_delete_user( $editor_user1 );
+		wp_delete_user( $editor_user2 );
 		wp_delete_user( $subscriber_user );
 	}
 

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -155,7 +155,7 @@ class Users_Query_Utils {
 		$subquery = "{$wpdb->users}.ID IN (
 			SELECT DISTINCT user_id
 			FROM {$wpdb->usermeta}
-			WHERE meta_key LIKE '%_capabilities'
+			WHERE meta_key LIKE 'wp%_capabilities'
 			AND (" . implode( ' OR ', $capability_checks ) . ')
 		)';
 

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -151,11 +151,12 @@ class Users_Query_Utils {
 		}
 
 		// Meta keys follow pattern: {prefix}_capabilities or {prefix}_{site_id}_capabilities
+		$base_prefix = $wpdb->base_prefix; // Always 'wp_' unless customized
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
 		$subquery = "{$wpdb->users}.ID IN (
 			SELECT DISTINCT user_id
 			FROM {$wpdb->usermeta}
-			WHERE meta_key LIKE 'wp%_capabilities'
+			WHERE meta_key LIKE '{$base_prefix}%_capabilities'
 			AND (" . implode( ' OR ', $capability_checks ) . ')
 		)';
 

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -30,4 +30,160 @@ class Users_Query_Utils {
 
 		return $count_sql;
 	}
+
+	/**
+	 * Perform a user query with proper capability/role filtering for network-wide queries.
+	 *
+	 * This method solves the WordPress core issue where WP_User_Query ignores
+	 * capability__in and role__in parameters when blog_id=0 is used.
+	 *
+	 * Similar to fix_found_users_query, this leverages WP_User_Query to build
+	 * the base SQL and then modifies the WHERE clause to add network-wide
+	 * capability/role filtering.
+	 *
+	 * @param array $query_args WP_User_Query arguments. Should include capability__in or role__in.
+	 * @param int   $blog_id    Blog ID. Use 0 for network-wide queries.
+	 * @param bool  $count_only Whether to return only the count (true) or user IDs (false).
+	 * @return int|array Returns count (int) if $count_only is true, otherwise array of user IDs.
+	 */
+	public static function query_users_with_capability_filtering( $query_args, $blog_id = null, $count_only = true ) {
+		global $wpdb;
+
+		// Single blog query
+		if ( ! is_multisite() || 0 !== $blog_id ) {
+			$query_args['blog_id'] = $blog_id;
+			if ( $count_only ) {
+				$query_args['count_total'] = true;
+				$query_args['fields']      = 'ID';
+				$query_args['number']      = 1; // We only need the count
+			} else {
+				$query_args['fields'] = 'ID';
+			}
+
+			$user_query = new \WP_User_Query( $query_args );
+			return $count_only ? $user_query->get_total() : $user_query->get_results();
+		}
+
+		// Network-wide query
+		$capabilities = $query_args['capability__in'] ?? [];
+		$roles        = $query_args['role__in'] ?? [];
+
+		// Remove capability/role filters from query args and let WP_User_Query build the base query
+		$base_query_args = $query_args;
+		unset( $base_query_args['capability__in'], $base_query_args['role__in'] );
+		$base_query_args['fields'] = 'ID';
+
+		// Create WP_User_Query to get the base SQL clauses
+		$temp_query = new \WP_User_Query( $base_query_args );
+
+		// Build our network-wide capability filtering clause
+		$capability_where = self::build_network_capability_where_clause( $capabilities, $roles );
+
+		if ( empty( $capability_where ) ) {
+			// No capability/role filtering needed, use the temp query results
+			return $count_only ? $temp_query->get_total() : $temp_query->get_results();
+		}
+
+		// Build the final query using WP_User_Query's SQL with our additional WHERE clause
+		if ( $count_only ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
+			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
+			$sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$result = $wpdb->get_var( $sql );
+			return (int) $result;
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
+			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
+			$sql = "SELECT DISTINCT {$wpdb->users}.ID {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$results = $wpdb->get_col( $sql );
+			return array_map( 'intval', $results );
+		}
+	}
+
+	/**
+	 * Build a WHERE clause for network-wide capability/role filtering.
+	 *
+	 * This creates a subquery that checks if the user has the required
+	 * capabilities or roles on any site in the network using pattern matching.
+	 *
+	 * @param array $capabilities Required capabilities (OR logic).
+	 * @param array $roles        Required roles (OR logic).
+	 * @return string SQL WHERE clause condition (without WHERE keyword).
+	 */
+	private static function build_network_capability_where_clause( $capabilities, $roles ) {
+		global $wpdb;
+
+		$capabilities = array_filter( (array) $capabilities );
+		$roles        = array_filter( (array) $roles );
+
+		if ( empty( $capabilities ) && empty( $roles ) ) {
+			return '';
+		}
+
+		$capability_checks = [];
+
+		// Build capability conditions - convert capabilities to roles
+		if ( ! empty( $capabilities ) ) {
+			foreach ( $capabilities as $capability ) {
+				$roles_with_capability = self::get_roles_with_capability( $capability );
+				foreach ( $roles_with_capability as $role ) {
+					$role                = esc_sql( $role );
+					$capability_checks[] = "meta_value LIKE '%\"{$role}\";b:1%'";
+				}
+			}
+		}
+
+		// Build role conditions
+		if ( ! empty( $roles ) ) {
+			foreach ( $roles as $role ) {
+				$role                = esc_sql( $role );
+				$capability_checks[] = "meta_value LIKE '%\"{$role}\";b:1%'";
+			}
+		}
+
+		// Remove duplicates to avoid redundant SQL conditions
+		$capability_checks = array_unique( $capability_checks );
+
+		if ( empty( $capability_checks ) ) {
+			return '';
+		}
+
+		// Meta keys follow pattern: {prefix}_capabilities or {prefix}_{site_id}_capabilities
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
+		$subquery = "{$wpdb->users}.ID IN (
+			SELECT DISTINCT user_id
+			FROM {$wpdb->usermeta}
+			WHERE meta_key LIKE '%_capabilities'
+			AND (" . implode( ' OR ', $capability_checks ) . ')
+		)';
+
+		return $subquery;
+	}
+
+	/**
+	 * Get all roles that have a specific capability.
+	 *
+	 * @param string $capability The capability to check for.
+	 * @return array Array of role names that have the capability.
+	 */
+	private static function get_roles_with_capability( $capability ) {
+		global $wp_roles;
+
+		if ( ! isset( $wp_roles ) ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Initializing $wp_roles if not set, standard WordPress pattern
+			$wp_roles = new \WP_Roles();
+		}
+
+		$roles_with_capability = [];
+
+		foreach ( $wp_roles->roles as $role_name => $role_info ) {
+			if ( isset( $role_info['capabilities'][ $capability ] ) && $role_info['capabilities'][ $capability ] ) {
+				$roles_with_capability[] = $role_name;
+			}
+		}
+
+		return $roles_with_capability;
+	}
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with network-wide user queries in WordPress multisite environments where `WP_User_Query` ignores `capability__in` and `role__in` parameters when `blog_id=0` is used.

WordPress core ignores `capabilities_in` filters when `blog_id=0`. See https://github.com/WordPress/WordPress/blob/52a06d5ed4dfd0a2ff94231f6eb9afe57b417f1f/wp-includes/class-wp-user-query.php#L557

The solution introduces a new utility method in `Users_Query_Utils` that allows us to perform network-wide user queries with proper capability/role filtering

This utility is then applied to both the inactive users module and the MFA highlight module to ensure accurate user counts and queries across the entire network.

## Changelog Description

### Fixed
- Fixed network-wide user queries ignoring capability and role filters in multisite environments

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Set up a WordPress multisite environment
2. Create users with different roles across multiple sites
3. Enable the inactive users and MFA highlight modules
4. Verify that user counts are accurate when querying network-wide (blog_id=0)
5. Check that capability and role filtering works correctly for network-wide queries

You can add something like:

```
$count_of_admins = Users_Query_Utils::query_users_with_capability_filtering(
	[ 'capability__in' => [ 'manage_options' ] ],
	0,
	true
);

error_log( 'Number of admins: ' . $count_of_admins );
```

to the end of the `vip-security-boost.php` file to test the counts.

6. Confirm that the modules now properly count users across all sites in the network

**Technical Details:**
- The new `Users_Query_Utils::query_users_with_capability_filtering()` method builds custom SQL queries that properly handle network-wide capability filtering
- The `fix_found_users_query()` method replaces unreliable `FOUND_ROWS()` with direct `COUNT(DISTINCT ID)` queries
- Both methods reuse WordPress's existing query building logic to ensure compatibility and security