### PR TITLE
fix: prevent null reference errors by returning early if user is not found

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -169,8 +169,8 @@ class Inactive_Users {
 			return $user;
 		}
 
-		// If user is not found, return it to avoid null reference errors below
-		if ( ! $user ) {
+		// If user is not a WP_User instance, return it to avoid null reference errors below
+		if ( ! $user instanceof \WP_User ) {
 			return $user;
 		}
 

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -169,6 +169,11 @@ class Inactive_Users {
 			return $user;
 		}
 
+		// If user is not found, return it to avoid null reference errors below
+		if ( ! $user ) {
+			return $user;
+		}
+
 		if ( $user->ID && self::is_considered_inactive( $user->ID ) ) {
 			Logger::info(
 				self::LOG_FEATURE_NAME,


### PR DESCRIPTION
## Description

We noticed some errors due to null pointer access on `$user->ID` so this should prevent that.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

<!--
Outline the steps to test and verify the PR here.

Example:

1. Check out PR.
1. Go to `wp-admin` > `Tools` > `Bakery`
1. Click on "Bake Cookies" button.
1. Verify cookies are delicious.
-->