### PR TITLE
[PLTFRM-1497] Fix cache keys for 2FA disabled SDS data

### DIFF
--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -225,8 +225,13 @@ class Highlight_MFA_Users {
 	 * Clear the MFA disabled count cache.
 	 * Called when user MFA settings or roles change.
 	 */
-	public static function clear_mfa_count_cache() {
-		wp_cache_delete( self::get_mfa_count_cache_key(), self::MFA_COUNT_CACHE_GROUP );
+	public static function clear_mfa_count_cache( $blog_id = null ) {
+		$blog_id = $blog_id ?? get_current_blog_id();
+
+		wp_cache_delete( self::get_mfa_count_cache_key( $blog_id ), self::MFA_COUNT_CACHE_GROUP );
+
+		// Clear the network-wide key as well
+    wp_cache_delete( self::get_mfa_count_cache_key( 0 ), self::MFA_COUNT_CACHE_GROUP );
 	}
 
 	/**
@@ -241,6 +246,9 @@ class Highlight_MFA_Users {
 			self::clear_mfa_count_cache();
 			return;
 		}
+
+		// Clear the network-wide key as well
+		wp_cache_delete( self::get_mfa_count_cache_key( 0 ), self::MFA_COUNT_CACHE_GROUP );
 
 		// Get all sites where this user has roles
 		$user_blogs = get_blogs_of_user( $user_id );

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -157,9 +157,10 @@ class Highlight_MFA_Users {
 	 */
 	private static function get_mfa_disabled_count( $blog_id = null ) {
 		$blog_id = $blog_id ?? get_current_blog_id();
+		$cache_key = self::get_mfa_count_cache_key( $blog_id );
 
 		// Try to get from cache first
-		$cached_count = wp_cache_get( self::get_mfa_count_cache_key(), self::MFA_COUNT_CACHE_GROUP );
+		$cached_count = wp_cache_get( $cache_key, self::MFA_COUNT_CACHE_GROUP );
 		if ( false !== $cached_count ) {
 			return (int) $cached_count;
 		}
@@ -208,7 +209,7 @@ class Highlight_MFA_Users {
 
 		// Cache the result
 		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
-		wp_cache_set( self::get_mfa_count_cache_key(), $mfa_disabled_count, self::MFA_COUNT_CACHE_GROUP, self::MFA_COUNT_CACHE_TTL );
+		wp_cache_set( $cache_key, $mfa_disabled_count, self::MFA_COUNT_CACHE_GROUP, self::MFA_COUNT_CACHE_TTL );
 
 		return $mfa_disabled_count;
 	}

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -149,7 +149,7 @@ class Highlight_MFA_Users {
 		$caps  = array_values( array_unique( self::$capabilities ) );
 
 		sort( $roles, SORT_STRING );
-		sort( $caps,  SORT_STRING );
+		sort( $caps, SORT_STRING );
 
 		$roles_hash        = md5( wp_json_encode( $roles ) );
 		$capabilities_hash = md5( wp_json_encode( $caps ) );
@@ -163,7 +163,7 @@ class Highlight_MFA_Users {
 	 * @return int The number of users with MFA disabled.
 	 */
 	private static function get_mfa_disabled_count( $blog_id = null ) {
-		$blog_id = $blog_id ?? get_current_blog_id();
+		$blog_id   = $blog_id ?? get_current_blog_id();
 		$cache_key = self::get_mfa_count_cache_key( $blog_id );
 
 		// Try to get from cache first
@@ -231,7 +231,7 @@ class Highlight_MFA_Users {
 		wp_cache_delete( self::get_mfa_count_cache_key( $blog_id ), self::MFA_COUNT_CACHE_GROUP );
 
 		// Clear the network-wide key as well
-    wp_cache_delete( self::get_mfa_count_cache_key( 0 ), self::MFA_COUNT_CACHE_GROUP );
+		wp_cache_delete( self::get_mfa_count_cache_key( 0 ), self::MFA_COUNT_CACHE_GROUP );
 	}
 
 	/**

--- a/modules/highlight-mfa-users/class-highlight-mfa-users.php
+++ b/modules/highlight-mfa-users/class-highlight-mfa-users.php
@@ -144,8 +144,15 @@ class Highlight_MFA_Users {
 		$blog_id = $blog_id ?? get_current_blog_id();
 
 		// Include a hash of the roles configuration to invalidate cache when roles change
-		$roles_hash        = md5( wp_json_encode( self::$roles ) );
-		$capabilities_hash = md5( wp_json_encode( self::$capabilities ) );
+		// Remove duplicates + sort to make the cache key stable regardless of array order
+		$roles = array_values( array_unique( self::$roles ) );
+		$caps  = array_values( array_unique( self::$capabilities ) );
+
+		sort( $roles, SORT_STRING );
+		sort( $caps,  SORT_STRING );
+
+		$roles_hash        = md5( wp_json_encode( $roles ) );
+		$capabilities_hash = md5( wp_json_encode( $caps ) );
 
 		return self::MFA_COUNT_CACHE_KEY_PREFIX . '_' . $blog_id . '_' . $roles_hash . '_' . $capabilities_hash;
 	}


### PR DESCRIPTION
## Description
1. Highlight 2FA module: Scope the cache key by `$blog_id` so per-network site and network-wide results don’t collide when calculating the `users_without_2fa_count_all_blogs` count for users who have 2FA disabled across all network sites. Without this, the value from the first per-network site call (usually site id 1) populates the cache and subsequent network-wide requests just return the initial site value.

2. Highlight 2FA module: For the same cache key, remove duplicate caps/roles in the array we receive and set the array to be fixed so the cache key doesn't change even if we have two arrays with the same keys but in different order.

```
{
  "vip_security_boost": {
    "custom_capabilities": "false",
    "custom_roles": "false",
    "inactive_users_count": 0,
    "inactive_users_count_all_blogs": 0,
    "two_factor_status": {
      "is_enforced_globally": false,
      "is_not_enforced_globally": true,
      "has_two_factor_forced_filter": true,
      "is_entirely_disabled": false,
      "has_enable_two_factor_filter": false
    },
    "users_without_2fa_count": 151,
    "users_without_2fa_count_all_blogs": 151 // same as `users_without_2fa_count` even though we have more users without 2FA enabled that meet the threshold
  }
}
```

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
2. Verify which capabilities you have set for the Highlight 2FA module on your local test site
1. Ensure your local dev env is running as a multisite
3. Add additional network sites: `vip dev-env exec -- wp site create --slug=<slug> --email=<email>`
6. Verify the sites you just created: `vip dev-env exec -- wp site list`
7. Create additional users and add them to the network sites. Assign various roles so that some users require 2FA and some don't according to the capabilities you checked in step 2:

```
// Pass in relevant site URL
vip dev-env exec -- wp user create testlocal test@localhost.local --role=subscriber --user_pass=password123 --url=http://<slug>.vip-security-boost.vipdev.lndo.site/

// Mass-create users. Specify the URL to target a specific network site
vip dev-env exec -- wp user generate --count=10 --role=editor
```

8. Flush cache: `vip dev-env exec -- wp cache flush`
9. Trigger SDS data:
```
 wp --quiet eval 'ini_set("display_errors",0); echo "JSON>>>"; echo wp_json_encode(apply_filters("vip_site_details_index_data", []), JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES|JSON_PARTIAL_OUTPUT_ON_ERROR); echo "<<<JSON";' \
  | sed -n 's/.*JSON>>>\(.*\)<<<JSON.*/\1/p' \
  | jq .
```

10. Make sure `users_without_2fa_count` and `users_without_2fa_count_all_blogs` are different. The latter should be bigger since it's the aggregate number of users without 2FA enabled across all network sites.