### PR TITLE
Exit only after wp_safe_redirect is true (fix tests)

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -643,8 +643,9 @@ class Inactive_Users {
 			'reset_last_seen_success' => 1,
 		), $url );
 
-		wp_safe_redirect( $url );
-		exit();
+		if ( wp_safe_redirect( $url ) ) {
+			exit();
+		}
 	}
 
 	public static function ignore_inactivity_check_for_user( $user_id, $until_timestamp = null ) {


### PR DESCRIPTION
Tests were running but not showing any output.

After some investigation, we discovered that the exit in the inactive users module was causing the issue.

This PR changes the logic so that we exit only if the safe redirect is successful. 

```
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

.................................S.............................  63 / 110 ( 57%)
..........F..SSS.SS3cabdb6a152ac92668cee4c2094e156fa2fd930e8f681428cd9f06c2f613383a
tests-1754390907000
```
