### PR TITLE
fix: correct capitalization in inactive account error messages

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -168,7 +168,7 @@ class Inactive_Users {
 			// checking if we have an application password error and if so add an error filter.
 			if ( Context::is_xmlrpc_api() && is_wp_error( self::$application_password_authentication_error ) ) {
 				add_filter('xmlrpc_login_error', function () {
-					return new \IXR_Error( 403, __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ) );
+					return new \IXR_Error( 403, __( 'Your account has been flagged as inactive. Please contact your site Administrator.', 'wpvip' ) );
 				});
 			}
 			return $user;
@@ -181,11 +181,11 @@ class Inactive_Users {
 			);
 			if ( Context::is_xmlrpc_api() ) {
 				add_filter('xmlrpc_login_error', function () {
-					return new \IXR_Error( 403, __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ) );
+					return new \IXR_Error( 403, __( 'Your account has been flagged as inactive. Please contact your site Administrator.', 'wpvip' ) );
 				});
 			}
 
-			return new \WP_Error( 'inactive_account', __( '<strong>Error</strong>: Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ) );
+			return new \WP_Error( 'inactive_account', __( '<strong>Error</strong>: Your account has been flagged as inactive. Please contact your site Administrator.', 'wpvip' ) );
 		}
 
 		return $user;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -218,7 +218,7 @@ class Inactive_Users {
 		}
 
 		if ( self::is_considered_inactive( $user->ID ) ) {
-			self::$application_password_authentication_error = new \WP_Error( 'inactive_account', __( 'Your account has been flagged as inactive. Please contact your site administrator.', 'wpvip' ), array( 'status' => 403 ) );
+			self::$application_password_authentication_error = new \WP_Error( 'inactive_account', __( 'Your account has been flagged as inactive. Please contact your site Administrator.', 'wpvip' ), array( 'status' => 403 ) );
 
 			return false;
 		}

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -1056,7 +1056,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Verify that authentication returns an error
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'inactive_account', $result->get_error_code() );
-		$this->assertEquals( '<strong>Error</strong>: Your account has been flagged as inactive. Please contact your site administrator.', $result->get_error_message() );
+		$this->assertEquals( '<strong>Error</strong>: Your account has been flagged as inactive. Please contact your site Administrator.', $result->get_error_message() );
 
 		// check that if we pass a WP_Error to the filter, the xmlrpc_login_error filter is added
 		remove_all_filters( 'xmlrpc_login_error' );
@@ -1067,7 +1067,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$error = apply_filters( 'xmlrpc_login_error', null );
 		$this->assertInstanceOf( 'IXR_Error', $error );
 		$this->assertEquals( 403, $error->code );
-		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site administrator.', $error->message );
+		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site Administrator.', $error->message );
 
 		wp_delete_user( $user_id );
 	}
@@ -1097,7 +1097,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( 'WP_Error', $error );
 		$this->assertEquals( 'inactive_account', $error->get_error_code() );
-		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site administrator.', $error->get_error_message() );
+		$this->assertEquals( 'Your account has been flagged as inactive. Please contact your site Administrator.', $error->get_error_message() );
 		$this->assertEquals( 403, $error->get_error_data()['status'] );
 
 		wp_delete_user( $user_id );


### PR DESCRIPTION
## Description

Minor fix on the error message we display when a user is blocked due to inactivity: Capitalize the work "Administrator"

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->