### PR TITLE
Fixes various unit tests due to PRs merged while our test runner wasn't working properly

### DIFF
--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -904,7 +904,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $current_site_admin );
 
 		// Verify the network user is not a member of the current site
-		$this->assertFalse( is_user_member_of_blog( $network_user_id, get_current_blog_id() ) );
+		$this->assertFalse( is_user_member_of_blog( $network_user_id, get_current_blog_id() ), 'Network user should not be a member of the current site' );
 
 		// Simulate the unblock action request
 		$_GET['action']                = 'reset_last_seen';
@@ -914,8 +914,11 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Call the unblock action method
 		Inactive_Users::last_seen_unblock_action();
 
-		// Verify that the user is still considered inactive, since the user is not a member of the current site
-		$this->assertTrue( Inactive_Users::is_considered_inactive( $network_user_id ) );
+		// Verify that notice was displayed
+		ob_start();
+		do_action( 'admin_notices' );
+		$output = ob_get_clean();
+		$this->assertStringContainsString( 'You can only unblock users who are members of this site.', $output );
 
 		// Clean up
 		wp_delete_user( $network_user_id );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -915,10 +915,11 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		Inactive_Users::last_seen_unblock_action();
 
 		// Verify that notice was displayed
+		set_current_screen( 'users' );
 		ob_start();
 		do_action( 'admin_notices' );
 		$output = ob_get_clean();
-		$this->assertStringContainsString( 'You can only unblock users who are members of this site.', $output );
+		$this->assertStringContainsString( 'You do not have permission to unblock this user.', $output );
 
 		// Clean up
 		wp_delete_user( $network_user_id );

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -133,7 +133,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test 2: method with network-wide query (should work correctly)
 		$utility_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'capability__in' => [ 'manage_options' ] ],
+			[
+				'capability__in' => [ 'manage_options' ],
+				'exclude'        => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			false // return user IDs
 		);
@@ -146,7 +149,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test 3: Compare counts - our utility should return fewer users than core
 		$utility_count = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'capability__in' => [ 'manage_options' ] ],
+			[
+				'capability__in' => [ 'manage_options' ],
+				'exclude'        => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			true // count only
 		);
@@ -200,7 +206,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test network-wide role filtering for administrators
 		$admin_count = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'role__in' => [ 'administrator' ] ],
+			[
+				'role__in' => [ 'administrator' ],
+				'exclude'  => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			true // count only
 		);
@@ -209,7 +218,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test network-wide role filtering for editors
 		$editor_count = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'role__in' => [ 'editor' ] ],
+			[
+				'role__in' => [ 'editor' ],
+				'exclude'  => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			true // count only
 		);
@@ -218,7 +230,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test multiple roles
 		$admin_editor_count = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'role__in' => [ 'administrator', 'editor' ] ],
+			[
+				'role__in' => [ 'administrator', 'editor' ],
+				'exclude'  => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			true // count only
 		);
@@ -227,7 +242,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Test multiple capabilities
 		$multi_cap_count = Users_Query_Utils::query_users_with_capability_filtering(
-			[ 'capability__in' => [ 'manage_options', 'edit_posts' ] ],
+			[
+				'capability__in' => [ 'manage_options', 'edit_posts' ],
+				'exclude'        => [ 1 ], // exclude the super admin user
+			],
 			0, // network-wide
 			true // count only
 		);

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -135,7 +135,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$utility_user_ids = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'capability__in' => [ 'manage_options' ],
-				'exclude'        => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'        => [ 1 ],
 			],
 			0, // network-wide
 			false // return user IDs
@@ -151,7 +152,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$utility_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'capability__in' => [ 'manage_options' ],
-				'exclude'        => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'        => [ 1 ],
 			],
 			0, // network-wide
 			true // count only
@@ -208,7 +210,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$admin_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'role__in' => [ 'administrator' ],
-				'exclude'  => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'  => [ 1 ],
 			],
 			0, // network-wide
 			true // count only
@@ -220,7 +223,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$editor_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'role__in' => [ 'editor' ],
-				'exclude'  => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'  => [ 1 ],
 			],
 			0, // network-wide
 			true // count only
@@ -232,7 +236,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$admin_editor_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'role__in' => [ 'administrator', 'editor' ],
-				'exclude'  => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'  => [ 1 ],
 			],
 			0, // network-wide
 			true // count only
@@ -244,7 +249,8 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$multi_cap_count = Users_Query_Utils::query_users_with_capability_filtering(
 			[
 				'capability__in' => [ 'manage_options', 'edit_posts' ],
-				'exclude'        => [ 1 ], // exclude the super admin user
+				// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Excluding super admin (user_id=1)
+				'exclude'        => [ 1 ],
 			],
 			0, // network-wide
 			true // count only

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -71,7 +71,8 @@ class Users_Query_Utils {
 		// Remove capability/role filters from query args and let WP_User_Query build the base query
 		$base_query_args = $query_args;
 		unset( $base_query_args['capability__in'], $base_query_args['role__in'] );
-		$base_query_args['fields'] = 'ID';
+		$base_query_args['fields']  = 'ID';
+		$base_query_args['blog_id'] = 0;
 
 		// Create WP_User_Query to get the base SQL clauses
 		$temp_query = new \WP_User_Query( $base_query_args );

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -151,12 +151,11 @@ class Users_Query_Utils {
 		}
 
 		// Meta keys follow pattern: {prefix}_capabilities or {prefix}_{site_id}_capabilities
-		$base_prefix = $wpdb->base_prefix; // Always 'wp_' unless customized
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
 		$subquery = "{$wpdb->users}.ID IN (
 			SELECT DISTINCT user_id
 			FROM {$wpdb->usermeta}
-			WHERE meta_key LIKE '{$base_prefix}%_capabilities'
+			WHERE meta_key LIKE 'wp%_capabilities'
 			AND (" . implode( ' OR ', $capability_checks ) . ')
 		)';
 

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -61,7 +61,7 @@ class Users_Query_Utils {
 			}
 
 			$user_query = new \WP_User_Query( $query_args );
-			return $count_only ? $user_query->get_total() : $user_query->get_results();
+			return $count_only ? $user_query->get_total() : array_map( 'intval', $user_query->get_results() );
 		}
 
 		// Network-wide query
@@ -81,7 +81,7 @@ class Users_Query_Utils {
 
 		if ( empty( $capability_where ) ) {
 			// No capability/role filtering needed, use the temp query results
-			return $count_only ? $temp_query->get_total() : $temp_query->get_results();
+			return $count_only ? $temp_query->get_total() : array_map( 'intval', $temp_query->get_results() );
 		}
 
 		// Build the final query using WP_User_Query's SQL with our additional WHERE clause


### PR DESCRIPTION
## Description

Related to https://github.com/Automattic/vip-security-boost/pull/77

- `base_prefix` doesn't work here because we're not dealing with a table name
- Test counts were not taking into account the default super admin user_id=1
- User query utility wasn't properly returning user ids as numbers
- Inactive suers block action test should check for admin notice error message

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->