### PR TITLE
Removes network-wide counting of inactive users

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -105,7 +105,6 @@ class Inactive_Users {
 	}
 
 	public static function add_inactive_users_count_to_sds_payload( $data ) {
-		$inact_ts = self::get_inactivity_timestamp();
 		// Start timer to measure query time
 		$timer = microtime( true );
 
@@ -115,13 +114,14 @@ class Inactive_Users {
 		// Add inactive users count for the current blog to the SDS payload
 		$data['inactive_users_count'] = $inactive_users_count;
 
-		if ( is_multisite() ) {
-			// Get number of inactive users for all blogs (network-wide with blog_id = 0)
-			$inactive_users_count_all_blogs = self::get_inactive_users_count( 0 );
+		// TODO - Fix performance issues with network-wide queries
+		// if ( is_multisite() ) {
+		// 	// Get number of inactive users for all blogs (network-wide with blog_id = 0)
+		// 	$inactive_users_count_all_blogs = self::get_inactive_users_count( 0 );
 
-			// Add network-wide inactive users count to the SDS payload
-			$data['inactive_users_count_all_blogs'] = $inactive_users_count_all_blogs;
-		}
+		// 	// Add network-wide inactive users count to the SDS payload
+		// 	$data['inactive_users_count_all_blogs'] = $inactive_users_count_all_blogs;
+		// }
 
 		// Stop timer
 		$timer = microtime( true ) - $timer;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -90,8 +90,9 @@ class Inactive_Users {
 			add_action( 'admin_init', [ __CLASS__, 'last_seen_unblock_action' ] );
 		}
 
+		// TODO - Fix performance issues with network-wide queries
 		// Add SDS hook
-		add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_inactive_users_count_to_sds_payload' ] );
+		// add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_inactive_users_count_to_sds_payload' ] );
 	}
 
 	public static function maybe_fix_found_users_query() {
@@ -114,14 +115,13 @@ class Inactive_Users {
 		// Add inactive users count for the current blog to the SDS payload
 		$data['inactive_users_count'] = $inactive_users_count;
 
-		// TODO - Fix performance issues with network-wide queries
-		// if ( is_multisite() ) {
-		// 	// Get number of inactive users for all blogs (network-wide with blog_id = 0)
-		// 	$inactive_users_count_all_blogs = self::get_inactive_users_count( 0 );
+		if ( is_multisite() ) {
+			// Get number of inactive users for all blogs (network-wide with blog_id = 0)
+			$inactive_users_count_all_blogs = self::get_inactive_users_count( 0 );
 
-		// 	// Add network-wide inactive users count to the SDS payload
-		// 	$data['inactive_users_count_all_blogs'] = $inactive_users_count_all_blogs;
-		// }
+			// Add network-wide inactive users count to the SDS payload
+			$data['inactive_users_count_all_blogs'] = $inactive_users_count_all_blogs;
+		}
 
 		// Stop timer
 		$timer = microtime( true ) - $timer;

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -536,7 +536,10 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * Test that the vip_site_details_index_security_boost_data filter is added and works correctly
 	 */
 	public function test_vip_site_details_index_security_boost_data_filter_is_added() {
+		$this->markTestSkipped( 'Skipping for now since SDS sync is temporarily disabled' );
+
 		// Verify the filter is added during init
+		// @phpstan-ignore-next-line deadCode.unreachable
 		$this->assertNotFalse( has_filter( 'vip_site_details_index_security_boost_data', [ 'Automattic\VIP\Security\InactiveUsers\Inactive_Users', 'add_inactive_users_count_to_sds_payload' ] ) );
 
 		// Test that the filter works by applying it
@@ -547,12 +550,11 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data );
 		$this->assertIsInt( $filtered_data['inactive_users_count'] );
 
-		// TODO - Re-enable network-wide query once performance issues are resolved
 		// Verify the network-wide count is added only in multisite
-		// if ( is_multisite() ) {
-		// 	$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data );
-		// 	$this->assertIsInt( $filtered_data['inactive_users_count_all_blogs'] );
-		// }
+		if ( is_multisite() ) {
+			$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data );
+			$this->assertIsInt( $filtered_data['inactive_users_count_all_blogs'] );
+		}
 
 		// Verify original data is preserved
 		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
@@ -594,8 +596,6 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * Each site should have its own count of inactive users
 	 */
 	public function test_add_inactive_users_count_to_sds_payload_multisite_counts() {
-		$this->markTestSkipped( 'Skipping for now since network-wide queries are temporarily disabled' );
-
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'This test requires multisite to be enabled' );
 		}

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -547,11 +547,12 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'inactive_users_count', $filtered_data );
 		$this->assertIsInt( $filtered_data['inactive_users_count'] );
 
+		// TODO - Re-enable network-wide query once performance issues are resolved
 		// Verify the network-wide count is added only in multisite
-		if ( is_multisite() ) {
-			$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data );
-			$this->assertIsInt( $filtered_data['inactive_users_count_all_blogs'] );
-		}
+		// if ( is_multisite() ) {
+		// 	$this->assertArrayHasKey( 'inactive_users_count_all_blogs', $filtered_data );
+		// 	$this->assertIsInt( $filtered_data['inactive_users_count_all_blogs'] );
+		// }
 
 		// Verify original data is preserved
 		$this->assertEquals( 'some_value', $filtered_data['some_key'] );
@@ -593,6 +594,8 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * Each site should have its own count of inactive users
 	 */
 	public function test_add_inactive_users_count_to_sds_payload_multisite_counts() {
+		$this->markTestSkipped( 'Skipping for now since network-wide queries are temporarily disabled' );
+
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'This test requires multisite to be enabled' );
 		}


### PR DESCRIPTION
## Description

We've been running into performance issues with large databases when querying for inactive users network-wide. This PR comments out the code that performs the counting, so we'll temporarily not send this count to SDS until we find a way to improve the performance of this query.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

`composer test:multisite` should pass