### PR TITLE
Avoids querying the DB twice just to get the counts and explicitly use `'COUNT(DISTINCT` for faster results

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -105,9 +105,6 @@ class Inactive_Users {
 	}
 
 	public static function add_inactive_users_count_to_sds_payload( $data ) {
-		// Add fix for unreliable FOUND_ROWS() query
-		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
-
 		// Start timer to measure query time
 		$timer = microtime( true );
 
@@ -130,9 +127,6 @@ class Inactive_Users {
 
 		// Register query time metric
 		do_action( 'vip_security_inactive_users_query_time', $timer );
-
-		// Remove fix for unreliable FOUND_ROWS() query
-		remove_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10 );
 
 		return $data;
 	}

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -52,16 +52,30 @@ class Users_Query_Utils {
 		// Single blog query
 		if ( ! is_multisite() || 0 !== $blog_id ) {
 			$query_args['blog_id'] = $blog_id;
+			$query_args['fields']  = 'ID';
+
 			if ( $count_only ) {
 				$query_args['count_total'] = true;
-				$query_args['fields']      = 'ID';
 				$query_args['number']      = 1; // We only need the count
-			} else {
-				$query_args['fields'] = 'ID';
 			}
 
-			$user_query = new \WP_User_Query( $query_args );
-			return $count_only ? $user_query->get_total() : array_map( 'intval', $user_query->get_results() );
+			$user_query = new \WP_User_Query();
+			$user_query->prepare_query( $query_args );
+
+			if ( $count_only ) {
+				// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+				$user_query->query_fields = 'COUNT(DISTINCT ' . $wpdb->users . '.ID)';
+			}
+
+			$request =
+				"SELECT {$user_query->query_fields}
+				{$user_query->query_from}
+				{$user_query->query_where}
+				{$user_query->query_orderby}
+				{$user_query->query_limit}";
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			return $count_only ? ( (int) $wpdb->get_var( $request ) ) : array_map( 'intval', $wpdb->get_col( $request ) );
 		}
 
 		// Network-wide query
@@ -75,7 +89,8 @@ class Users_Query_Utils {
 		$base_query_args['blog_id'] = 0;
 
 		// Create WP_User_Query to get the base SQL clauses
-		$temp_query = new \WP_User_Query( $base_query_args );
+		$temp_query = new \WP_User_Query();
+		$temp_query->prepare_query( $base_query_args );
 
 		// Build our network-wide capability filtering clause
 		$capability_where = self::build_network_capability_where_clause( $capabilities, $roles );

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -74,10 +74,11 @@ class Users_Query_Utils {
 				{$user_query->query_orderby}
 				{$user_query->query_limit}";
 
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 			if ( $count_only ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 				return (int) $wpdb->get_var( $request );
 			} else {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 				return array_map( 'intval', $wpdb->get_col( $request ) );
 			}
 		}

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -75,7 +75,11 @@ class Users_Query_Utils {
 				{$user_query->query_limit}";
 
 			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			return $count_only ? ( (int) $wpdb->get_var( $request ) ) : array_map( 'intval', $wpdb->get_col( $request ) );
+			if ( $count_only ) {
+				return (int) $wpdb->get_var( $request );
+			} else {
+				return array_map( 'intval', $wpdb->get_col( $request ) );
+			}
 		}
 
 		// Network-wide query


### PR DESCRIPTION
## Description

We already had a patch to use `COUNT(DISTINCT` on our `fix_found_users_query` hook, but that didn't prevent WP from doing the `SELECT SQL_CALC_FOUND_ROWS()` first.

WordPress will do two queries:
1. To get the results with `SELECT SQL_CALC_FOUND_ROWS()`: https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-user-query.php#L844
2. To get the count: https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-user-query.php#L861

Our previous solution only changed the count query, but WP was still doing the first `SQL_CALC_FOUND_ROWS` as usual.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->