### PR TITLE
Fix infinite loop using recursion guard

### DIFF
--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -20,7 +20,8 @@ class Capability_Utils {
 	 * @var array<int, bool>
 	 */
 	private static $checking_capability = [];
-	
+	const LOG_FEATURE_NAME              = 'sb_capability_utils';
+
 	/**
 	 * Check if a user has elevated permissions based on capabilities or roles.
 	 * 
@@ -68,7 +69,11 @@ class Capability_Utils {
 		// Check if we're already checking capabilities for this user
 		if ( isset( self::$checking_capability[ $user->ID ] ) && self::$checking_capability[ $user->ID ] ) {
 			// We're in a recursive call - fall back to allcaps check
-			return self::user_has_any_capability( $user, $capabilities );
+			Logger::error(
+				self::LOG_FEATURE_NAME,
+				'Recursion detected in user_has_any_capability_full for user ID ' . $user->ID
+			);
+				return self::user_has_any_capability( $user, $capabilities );
 		}
 		
 		// Set recursion guard
@@ -112,7 +117,7 @@ class Capability_Utils {
 		}
 		
 		// Ensure allcaps exists and is an array to prevent fatal errors
-		// phpcs:ignore -- PHPStan thinks allcaps always exists, but it can be unset/corrupted
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_allcaps -- PHPStan thinks allcaps always exists, but it can be unset/corrupted
 		// @phpstan-ignore-next-line
 		if ( ! property_exists( $user, 'allcaps' ) || ! is_array( $user->allcaps ) ) {
 			Logger::error(

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -14,6 +14,14 @@ namespace Automattic\VIP\Security\Utils;
 class Capability_Utils {
 	
 	/**
+	 * Track recursion state per user ID to prevent infinite loops.
+	 * Uses user ID as key to handle concurrent checks for different users.
+	 * 
+	 * @var array<int, bool>
+	 */
+	private static $checking_capability = [];
+	
+	/**
 	 * Check if a user has elevated permissions based on capabilities or roles.
 	 * 
 	 * @param \WP_User|false|null $user The user to check.
@@ -34,14 +42,65 @@ class Capability_Utils {
 		$roles        = self::normalize_roles_input( $roles );
 		
 		if ( ! empty( $capabilities ) ) {
-			return self::user_has_any_capability( $user, $capabilities );
+			// Always use full resolution for capabilities (detects dynamic grants)
+			return self::user_has_any_capability_full( $user, $capabilities );
 		}
 		
 		return self::user_has_any_role( $user, $roles );
 	}
 	
 	/**
+	 * Check if a user has any of the specified capabilities using full capability resolution.
+	 * 
+	 * This method uses user_can() to check capabilities, which includes dynamic grants
+	 * from map_meta_cap and user_has_cap filters. It includes recursion protection
+	 * to prevent infinite loops when called from within capability filters.
+	 * 
+	 * @param \WP_User|false|null $user The user to check.
+	 * @param array $capabilities Array of capabilities to check.
+	 * @return bool True if user has any of the capabilities, false otherwise.
+	 */
+	public static function user_has_any_capability_full( $user, $capabilities ): bool {
+		if ( ! ( $user instanceof \WP_User ) || ! $user->exists() || empty( $capabilities ) ) {
+			return false;
+		}
+		
+		// Check if we're already checking capabilities for this user
+		if ( isset( self::$checking_capability[ $user->ID ] ) && self::$checking_capability[ $user->ID ] ) {
+			// We're in a recursive call - fall back to allcaps check
+			return self::user_has_any_capability( $user, $capabilities );
+		}
+		
+		// Set recursion guard
+		self::$checking_capability[ $user->ID ] = true;
+		
+		$has_capability = false;
+		
+		try {
+			foreach ( $capabilities as $capability ) {
+				if ( ! is_scalar( $capability ) ) {
+					continue;
+				}
+				
+				// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is from configuration
+				if ( user_can( $user, $capability ) ) {
+					$has_capability = true;
+					break;
+				}
+			}
+		} finally {
+			// Always clear recursion guard, even if an exception occurs
+			unset( self::$checking_capability[ $user->ID ] );
+		}
+		
+		return $has_capability;
+	}
+	
+	/**
 	 * Check if a user has any of the specified capabilities (OR logic).
+	 * 
+	 * This method directly checks the allcaps array to avoid infinite loops
+	 * when called from within map_meta_cap filters.
 	 * 
 	 * @param \WP_User|false|null $user The user to check.
 	 * @param array $capabilities Array of capabilities to check.
@@ -52,9 +111,25 @@ class Capability_Utils {
 			return false;
 		}
 		
+		// Ensure allcaps exists and is an array to prevent fatal errors
+		// phpcs:ignore -- PHPStan thinks allcaps always exists, but it can be unset/corrupted
+		// @phpstan-ignore-next-line
+		if ( ! property_exists( $user, 'allcaps' ) || ! is_array( $user->allcaps ) ) {
+			Logger::error(
+				'Capability_Utils::user_has_any_capability',
+				'allcaps does not exist or is not an array'
+			);
+			return false;
+		}
+
 		foreach ( $capabilities as $capability ) {
-			// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is from configuration
-			if ( user_can( $user, $capability ) ) {
+			// Skip non-scalar capabilities to prevent errors
+			if ( ! is_scalar( $capability ) ) {
+				continue;
+			}
+			
+			// Check if capability exists and is truthy
+			if ( isset( $user->allcaps[ $capability ] ) && $user->allcaps[ $capability ] ) {
 				return true;
 			}
 		}

--- a/utils/class-capability-utils.php
+++ b/utils/class-capability-utils.php
@@ -83,7 +83,7 @@ class Capability_Utils {
 		
 		try {
 			foreach ( $capabilities as $capability ) {
-				if ( ! is_scalar( $capability ) ) {
+				if ( ! is_string( $capability ) || trim( $capability ) === '' ) {
 					continue;
 				}
 				
@@ -129,7 +129,7 @@ class Capability_Utils {
 
 		foreach ( $capabilities as $capability ) {
 			// Skip non-scalar capabilities to prevent errors
-			if ( ! is_scalar( $capability ) ) {
+			if ( ! is_string( $capability ) || trim( $capability ) === '' ) {
 				continue;
 			}
 			


### PR DESCRIPTION
## Description

This PR fixes an infinite loop issue in the `inactive-users`, `forced-mfa-users`  module by adding a recursion protection in Capability util.

**Note: Count Discrepancies**

  Dashboard counts may not match actual enforcement because:
  - Counts: Use database queries (checks stored roles/capabilities only)
  - Enforcement: Uses WordPress's full capability system (includes dynamic grants via `map_meta_cap` and `user_has_cap`
   filters)

Users with dynamically-granted capabilities will be affected by enforcement but won't appear in counts.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation).

## Steps to Test

1. Check out PR branch
2. Set forced-mfa-users to require for `manage_options` capabilitiy

```
curl -X POST "http://localhost:2999/v1/vip-integrations/backend/integration" -H "Content-Type: application/json" --data '{
  "slug": "security-boost",
  "level": "site",
  "site_id": 101,
  "status": "enabled",
  "config": {
    "enabled_modules": ["highlight-mfa-users","forced-mfa-users", "inactive-users", "session-control", "xml-rpc"],
    "module_configs": {
      "forced-mfa-users": {
        "capabilities": [
          "manage_options"
        ]
      }
    }
  }
}' | jq
```

3. Create a test `subscriber` user

```
vip dev-env exec --  wp user create testlocal test@localhost.local --role=subscriber --user_pass=password123`
```

4. Add 2FA local testing filter and a call to map_meta_cap in `vip-security-boost.php`, ths will upgrade subscribers to have `manage_options` cap, therefore require 2FA:
      ```php
      function test_map_meta_cap_grant( $caps, $cap, $user_id, $args ) {
      if ( 'manage_options' === $cap ) {
        $user = get_user_by( 'id', $user_id );
        if ( $user && in_array( 'subscriber', $user->roles ) ) {
          return [ 'read' ];
        }
      }
      return $caps;
    }
    add_filter( 'map_meta_cap', __NAMESPACE__ . '\\test_map_meta_cap_grant', 10, 4 );
    add_filter( 'wpcom_vip_is_two_factor_local_testing', '__return_true' );
   ```
5. Login using the test user and verify that your see the requires 2FA banner and it doesn't OOM
<img width="818" height="271" alt="image" src="https://github.com/user-attachments/assets/bbead441-bdb0-49fa-86cf-c00b2c086af5" />
6 Comment this out:

```php
    // add_filter( 'map_meta_cap', __NAMESPACE__ . '\\test_map_meta_cap_grant', 10, 4 );
```

7. Try to login again and verify that you **DO NOT** see the requires 2FA banner
