### PR TITLE
Improve Inactive Users errors when using Application Passwords

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./bin/load-mu-plugins.sh
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@fc14643b0a99ee9db10a3c025a33d76544fa3761 # 2.30.5
+        uses: shivammathur/setup-php@20529878ed81ef8e78ddf08b480401e6101a850f # 2.35.3
         with:
           coverage: none
         env:
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # 3.0.0
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       - name: Add error matcher
         run: echo "::add-matcher::$(pwd)/.github/checkstyle-problem-matcher.json"

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ phpcs.xml
 # Editor/IDE related
 .vscode/*
 !.vscode/launch.json
+
+.claude

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ or, in case you want to test for a specific function you can run
 composer test -- --filter test_honor_vip_should_force_two_factor
 ```
 
+If you are using Claude in VSCode/Cursor and find trouble with running the tests, it's because you need to pass the CI environment variable to the test script.
+Run ```composer test-noninteractive``` instead of ```composer test```. All the rest applies.
 #### Testing Modules
 
 When testing classes defined within the `modules/` directory, ensure they are correctly autoloaded for the test environment. Add the necessary file paths to the `autoload-dev` section in `composer.json`:

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
 		"phpcs": "./vendor/bin/phpcs",
 		"test": "./bin/test.sh --php 8.1 --wp 6.8",
+		"test-noninteractive": "CI=true ./bin/test.sh --php 8.1 --wp 6.8",
 		"test-ci": "./bin/test.sh ",
 		"test:multisite": "./bin/test.sh --php 8.1 --wp 6.8 --multisite 1",
 		"test:integration": "./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/",

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -1034,4 +1034,72 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		wp_delete_user( $admin_user_id );
 		unset( $_GET['action'], $_GET['user_id'], $_GET['reset_last_seen_nonce'] );
 	}
+
+	/**
+	 * Test XML-RPC authentication for inactive users returns proper error message
+	 */
+	public function test_xmlrpc_authentication_inactive_user_error_message() {
+		// Create an inactive user
+		$user_id = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		update_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		delete_user_meta( $user_id, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		$user = new WP_User( $user_id );
+
+		// Test authentication with inactive user
+		$result = Inactive_Users::maybe_block_inactive_user_on_authenticate( $user );
+		if ( ! defined( 'XMLRPC_REQUEST' ) ) {
+			define( 'XMLRPC_REQUEST', true );
+		}
+		// Verify that authentication returns an error
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'inactive_account', $result->get_error_code() );
+		$this->assertEquals( '<strong>Error</strong>: Your account has been flagged as inactive. Please contact your site administrator.', $result->get_error_message() );
+
+		// check that if we pass a WP_Error to the filter, the xmlrpc_login_error filter is added
+		remove_all_filters( 'xmlrpc_login_error' );
+		Inactive_Users::maybe_block_inactive_user_on_app_password_auth( true, $user );
+		$result = Inactive_Users::maybe_block_inactive_user_on_authenticate( new \WP_Error( 'random_error', 'random error' ) );
+
+		$this->assertTrue( has_filter( 'xmlrpc_login_error' ) !== false );
+		$error = apply_filters( 'xmlrpc_login_error', null );
+		$this->assertInstanceOf( 'IXR_Error', $error );
+		$this->assertEquals( 403, $error->code );
+		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site administrator.', $error->message );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test application password authentication for inactive users
+	 */
+	public function test_application_password_authentication_inactive_user() {
+		// Create an inactive user
+		$user_id = $this->factory->user->create([
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		]);
+		update_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+		delete_user_meta( $user_id, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+		$user = new WP_User( $user_id );
+
+		// Test application password availability for inactive user
+		$available = Inactive_Users::maybe_block_inactive_user_on_app_password_auth( true, $user );
+		$this->assertFalse( $available );
+
+		// Verify that the error was stored properly for REST API usage
+		$reflection = new ReflectionClass( Inactive_Users::class );
+		$property   = $reflection->getProperty( 'application_password_authentication_error' );
+		$property->setAccessible( true );
+		$error = $property->getValue();
+
+		$this->assertInstanceOf( 'WP_Error', $error );
+		$this->assertEquals( 'inactive_account', $error->get_error_code() );
+		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site administrator.', $error->get_error_message() );
+		$this->assertEquals( 403, $error->get_error_data()['status'] );
+
+		wp_delete_user( $user_id );
+	}
 }


### PR DESCRIPTION
## Description

This PR introduces changes to improve errors whenever an inactive user is using application passwords. In that case, because of an internal loop, we were not returning the proper error to the user. With this change, either if you call XML-RPC or REST through a user that is inactive and is using application passwords, you'll get the right error. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

Ensure you get "Your account has been flagged as inactive." with both methods.

**Test with REST with an inactive user using app passwords** 
```
curl -X POST --user "<username>:<app_password>" "https://vip-security-boost.vipdev.lndo.site/wp-json/wp/v2/posts?content=content&title=title"
{"code":"inactive_account","message":"Your account has been flagged as inactive. Please contact your site administrator.","data":{"status":403}}
```


**Test with XML-RPC with an inactive user using app passwords** 
```
curl -i \
        -H 'Content-Type: text/xml' \
        --data '<?xml version="1.0"?>
  <methodCall>
    <methodName>wp.getUsersBlogs</methodName>
    <params>
      <param><value><string><username></string></value></param>
      <param><value><string><app_password></string></value></param>
    </params>
  </methodCall>' \
        http://vip-security-boost.vipdev.lndo.site/xmlrpc.php
HTTP/1.1 200 OK
Content-Type: text/xml; charset=UTF-8
Date: Tue, 12 Aug 2025 13:54:43 +0000
Server: nginx/1.29.0
X-Powered-By: PHP/8.2.29
X-Xmlrpc-Error-Code: 403
Transfer-Encoding: chunked

<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>403</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>Your account has been flagged as inactive. Please contact your site administrator.</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```