### PR TITLE
[ForcedMFA] Add 2FA hooks right away, improve Two_Factor plugin detection

### DIFF
--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -166,7 +166,7 @@ class Forced_MFA_Users {
 	 */
 	public static function add_users_without_2fa_count_to_sds_payload( $data ) {
 		// Ensure the Two Factor plugin is active
-		if ( ! class_exists( '\Two_Factor_Core' ) ) {
+		if ( ! self::has_two_factor_plugin() ) {
 			return $data;
 		}
 		// Add fix for unreliable FOUND_ROWS() query

--- a/modules/forced-mfa-users/class-forced-mfa-users.php
+++ b/modules/forced-mfa-users/class-forced-mfa-users.php
@@ -27,20 +27,11 @@ class Forced_MFA_Users {
 	private static $capabilities = [];
 
 	public static function init() {
-		// If plugins_loaded has already fired (e.g., in tests), register hooks immediately
-		if ( did_action( 'plugins_loaded' ) ) {
-			self::register_hooks();
-		} else {
-			add_action( 'plugins_loaded', [ __CLASS__, 'register_hooks' ] );
-		}
+		// we want to add the hooks right away. Adding it with the "plugins_loaded" action won't work. We want to run it ASAP to make sure we add wpcom_vip_internal_is_two_factor_forced if needed.
+		self::register_hooks();
 	}
 
 	public static function register_hooks() {
-		// Ensure the Two Factor plugin is active
-		if ( ! class_exists( '\Two_Factor_Core' ) ) {
-			return;
-		}
-
 		$forced_mfa_configs = Configs::get_module_configs( 'forced-mfa-users' );
 
 		// Normalize capabilities and roles configuration
@@ -52,7 +43,17 @@ class Forced_MFA_Users {
 			add_action( 'set_current_user', [ __CLASS__, 'maybe_enforce_two_factor' ], 10 );
 			add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_custom_enforced_capabilities_to_sds' ] );
 		}
-
+		if ( did_action( 'plugins_loaded' ) ) {
+			self::register_plugin_loaded_hooks();
+		} else {
+			add_action( 'plugins_loaded', [ __CLASS__, 'register_plugin_loaded_hooks' ] );
+		}
+	}
+	public static function register_plugin_loaded_hooks() {
+		if ( ! self::has_two_factor_plugin() ) {
+			// Two Factor plugin is not active, nothing more to do
+			return;
+		}
 		// Always add SDS reporting hook (even without config, to report zero count)
 		add_filter( 'vip_site_details_index_security_boost_data', [ __CLASS__, 'add_users_without_2fa_count_to_sds_payload' ] );
 
@@ -112,10 +113,19 @@ class Forced_MFA_Users {
 		return array_unique( array_merge( self::$roles, self::get_custom_enforced_roles() ) );
 	}
 
+	public static function has_two_factor_plugin() {
+		return class_exists( '\Two_Factor_Core' );
+	}
+
 	/**
 	 * Require 2FA based on capabilities or roles set in config
 	 */
 	public static function maybe_enforce_two_factor() {
+		// Ensure the Two Factor plugin is active
+		if ( ! self::has_two_factor_plugin() ) {
+			return;
+		}
+
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
@@ -155,6 +165,10 @@ class Forced_MFA_Users {
 	 * @return array The modified SDS payload data.
 	 */
 	public static function add_users_without_2fa_count_to_sds_payload( $data ) {
+		// Ensure the Two Factor plugin is active
+		if ( ! class_exists( '\Two_Factor_Core' ) ) {
+			return $data;
+		}
 		// Add fix for unreliable FOUND_ROWS() query
 		add_filter( 'found_users_query', [ Users_Query_Utils::class, 'fix_found_users_query' ], 10, 2 );
 

--- a/tests/phpunit/test-forced-mfa-users-missing-two-factor-plugin.php
+++ b/tests/phpunit/test-forced-mfa-users-missing-two-factor-plugin.php
@@ -1,9 +1,6 @@
 <?php
 
 use Automattic\VIP\Security\MFAUsers\Forced_MFA_Users;
-use Automattic\VIP\Security\Utils\Testable_Logger;
-use Automattic\VIP\Jetpack\Connection_Pilot\Attendant;
-use Automattic\VIP\Security\Constants;
 
 /**
  * Tests for Forced_MFA_Users when Two Factor plugin (Two_Factor_Core) is missing.

--- a/tests/phpunit/test-forced-mfa-users-missing-two-factor-plugin.php
+++ b/tests/phpunit/test-forced-mfa-users-missing-two-factor-plugin.php
@@ -1,0 +1,111 @@
+<?php
+
+use Automattic\VIP\Security\MFAUsers\Forced_MFA_Users;
+use Automattic\VIP\Security\Utils\Testable_Logger;
+use Automattic\VIP\Jetpack\Connection_Pilot\Attendant;
+use Automattic\VIP\Security\Constants;
+
+/**
+ * Tests for Forced_MFA_Users when Two Factor plugin (Two_Factor_Core) is missing.
+ */
+class Test_Forced_MFA_Users_Missing_Two_Factor_Plugin extends WP_UnitTestCase {
+
+	/**
+	 * Ensure maybe_enforce_two_factor does not error when Two_Factor_Core is missing.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_maybe_enforce_two_factor_no_two_factor_plugin_no_error() {
+		// Configure enforcement so that, if the plugin existed, it would try to enforce.
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			define( 'VIP_SECURITY_BOOST_CONFIGS', [
+				'module_configs' => [
+					'forced-mfa-users' => [ 'roles' => 'administrator' ],
+				],
+			] );
+		}
+
+		// Call the method; it should early-return and not throw exceptions.
+		Forced_MFA_Users::maybe_enforce_two_factor();
+
+		// Since plugin is missing, our internal filter shouldn't be enforced
+		$this->assertFalse( apply_filters( 'wpcom_vip_internal_is_two_factor_forced', false ) );
+	}
+
+	/**
+	 * Ensure add_custom_enforced_capabilities_to_sds works when Two_Factor plugin is missing.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_add_custom_enforced_capabilities_to_sds_without_two_factor_plugin() {
+		// No additional filters present
+		$this->assertFalse( has_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME ) );
+		$this->assertFalse( has_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME ) );
+
+		$payload = [ 'foo' => 'bar' ];
+		$result  = Forced_MFA_Users::add_custom_enforced_capabilities_to_sds( $payload );
+
+		$this->assertSame( 'false', $result['custom_capabilities'] );
+		$this->assertSame( 'false', $result['custom_roles'] );
+
+		// Add filters and ensure normalization still works without the plugin
+		add_filter( Forced_MFA_Users::ADDITIONAL_CAPABILITIES_FILTER_NAME, static function () {
+			return [ 'manage_options', 'edit_posts' ];
+		} );
+		add_filter( Forced_MFA_Users::ADDITIONAL_ROLES_FILTER_NAME, static function () {
+			return [ 'administrator', 'subscriber' ];
+		} );
+
+		Forced_MFA_Users::add_custom_enforced_capabilities_to_sds( [ 'baz' => 'qux' ] );
+		// we only want to ensure there are no errors, no extra check is needed.
+	}
+
+
+	/**
+	 * Ensure has_two_factor_plugin returns false when the plugin is missing.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_has_two_factor_plugins_is_false() {
+		$this->assertFalse( Forced_MFA_Users::has_two_factor_plugin() );
+	}
+	/**
+	 * Ensure hooks added in register_plugin_loaded_hooks are NOT added when Two_Factor_Core is missing.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_register_plugin_loaded_hooks_not_added_when_two_factor_missing() {
+		if ( ! defined( 'VIP_SECURITY_BOOST_CONFIGS' ) ) {
+			define( 'VIP_SECURITY_BOOST_CONFIGS', [
+				'module_configs' => [
+					'forced-mfa-users' => [ 'roles' => 'administrator' ],
+				],
+			] );
+		}
+		$class_name = get_class( new Forced_MFA_Users() );
+
+		Forced_MFA_Users::init();
+
+		// The SDS reporting hook that depends on Two_Factor_Core should not be present
+		$this->assertFalse( has_filter( 'vip_site_details_index_security_boost_data', [ $class_name, 'add_users_without_2fa_count_to_sds_payload' ] ) );
+
+		// User-related cache clearing hooks should also not be present
+		$this->assertFalse( has_action( 'user_register', [ $class_name, 'clear_mfa_count_cache' ] ) );
+		$this->assertFalse( has_action( 'delete_user', [ $class_name, 'clear_mfa_count_cache' ] ) );
+		$this->assertFalse( has_action( 'updated_user_meta', [ $class_name, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertFalse( has_action( 'added_user_meta', [ $class_name, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertFalse( has_action( 'deleted_user_meta', [ $class_name, 'clear_mfa_count_cache_on_meta_update' ] ) );
+		$this->assertFalse( has_action( 'set_user_role', [ $class_name, 'clear_mfa_count_cache_for_user_role_change' ] ) );
+
+		// Multisite-specific hooks for user deletion/removal
+		if ( is_multisite() ) {
+			$this->assertFalse( has_action( 'wpmu_delete_user', [ $class_name, 'clear_mfa_count_cache_for_user_sites' ] ) );
+			$this->assertFalse( has_action( 'remove_user_from_blog', [ $class_name, 'clear_mfa_count_cache' ] ) );
+			$this->assertFalse( has_action( 'add_user_to_blog', [ $class_name, 'clear_mfa_count_cache' ] ) );
+		}
+	}
+}


### PR DESCRIPTION
## Description
Followup to https://github.com/Automattic/vip-security-boost/pull/94 to split the hooks in two major groups.

**Why is this needed:** 
There are some scenarios where the 2FA hook would not be triggered or would not be executed right away, so we wanted to be sure that that takes precedence. 

I decided to split into two separate groups of hooks, one that can run after the plugin is loaded and one right away. This is to simplify the logic to check if the Two_Factor plugin is loaded, instead of repeating it in each function-
Additionally, I added some tests to ensure that we can detect if the logic changes and we're introducing some possible errors when the two-factor plugin is not loaded. 


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 