### PR TITLE
Add checking if `Two_Factor_Core` exists before registering hooks

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -27,6 +27,20 @@ class Forced_MFA_Users {
 	private static $capabilities = [];
 
 	public static function init() {
+		// If plugins_loaded has already fired (e.g., in tests), register hooks immediately
+		if ( did_action( 'plugins_loaded' ) ) {
+			self::register_hooks();
+		} else {
+			add_action( 'plugins_loaded', [ __CLASS__, 'register_hooks' ] );
+		}
+	}
+
+	public static function register_hooks() {
+		// Ensure the Two Factor plugin is active
+		if ( ! class_exists( '\Two_Factor_Core' ) ) {
+			return;
+		}
+
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
 
 		// Normalize capabilities and roles configuration


### PR DESCRIPTION
## Description

Uses the same checks in `highlight-mfa-users` module to make sure `Two_Factor_Core` exists.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test
1. Checkout PR
2. vip dev-env create && vip dev-env start
3. Login to wp-admin users page
4. Make sure there are no errors
