### PR TITLE
Add new filter to require additional (custom) capabilities to have MFA and honor filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ composer test
 
 This script uses Docker to run the tests in an isolated environment.
 
+To test for a specific test module you can run
+
+```bash
+composer test -- --filter Test_Forced_MFA_Users
+```
+
+or, in case you want to test for a specific function you can run
+
+```bash
+composer test -- --filter test_honor_vip_should_force_two_factor
+```
+
 #### Testing Modules
 
 When testing classes defined within the `modules/` directory, ensure they are correctly autoloaded for the test environment. Add the necessary file paths to the `autoload-dev` section in `composer.json`:

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -98,12 +98,18 @@ class Forced_MFA_Users {
 			self::get_roles() // we're using the merged array of roles
 		);
 
-		if ( $user_has_two_factor_enforced ) {
-			// TODO migrate to wpcom_vip_internal_is_two_factor_forced once PR https://github.com/Automattic/vip-go-mu-plugins/pull/6424 is released
-			add_filter( 'wpcom_vip_is_two_factor_forced', function () {
-				return true;
-			}, PHP_INT_MAX );
+		// we're intentionally applying the is_two_factor_forced filter with a default of "true" to check if someone is overriding the value and returning false.
+		$is_forced_to_false_via_filter = apply_filters( 'wpcom_vip_is_two_factor_forced', true ) === false;
+		if ( $is_forced_to_false_via_filter ) {
+			// honor the filter and don't enforce 2FA
+			error_log( 'Forced MFA Users: User has 2FA forced via filter, but filter returned false.' );
+			return;
 		}
+
+		add_filter( 'wpcom_vip_internal_is_two_factor_forced', function ( $limited ) use ( $user_has_two_factor_enforced ) {
+			// we're honoring the $limited value in case it's stricter than ours.
+			return $limited || $user_has_two_factor_enforced;
+		}, PHP_INT_MAX, 1 );
 	}
 }
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -5,8 +5,8 @@ use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Forced_MFA_Users {
-	public const ADDITIONAL_CAPABILITIES_FILTER_NAME = 'wpcom_vip_sb_forced_mfa_users_additional_capabilities';
-	public const ADDITIONAL_ROLES_FILTER_NAME        = 'wpcom_vip_sb_forced_mfa_users_additional_roles';
+	public const ADDITIONAL_CAPABILITIES_FILTER_NAME = 'wpcom_vip_wsc_forced_mfa_users_additional_capabilities';
+	public const ADDITIONAL_ROLES_FILTER_NAME        = 'wpcom_vip_wsc_forced_mfa_users_additional_roles';
 	/**
 	 * The roles that should have MFA enforced.
 	 *

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -5,6 +5,7 @@ use Automattic\VIP\Security\Utils\Configs;
 use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Forced_MFA_Users {
+	public const ADDITIONAL_CAPABILITIES_FILTER_NAME = 'wpcom_vip_sb_forced_mfa_users_additional_capabilities';
 	/**
 	 * The roles that should have MFA enforced.
 	 *
@@ -36,6 +37,17 @@ class Forced_MFA_Users {
 		}
 
 		add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ], 10 );
+		add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_custom_enforced_capabilities_to_sds' ] );
+	}
+
+	public static function add_custom_enforced_capabilities_to_sds( $data ) {
+		$has_custom_capabilities_filter = has_filter( self::ADDITIONAL_CAPABILITIES_FILTER_NAME ) !== false;
+		$data['custom_capabilities']    = $has_custom_capabilities_filter ? self::get_custom_enforced_capabilities() : [];
+		return $data;
+	}
+
+	public static function get_custom_enforced_capabilities() {
+		return Capability_Utils::normalize_capabilities_input( apply_filters( self::ADDITIONAL_CAPABILITIES_FILTER_NAME, [] ) );
 	}
 
 	/**
@@ -55,10 +67,12 @@ class Forced_MFA_Users {
 			return;
 		}
 
+		$custom_enforced_capabilities = self::get_custom_enforced_capabilities();
+
 		// Check if user has elevated permissions based on capabilities or roles
 		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions(
 			$user,
-			self::$capabilities,
+			array_merge( self::$capabilities, $custom_enforced_capabilities ),
 			self::$roles
 		);
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -72,7 +72,7 @@ class Forced_MFA_Users {
 		// Check if user has elevated permissions based on capabilities or roles
 		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions(
 			$user,
-			array_merge( self::$capabilities, $custom_enforced_capabilities ),
+			array_unique( array_merge( self::$capabilities, $custom_enforced_capabilities ) ),
 			self::$roles
 		);
 

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -6,6 +6,7 @@ use Automattic\VIP\Security\Utils\Capability_Utils;
 
 class Forced_MFA_Users {
 	public const ADDITIONAL_CAPABILITIES_FILTER_NAME = 'wpcom_vip_sb_forced_mfa_users_additional_capabilities';
+	public const ADDITIONAL_ROLES_FILTER_NAME        = 'wpcom_vip_sb_forced_mfa_users_additional_roles';
 	/**
 	 * The roles that should have MFA enforced.
 	 *
@@ -42,12 +43,36 @@ class Forced_MFA_Users {
 
 	public static function add_custom_enforced_capabilities_to_sds( $data ) {
 		$has_custom_capabilities_filter = has_filter( self::ADDITIONAL_CAPABILITIES_FILTER_NAME ) !== false;
-		$data['custom_capabilities']    = $has_custom_capabilities_filter ? self::get_custom_enforced_capabilities() : [];
+		$data['custom_capabilities']    = $has_custom_capabilities_filter ? implode( ',', self::get_custom_enforced_capabilities() ) : 'false';
+		$has_custom_roles_filter        = has_filter( self::ADDITIONAL_ROLES_FILTER_NAME ) !== false;
+		$data['custom_roles']           = $has_custom_roles_filter ? implode( ',', self::get_custom_enforced_roles() ) : 'false';
 		return $data;
 	}
 
 	public static function get_custom_enforced_capabilities() {
 		return Capability_Utils::normalize_capabilities_input( apply_filters( self::ADDITIONAL_CAPABILITIES_FILTER_NAME, [] ) );
+	}
+
+	public static function get_custom_enforced_roles() {
+		return Capability_Utils::normalize_roles_input( apply_filters( self::ADDITIONAL_ROLES_FILTER_NAME, [] ) );
+	}
+
+	/**
+	 * Returns the merged array of capabilities from the config and the custom enforced capabilities
+	 *
+	 * @return array
+	 */
+	public static function get_capabilities() {
+		return array_unique( array_merge( self::$capabilities, self::get_custom_enforced_capabilities() ) );
+	}
+
+	/**
+	 * Returns the merged array of roles from the config and the custom enforced roles
+	 *
+	 * @return array
+	 */
+	public static function get_roles() {
+		return array_unique( array_merge( self::$roles, self::get_custom_enforced_roles() ) );
 	}
 
 	/**
@@ -66,14 +91,11 @@ class Forced_MFA_Users {
 		if ( ! $user->exists() ) {
 			return;
 		}
-
-		$custom_enforced_capabilities = self::get_custom_enforced_capabilities();
-
 		// Check if user has elevated permissions based on capabilities or roles
 		$user_has_two_factor_enforced = Capability_Utils::user_has_elevated_permissions(
 			$user,
-			array_unique( array_merge( self::$capabilities, $custom_enforced_capabilities ) ),
-			self::$roles
+			self::get_capabilities(), // we're using the merged array of capabilities
+			self::get_roles() // we're using the merged array of roles
 		);
 
 		if ( $user_has_two_factor_enforced ) {

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -102,7 +102,6 @@ class Forced_MFA_Users {
 		$is_forced_to_false_via_filter = apply_filters( 'wpcom_vip_is_two_factor_forced', true ) === false;
 		if ( $is_forced_to_false_via_filter ) {
 			// honor the filter and don't enforce 2FA
-			error_log( 'Forced MFA Users: User has 2FA forced via filter, but filter returned false.' );
 			return;
 		}
 

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -429,4 +429,67 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		sort( $actual_roles );
 		$this->assertSame( $expected_roles, $actual_roles, 'Custom roles should match the normalized output from the filter.' );
 	}
+	/**
+	 * Test the logic to get the capabilities
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_capabilities() {
+		$default_capabilities = [ 'manage_options', 'edit_posts' ];
+		$default_roles        = [ 'administrator', 'subscriber' ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [
+					'capabilities' => $default_capabilities,
+					'roles'        => $default_roles,
+				],
+			],
+		] );
+		Forced_MFA_Users::init();
+		$this->assertEquals( $default_capabilities, Forced_MFA_Users::get_capabilities() );
+		add_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME, function () use ( $default_capabilities ) {
+			return $default_capabilities;
+		} );
+		$this->assertEquals( array_unique( array_merge( $default_capabilities, $default_capabilities ) ), Forced_MFA_Users::get_capabilities() );
+		remove_all_filters( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME );
+		$this->assertEquals( $default_capabilities, Forced_MFA_Users::get_capabilities() );
+		add_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME, function () {
+			return [ 'other_capability', 'edit_posts' ];
+		} );
+		$this->assertEquals( array_unique( array_merge( $default_capabilities, [ 'other_capability' ] ) ), Forced_MFA_Users::get_capabilities() );
+		remove_all_filters( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME );
+	}
+
+	/**
+	 * Test the logic to get the roles.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_roles() {
+		$default_capabilities = [ 'manage_options', 'edit_posts' ];
+		$default_roles        = [ 'administrator', 'subscriber' ];
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [
+					'capabilities' => $default_capabilities,
+					'roles'        => $default_roles,
+				],
+			],
+		] );
+		Forced_MFA_Users::init();
+		$this->assertEquals( $default_roles, Forced_MFA_Users::get_roles() );
+		add_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME, function () use ( $default_roles ) {
+			return $default_roles;
+		} );
+		$this->assertEquals( array_unique( array_merge( $default_roles, $default_roles ) ), Forced_MFA_Users::get_roles() );
+		remove_all_filters( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME );
+		$this->assertEquals( $default_roles, Forced_MFA_Users::get_roles() );
+		add_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME, function () {
+			return [ 'other_role', 'subscriber' ];
+		} );
+		$this->assertEquals( array_unique( array_merge( $default_roles, [ 'other_role' ] ) ), Forced_MFA_Users::get_roles() );
+		remove_all_filters( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME );
+	}
 }

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -494,7 +494,8 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the logic to get the roles.
+	 * Test that the logic honors the vip_should_force_two_factor filter returning false,
+	 * ensuring two-factor enforcement is not applied in that case.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -374,4 +374,59 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 		$this->assertFalse( has_action( 'set_current_user', [ Forced_MFA_Users::class, 'maybe_enforce_two_factor' ] ) );
 	}
+
+	/**
+	 * Ensure add_custom_enforced_capabilities_to_sds returns empty array when no additional capabilities filter present.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_custom_enforced_capabilities_roles_to_sds_without_filter() {
+		// Prepare dummy input data
+		$payload = [ 'foo' => 'bar' ];
+
+		// Sanity: the filter should not be present
+		$this->assertFalse( has_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME ) );
+		$this->assertFalse( has_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME ) );
+
+		$result = Forced_MFA_Users::add_custom_enforced_capabilities_to_sds( $payload );
+
+		$this->assertArrayHasKey( 'custom_capabilities', $result );
+		$this->assertSame( 'false', $result['custom_capabilities'], 'Expected custom_capabilities to be an empty array when no filter is registered.' );
+		$this->assertArrayHasKey( 'custom_roles', $result );
+		$this->assertSame( 'false', $result['custom_roles'], 'Expected custom_roles to be an empty array when no filter is registered.' );
+	}
+
+	/**
+	 * Ensure add_custom_enforced_capabilities_to_sds correctly injects normalized capabilities when the additional capabilities filter is present.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_custom_enforced_capabilities_roles_to_sds_with_filter() {
+		// Define a filter that returns a mix of whitespace and duplicates to test normalization
+		add_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME, static function () {
+			return [ 'manage_options', 'edit_posts' ];
+		} );
+		add_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME, static function () {
+			return [ 'administrator', 'subscriber' ];
+		} );
+
+		$payload = [ 'foo' => 'bar' ];
+
+		$result = Forced_MFA_Users::add_custom_enforced_capabilities_to_sds( $payload );
+
+		$this->assertArrayHasKey( 'custom_capabilities', $result );
+		$expected_capabilities = [ 'manage_options', 'edit_posts' ];
+		sort( $expected_capabilities );
+		$actual_capabilities = explode( ',', $result['custom_capabilities'] );
+		sort( $actual_capabilities );
+		$this->assertSame( $expected_capabilities, $actual_capabilities, 'Custom capabilities should match the normalized output from the filter.' );
+		$this->assertArrayHasKey( 'custom_roles', $result );
+		$expected_roles = [ 'administrator', 'subscriber' ];
+		sort( $expected_roles );
+		$actual_roles = explode( ',', $result['custom_roles'] );
+		sort( $actual_roles );
+		$this->assertSame( $expected_roles, $actual_roles, 'Custom roles should match the normalized output from the filter.' );
+	}
 }

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -528,7 +528,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 
 	/**
-	 * Test the logic to get the roles.
+	 * Test that the logic honors the vip_should_force_two_factor filter when it returns true.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -492,4 +492,78 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		$this->assertEquals( array_unique( array_merge( $default_roles, [ 'other_role' ] ) ), Forced_MFA_Users::get_roles() );
 		remove_all_filters( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME );
 	}
+
+	/**
+	 * Test the logic to get the roles.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_honor_vip_should_force_two_factor_false() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [
+					'capabilities' => [ 'manage_options' ],
+					'roles'        => [],
+				],
+			],
+		] );
+
+		// we're now removing the filter to ensure that the logic is working as expected
+		remove_all_filters( 'wpcom_vip_is_two_factor_forced' );
+		remove_all_filters( 'wpcom_vip_internal_is_two_factor_forced' );
+		Forced_MFA_Users::init();
+		add_filter( 'wpcom_vip_is_two_factor_forced', function () {
+			return false;
+		} );
+		$this->setup_user_and_filter( 'administrator' );
+
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true because we honor the wpcom_vip_is_two_factor_forced filter.' );
+		// we're now removing the filter to ensure that the logic is working as expected
+		remove_all_filters( 'wpcom_vip_is_two_factor_forced' );
+		remove_all_filters( 'wpcom_vip_internal_is_two_factor_forced' );
+		Forced_MFA_Users::maybe_enforce_two_factor();
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
+	}
+
+
+	/**
+	 * Test the logic to get the roles.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_honor_vip_should_force_two_factor_true() {
+		define( 'VIP_SECURITY_BOOST_CONFIGS', [
+			'module_configs' => [
+				'forced-mfa-users' => [
+					'capabilities' => [],
+					'roles'        => [ 'administrator' ],
+				],
+			],
+		] );
+
+		// we're now removing the filter to ensure that the logic is working as expected
+		remove_all_filters( 'wpcom_vip_is_two_factor_forced' );
+		remove_all_filters( 'wpcom_vip_internal_is_two_factor_forced' );
+		Forced_MFA_Users::init();
+		add_filter( 'wpcom_vip_is_two_factor_forced', function () {
+			return true;
+		} );
+		// we're creating an editor user but will require admin role to enforce 2FA
+		$this->setup_user_and_filter( 'editor' );
+
+		// testing both the wpcom_vip_is_two_factor_forced function that will change based on the filter, and how the internal filter works once we add our MFA enforcement
+		$this->assertTrue( wpcom_vip_is_two_factor_forced(), 'Filter should be true because we honor the wpcom_vip_is_two_factor_forced filter.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', true ), 'Filter should be true because we honor the wpcom_vip_is_two_factor_forced filter.' );
+
+		// we're now removing the filter to ensure that the logic is working as expected
+		remove_all_filters( 'wpcom_vip_is_two_factor_forced' );
+		remove_all_filters( 'wpcom_vip_internal_is_two_factor_forced' );
+		Forced_MFA_Users::maybe_enforce_two_factor();
+
+		// testing both the wpcom_vip_is_two_factor_forced function that will change based on the filter, and how the internal filter works once we add our MFA enforcement
+		$this->assertFalse( wpcom_vip_is_two_factor_forced(), 'Filter should be false when user has none of the required capabilities.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be false when user has none of the required capabilities.' );
+	}
 }

--- a/tests/phpunit/test-forced-mfa-users.php
+++ b/tests/phpunit/test-forced-mfa-users.php
@@ -11,8 +11,8 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		add_action( 'wpcom_vip_is_two_factor_local_testing', '__return_true' ); // Tell the two-factor plugin we're in local testing
 
 		// removing these for the SDS testing part
-		remove_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' );
-		remove_filter( 'wpcom_vip_is_two_factor_forced', [ Attendant::instance(), 'bypass_two_factor_auth' ], PHP_INT_MAX );
+		remove_filter( 'wpcom_vip_internal_is_two_factor_forced', '__return_false' );
+		remove_filter( 'wpcom_vip_internal_is_two_factor_forced', [ Attendant::instance(), 'bypass_two_factor_auth' ], PHP_INT_MAX );
 
 		// Loads the Two_Factor_Core class (required for the wpcom_vip_should_force_two_factor to work)
 		require_once WPVIP_MU_PLUGIN_DIR . '/shared-plugins/two-factor/two-factor.php';
@@ -114,7 +114,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init(); // Run init to set the static property
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when no role is set.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true when no role is set.' );
 	}
 
 	/**
@@ -130,7 +130,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the single required role.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has the single required role.' );
 	}
 
 	/**
@@ -146,7 +146,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'subscriber' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks the single required role.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true when user lacks the single required role.' );
 	}
 
 	/**
@@ -163,7 +163,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'editor' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required roles.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has one of the required roles.' );
 	}
 
 	/**
@@ -180,7 +180,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'author' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks all required roles.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true when user lacks all required roles.' );
 	}
 
 	/**
@@ -197,7 +197,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true with an empty role array.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true with an empty role array.' );
 	}
 
 	/**
@@ -214,7 +214,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'editor' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has a valid role even if other array items are invalid.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has a valid role even if other array items are invalid.' );
 	}
 
 	/**
@@ -231,7 +231,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when all roles in array are invalid types.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true when all roles in array are invalid types.' );
 	}
 
 	/**
@@ -250,7 +250,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		add_filter( 'wpcom_vip_is_user_using_two_factor', '__return_true' ); // we're using this to change the behavior of the wpcom_vip_should_force_two_factor to return false.
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_should_force_two_factor returns false even if the user has the required capability.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true if wpcom_vip_should_force_two_factor returns false even if the user has the required capability.' );
 	}
 
 	/**
@@ -271,7 +271,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 		// Create administrator user (has manage_options capability but not subscriber role)
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the required capability.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has the required capability.' );
 	}
 
 	/**
@@ -289,7 +289,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 		// Administrator has edit_posts capability
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has the single required capability.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has the single required capability.' );
 	}
 
 	/**
@@ -307,7 +307,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 
 		// Subscriber doesn't have manage_options capability
 		$this->setup_user_and_filter( 'subscriber' );
-		$this->assertFalse( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should not be true when user lacks the required capability.' );
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should not be true when user lacks the required capability.' );
 	}
 
 	/**
@@ -332,7 +332,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		Forced_MFA_Users::maybe_enforce_two_factor();
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should be true when user has one of the required capabilities.' );
 	}
 
 	/**
@@ -352,7 +352,7 @@ class Test_Forced_MFA_Users extends WP_UnitTestCase {
 		Forced_MFA_Users::init();
 
 		$this->setup_user_and_filter( 'administrator' );
-		$this->assertTrue( apply_filters( 'wpcom_vip_is_two_factor_forced', false ), 'Filter should use roles when capabilities array is empty.' );
+		$this->assertTrue( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ), 'Filter should use roles when capabilities array is empty.' );
 	}
 
 	/**


### PR DESCRIPTION
## Description

This PR introduces two new filters for customers to require additional roles or capabilities to be protected.
New filters
* `wpcom_vip_wsc_forced_mfa_users_additional_capabilities` -> returns an array of capabilities
* `wpcom_vip_wsc_forced_mfa_users_additional_roles` -> returns an array of roles

This two filters will only append capabilities to what's being configure at the dashboard level. They won't have a way to remove the config from the dashboard.

We also started using the newly introduced `wpcom_vip_internal_is_two_factor_forced` filter, and implemented logic to honor the previous configuration of `wpcom_vip_is_two_factor_forced` if present.
To do so, we
* Check if, by `apply_filters('wpcom_vip_is_two_factor_forced', true)` (notice the true) it returns false. If so, we can assume that there's a filter returning false somewhere and we should trust it.
* Otherwise, in the `wpcom_vip_internal_is_two_factor_forced` we'll require MFA based on the input or if we detected 2FA requirement.

**🚨 Important**: This PR requires this code (https://github.com/Automattic/vip-go-mu-plugins/pull/6424) to be released in mu-plugins production. Don't merge it if it's not released yet.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
### Setup

**Step 1:** 
Generate an admin user and an editor user, these will be used to test the 2FA enforcements

**Step 2**
By default the local environment won't enforce 2FA. 
To make sure the module works 
* add `add_filter( 'wpcom_vip_is_two_factor_local_testing', '__return_true' );` in https://github.com/Automattic/vip-security-boost/blob/7e17dd0f68c8b68ff4133f80ecb528932e84b472/vip-security-boost.php#L61
* add `remove_filter( 'wpcom_vip_is_two_factor_forced', '__return_false' );` right at the beginning of the `maybe_enforce_two_factor` [function](https://github.com/Automattic/vip-security-boost/blob/7e17dd0f68c8b68ff4133f80ecb528932e84b472/modules/forced-mfa-users/class-forced-mfa-users.php#L81), this will revert [the filter added by the `dev-env-plugin.php` file](https://github.com/Automattic/vip-container-images/blob/9f4b8fea96bc5b4b437307fbf0e344993f253159/wordpress/dev-tools/dev-env-plugin.php#L47)

### Testing
1. Check out PR.
1. set your site to require 2FA for Admins (or `manage_options` only) 
1. Login as admin, you should be prompted to have MFA (this is the standard behavior)
2. login as editor, no MFA should be required.

#### Custom Roles/Capabilities testing

Add this filter to the `vip-security-boost.php` file
```
add_filter( 'wpcom_vip_wsc_forced_mfa_users_additional_capabilities', function () {
	return [ 'other_capability', 'edit_posts' ];
} );
```
Refresh the page with the editor, now it should require the MFA

Same should happen if you replace the filter with (be aware that capabilities take precedence, so you need capabilities to be removed from the config and roles set instead)

```
add_filter( 'wpcom_vip_wsc_forced_mfa_users_additional_roles', function () {
	return [ 'other_role', 'editor' ];
} );
```

#### Honoring previous config testing

We also want to honor the previous config, if someone added a filter to `wpcom_vip_is_two_factor_forced`.
Before continuing remove the `wpcom_vip_wsc_forced_mfa_users_additional_roles` or `wpcom_vip_wsc_forced_mfa_users_additional_capabilities` filter you have added, but keep the rests.
Check, again, that for the editor 2FA is not required while for the admin it is.

Then, add this code to the `vip-security-boost.php`

```
add_filter( 'wpcom_vip_is_two_factor_forced', function () {
	return true;
} );
```
Logging in as the editor should require 2FA.

If you switch it to false, the admin should not get the 2FA request anymore, meaning we are honoring the previous filter.
