### PR TITLE
Skip emails for the Jetpack org owner user

### DIFF
--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -24,11 +24,11 @@ class Notify_Privileged_Activity {
 			return false;
 		}
 
-		if ( ! ( class_exists( Support_User::class ) && method_exists( Support_User::class, 'is_a8c_email' ) ) ) {
-			return false;
-		}
-
-		if ( ! Support_User::is_a8c_email( $user->user_email ) ) {
+		if ( class_exists( Support_User::class ) && method_exists( Support_User::class, 'is_a8c_email' ) ) {
+			if ( ! Support_User::is_a8c_email( $user->user_email ) ) {
+				return false;
+			}
+		} else {
 			return false;
 		}
 

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -115,13 +115,13 @@ class Notify_Privileged_Activity {
 	 */
 	private static function send_notification( $user, $subject, $email_title, $template ) {
 		// Skip notification for the Jetpack connection owner
-	if ( self::is_jetpack_connection_owner( $user ) ) {
-		Logger::info(
-			self::LOG_FEATURE_NAME,
-			'Skipping notification for Jetpack connection owner: ' . $user->user_login
-		);
-		return;
-	}
+		if ( self::is_jetpack_connection_owner( $user ) ) {
+			Logger::info(
+				self::LOG_FEATURE_NAME,
+				'Skipping notification for Jetpack connection owner: ' . $user->user_login
+			);
+			return;
+		}
 
 		// Skip notification for VIP Support users
 		if ( class_exists( Support_User::class ) && Support_User::user_has_vip_support_role( $user->ID ) ) {

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -2,6 +2,7 @@
 namespace Automattic\VIP\Security\PrivilegedActivityNotifier;
 
 use Automattic\VIP\Security\Email\Email;
+use Automattic\VIP\Security\Utils\Email_Utils;
 use Automattic\VIP\Security\Constants;
 use Automattic\VIP\Security\Utils\Logger;
 use Automattic\VIP\Support_User\User as Support_User;
@@ -9,9 +10,17 @@ use Automattic\VIP\Support_User\User as Support_User;
 class Notify_Privileged_Activity {
 	const LOG_FEATURE_NAME = 'sb_notify_privileged_activity';
 
+	/**
+	 * Only treat as the Jetpack connection owner if:
+	 *  - The login matches the canonical owner
+	 *  - Email domain is A8C/VIP owned
+	 */
 	private static function is_jetpack_connection_owner( $user ): bool {
 		return ( $user instanceof \WP_User )
-			&& 'wpvip-jetpack-connection-owner' === strtolower( $user->user_login );
+			&& strtolower( (string) $user->user_login ) === ( defined( Constants::class . '::JETPACK_OWNER_LOGIN' )
+				? Constants::JETPACK_OWNER_LOGIN
+				: 'wpvip-jetpack-connection-owner' )
+			&& Email_Utils::is_a8c_owned( $user->user_email );
 	}
 
 	public static function init() {

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -16,11 +16,19 @@ class Notify_Privileged_Activity {
 	 *  - Email domain is A8C/VIP owned
 	 */
 	private static function is_jetpack_connection_owner( $user ): bool {
-		return ( $user instanceof \WP_User )
-			&& strtolower( (string) $user->user_login ) === ( defined( Constants::class . '::JETPACK_OWNER_LOGIN' )
-				? Constants::JETPACK_OWNER_LOGIN
-				: 'wpvip-jetpack-connection-owner' )
-			&& Email_Utils::is_a8c_owned( $user->user_email );
+		if ( ! ( $user instanceof \WP_User ) ) {
+			return false;
+		}
+
+		if ( strtolower( (string) $user->user_login ) !== Constants::JETPACK_OWNER_LOGIN ) {
+			return false;
+		}
+
+		if ( ! Email_Utils::is_a8c_owned( $user->user_email ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public static function init() {

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -8,6 +8,12 @@ use Automattic\VIP\Support_User\User as Support_User;
 
 class Notify_Privileged_Activity {
 	const LOG_FEATURE_NAME = 'sb_notify_privileged_activity';
+
+	private static function is_jetpack_connection_owner( $user ): bool {
+		return ( $user instanceof \WP_User )
+			&& 'wpvip-jetpack-connection-owner' === strtolower( $user->user_login );
+	}
+
 	public static function init() {
 		if ( is_multisite() ) {
 			add_action( 'add_user_to_blog', [ __CLASS__, 'notify_admin_user_creation' ] );
@@ -108,6 +114,15 @@ class Notify_Privileged_Activity {
 	 * @param string   $subject The email subject.
 	 */
 	private static function send_notification( $user, $subject, $email_title, $template ) {
+		// Skip notification for the Jetpack connection owner
+	if ( self::is_jetpack_connection_owner( $user ) ) {
+		Logger::info(
+			self::LOG_FEATURE_NAME,
+			'Skipping notification for Jetpack connection owner: ' . $user->user_login
+		);
+		return;
+	}
+
 		// Skip notification for VIP Support users
 		if ( class_exists( Support_User::class ) && Support_User::user_has_vip_support_role( $user->ID ) ) {
 			Logger::info(

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -24,11 +24,7 @@ class Notify_Privileged_Activity {
 			return false;
 		}
 
-		if ( class_exists( Support_User::class ) && method_exists( Support_User::class, 'is_a8c_email' ) ) {
-			if ( ! Support_User::is_a8c_email( $user->user_email ) ) {
-				return false;
-			}
-		} else {
+		if ( ! class_exists( Support_User::class ) || ! Support_User::is_a8c_email( $user->user_email ) ) {
 			return false;
 		}
 

--- a/modules/notify-privileged-activity/class-notify-privileged-activity.php
+++ b/modules/notify-privileged-activity/class-notify-privileged-activity.php
@@ -24,7 +24,11 @@ class Notify_Privileged_Activity {
 			return false;
 		}
 
-		if ( ! Email_Utils::is_a8c_owned( $user->user_email ) ) {
+		if ( ! ( class_exists( Support_User::class ) && method_exists( Support_User::class, 'is_a8c_email' ) ) ) {
+			return false;
+		}
+
+		if ( ! Support_User::is_a8c_email( $user->user_email ) ) {
 			return false;
 		}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ require_once __DIR__ . '/../utils/class-constants.php';
 require_once __DIR__ . '/../utils/class-capability-utils.php';
 require_once __DIR__ . '/../utils/class-users-query-utils.php';
 require_once __DIR__ . '/../utils/class-logger.php';
+require_once __DIR__ . '/../utils/class-email-utils.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 require_once __DIR__ . '/../email/class-email.php';
 require_once __DIR__ . '/class-testable-logger.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/../utils/class-email-utils.php';
 require_once __DIR__ . '/class-speedup-isolated-wp-tests.php';
 require_once __DIR__ . '/../email/class-email.php';
 require_once __DIR__ . '/class-testable-logger.php';
+require_once __DIR__ . '/phpunit/mocks/class-support-user-mock.php';
 
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );

--- a/tests/phpunit/mocks/class-support-user-mock.php
+++ b/tests/phpunit/mocks/class-support-user-mock.php
@@ -27,6 +27,11 @@ if ( ! class_exists( '\Automattic\VIP\Support_User\User' ) ) {
 			return in_array( $domain, $a8c_domains, true );
 		}
 
+		// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		public static function is_verified_automattician( $user_id ) {
+			return false;
+		}
+
 		public static function reset_mock() {
 			self::$mock_vip_support_users = [];
 		}

--- a/tests/phpunit/mocks/class-support-user-mock.php
+++ b/tests/phpunit/mocks/class-support-user-mock.php
@@ -8,11 +8,25 @@ namespace Automattic\VIP\Support_User;
 if ( ! class_exists( '\Automattic\VIP\Support_User\User' ) ) {
 	class User {
 		public static $mock_vip_support_users = [];
-		
+
 		public static function user_has_vip_support_role( $user_id ) {
 			return in_array( $user_id, self::$mock_vip_support_users, true );
 		}
-		
+
+		public static function is_a8c_email( $email ) {
+			if ( ! is_email( $email ) ) {
+				return false;
+			}
+			list( , $domain ) = explode( '@', $email, 2 );
+			$a8c_domains      = array(
+				'a8c.com',
+				'automattic.com',
+				'matticspace.com',
+				'wpvip.com',
+			);
+			return in_array( $domain, $a8c_domains, true );
+		}
+
 		public static function reset_mock() {
 			self::$mock_vip_support_users = [];
 		}

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -291,69 +291,69 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
  * @runInSeparateProcess
  * @preserveGlobalState disabled
  */
-public function test_jetpack_connection_owner_creation_skips_email() {
-	$user_id = self::factory()->user->create( [
-		'role'       => 'administrator',
-		'user_login' => 'wpvip-jetpack-connection-owner',
-		'user_email' => 'vip-jetpack-owner+1@wpvip.com',
-	] );
+	public function test_jetpack_connection_owner_creation_skips_email() {
+		$user_id = self::factory()->user->create( [
+			'role'       => 'administrator',
+			'user_login' => 'wpvip-jetpack-connection-owner',
+			'user_email' => 'vip-jetpack-owner+1@wpvip.com',
+		] );
 
-	// Ensure admin_email is valid so any skip is due to our logic, not config.
-	update_option( 'admin_email', 'admin@example.com' );
+		// Ensure admin_email is valid so any skip is due to our logic, not config.
+		update_option( 'admin_email', 'admin@example.com' );
 
-	Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
+		Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
 
-	$this->assertNull(
-		Email::$last_call_args_for_test,
-		'Email::send should be skipped for the Jetpack connection owner on creation.'
-	);
-}
-
-/**
- * @runInSeparateProcess
- * @preserveGlobalState disabled
- */
-public function test_jetpack_connection_owner_promotion_skips_email() {
-	$user_id = self::factory()->user->create( [
-		'role'       => 'author',
-		'user_login' => 'wpvip-jetpack-connection-owner',
-		'user_email' => 'vip-jetpack-owner+2@wpvip.com',
-	] );
-
-	update_option( 'admin_email', 'admin@example.com' );
-
-	Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'author' ] );
-
-	$this->assertNull(
-		Email::$last_call_args_for_test,
-		'Email::send should be skipped for the Jetpack connection owner on promotion.'
-	);
-}
-
-/**
- * @runInSeparateProcess
- * @preserveGlobalState disabled
- */
-public function test_jetpack_connection_owner_super_admin_grant_skips_email() {
-	if ( ! is_multisite() ) {
-		$this->markTestSkipped( 'Multisite is required for this test.' );
+		$this->assertNull(
+			Email::$last_call_args_for_test,
+			'Email::send should be skipped for the Jetpack connection owner on creation.'
+		);
 	}
 
-	$user_id = self::factory()->user->create( [
-		'role'       => 'administrator',
-		'user_login' => 'wpvip-jetpack-connection-owner',
-		'user_email' => 'vip-jetpack-owner+3@wpvip.com',
-	] );
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_jetpack_connection_owner_promotion_skips_email() {
+		$user_id = self::factory()->user->create( [
+			'role'       => 'author',
+			'user_login' => 'wpvip-jetpack-connection-owner',
+			'user_email' => 'vip-jetpack-owner+2@wpvip.com',
+		] );
 
-	update_option( 'admin_email', 'admin@example.com' );
+		update_option( 'admin_email', 'admin@example.com' );
 
-	Notify_Privileged_Activity::notify_user_granted_super_admin( $user_id );
+		Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'author' ] );
 
-	$this->assertNull(
-		Email::$last_call_args_for_test,
-		'Email::send should be skipped for the Jetpack connection owner on super admin grant.'
-	);
-}
+		$this->assertNull(
+			Email::$last_call_args_for_test,
+			'Email::send should be skipped for the Jetpack connection owner on promotion.'
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_jetpack_connection_owner_super_admin_grant_skips_email() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Multisite is required for this test.' );
+		}
+
+		$user_id = self::factory()->user->create( [
+			'role'       => 'administrator',
+			'user_login' => 'wpvip-jetpack-connection-owner',
+			'user_email' => 'vip-jetpack-owner+3@wpvip.com',
+		] );
+
+		update_option( 'admin_email', 'admin@example.com' );
+
+		Notify_Privileged_Activity::notify_user_granted_super_admin( $user_id );
+
+		$this->assertNull(
+			Email::$last_call_args_for_test,
+			'Email::send should be skipped for the Jetpack connection owner on super admin grant.'
+		);
+	}
 
 	/**
 	 * Mock the VIP Support User class for testing

--- a/tests/phpunit/test-notify-privileged-activity.php
+++ b/tests/phpunit/test-notify-privileged-activity.php
@@ -288,6 +288,74 @@ class TestNotifyPrivilegedActivity extends WP_UnitTestCase {
 	}
 
 	/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+public function test_jetpack_connection_owner_creation_skips_email() {
+	$user_id = self::factory()->user->create( [
+		'role'       => 'administrator',
+		'user_login' => 'wpvip-jetpack-connection-owner',
+		'user_email' => 'vip-jetpack-owner+1@wpvip.com',
+	] );
+
+	// Ensure admin_email is valid so any skip is due to our logic, not config.
+	update_option( 'admin_email', 'admin@example.com' );
+
+	Notify_Privileged_Activity::notify_admin_user_creation( $user_id );
+
+	$this->assertNull(
+		Email::$last_call_args_for_test,
+		'Email::send should be skipped for the Jetpack connection owner on creation.'
+	);
+}
+
+/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+public function test_jetpack_connection_owner_promotion_skips_email() {
+	$user_id = self::factory()->user->create( [
+		'role'       => 'author',
+		'user_login' => 'wpvip-jetpack-connection-owner',
+		'user_email' => 'vip-jetpack-owner+2@wpvip.com',
+	] );
+
+	update_option( 'admin_email', 'admin@example.com' );
+
+	Notify_Privileged_Activity::notify_user_promoted_to_admin( $user_id, 'administrator', [ 'author' ] );
+
+	$this->assertNull(
+		Email::$last_call_args_for_test,
+		'Email::send should be skipped for the Jetpack connection owner on promotion.'
+	);
+}
+
+/**
+ * @runInSeparateProcess
+ * @preserveGlobalState disabled
+ */
+public function test_jetpack_connection_owner_super_admin_grant_skips_email() {
+	if ( ! is_multisite() ) {
+		$this->markTestSkipped( 'Multisite is required for this test.' );
+	}
+
+	$user_id = self::factory()->user->create( [
+		'role'       => 'administrator',
+		'user_login' => 'wpvip-jetpack-connection-owner',
+		'user_email' => 'vip-jetpack-owner+3@wpvip.com',
+	] );
+
+	update_option( 'admin_email', 'admin@example.com' );
+
+	Notify_Privileged_Activity::notify_user_granted_super_admin( $user_id );
+
+	$this->assertNull(
+		Email::$last_call_args_for_test,
+		'Email::send should be skipped for the Jetpack connection owner on super admin grant.'
+	);
+}
+
+	/**
 	 * Mock the VIP Support User class for testing
 	 */
 	private function mock_vip_support_user_class() {

--- a/utils/class-constants.php
+++ b/utils/class-constants.php
@@ -6,4 +6,8 @@ class Constants {
 	const LOG_PLUGIN_NAME = 'vip-security-boost';
 
 	const SDS_DATA_KEY = 'vip_security_boost';
+
+	const JETPACK_OWNER_LOGIN = 'wpvip-jetpack-connection-owner';
+
+	const A8C_EMAIL_DOMAINS = [ 'wpvip.com', 'automattic.com' ];
 }

--- a/utils/class-email-utils.php
+++ b/utils/class-email-utils.php
@@ -20,26 +20,4 @@ class Email_Utils {
 		}
 		return substr( $part, 1 ); // strip leading "@"
 	}
-
-	/** True if the email is on an Automattic/VIP-owned domain (filterable) */
-	public static function is_a8c_owned( $email ): bool {
-		$domain = self::domain( $email );
-		if ( null === $domain ) {
-			return false;
-		}
-
-		$allowed = apply_filters(
-			'vip_security_jetpack_owner_email_domains',
-			defined( Constants::class . '::A8C_EMAIL_DOMAINS' )
-				? Constants::A8C_EMAIL_DOMAINS
-				: [ 'wpvip.com', 'automattic.com' ]
-		);
-
-		$allowed = array_map(
-			static fn( $d ) => strtolower( trim( (string) $d ) ),
-			(array) $allowed
-		);
-
-		return in_array( $domain, $allowed, true );
-	}
 }

--- a/utils/class-email-utils.php
+++ b/utils/class-email-utils.php
@@ -13,6 +13,7 @@ class Email_Utils {
 		if ( ! is_email( $normalized ) ) {
 			return null;
 		}
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		$part = strrchr( $normalized, '@' ); // "@domain" or false
 		if ( false === $part ) {
 			return null;

--- a/utils/class-email-utils.php
+++ b/utils/class-email-utils.php
@@ -1,0 +1,44 @@
+<?php
+namespace Automattic\VIP\Security\Utils;
+
+use Automattic\VIP\Security\Constants;
+
+class Email_Utils {
+	/** Extract lowercase domain from a valid email; null if invalid */
+	public static function domain( $email ): ?string {
+		if ( ! is_string( $email ) ) {
+			return null;
+		}
+		$normalized = strtolower( trim( $email ) );
+		if ( ! is_email( $normalized ) ) {
+			return null;
+		}
+		$part = strrchr( $normalized, '@' ); // "@domain" or false
+		if ( false === $part ) {
+			return null;
+		}
+		return substr( $part, 1 ); // strip leading "@"
+	}
+
+	/** True if the email is on an Automattic/VIP-owned domain (filterable) */
+	public static function is_a8c_owned( $email ): bool {
+		$domain = self::domain( $email );
+		if ( null === $domain ) {
+			return false;
+		}
+
+		$allowed = apply_filters(
+			'vip_security_jetpack_owner_email_domains',
+			defined( Constants::class . '::A8C_EMAIL_DOMAINS' )
+				? Constants::A8C_EMAIL_DOMAINS
+				: [ 'wpvip.com', 'automattic.com' ]
+		);
+
+		$allowed = array_map(
+			static fn( $d ) => strtolower( trim( (string) $d ) ),
+			(array) $allowed
+		);
+
+		return in_array( $domain, $allowed, true );
+	}
+}

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -20,6 +20,7 @@ require_once __DIR__ . '/utils/class-configs.php';
 require_once __DIR__ . '/utils/class-capability-utils.php';
 require_once __DIR__ . '/utils/class-users-query-utils.php';
 require_once __DIR__ . '/email/class-email.php';
+require_once __DIR__ . '/utils/class-email-utils.php';
 require_once __DIR__ . '/utils/class-constants.php';
 require_once __DIR__ . '/utils/class-logger.php';
 require_once __DIR__ . '/utils/class-tracking.php';


### PR DESCRIPTION
## Description

This PR adds logic to skip email notifications for the [Jetpack organization owner user](https://github.com/Automattic/vip-go-mu-plugins/blob/57c86e4ec4d088796d06a9e865f75eb12402675d/vip-jetpack/connection-pilot/class-jetpack-connection-attendant.php#L173). Users don't need to get the privileged user email notification because this is an automated user for Jetpack connection setup activities.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out PR.
1. Test that emails send as expected for regular users:

```
vip dev-env exec -- wp user create testadminuser joanne.lee+adminadmin3@automattic.com --user_pass=password123345

vip dev-env exec -- wp user set-role testadminuser administrator --url=https://vip-security-boost.vipdev.lndo.site/
```

3. Make sure you get an email in Mailpit: http://vip-security-boost-mailpit.vipdev.lndo.site/
4. Create the Jetpack org owner user:

```
vip dev-env exec -- wp eval 'var_export( wp_insert_user([
  "user_login"=>"wpvip-jetpack-connection-owner",
  "user_email"=>"vip-jetpack-owner+0@wpvip.com",
  "display_name"=>"WPVIP Jetpack Connection Owner",
  "role"=>"administrator",
  "user_pass"=>"password"
]) );'
```

_P.S - The usual `wp user create wpvip-jetpack-connection-owner` won't work here bc you'll get an error: `Error: Usernames can only contain lowercase letters (a-z) and numbers.`_

5. Make sure you don't get a new email in Mailpit
6. Upgrade user to Super Admin: `vip dev-env exec -- wp super-admin add wpvip-jetpack-connection-owner`
7. Make sure you don't get a new email
8. Also test with the Jetpack user but an email address that doesn't use an A8C-owned domain:

```
// Remove old user from DB (WP-CLI commands aren't working for some reason)
vip dev-env exec -- wp cache flush

// Re-add user but with a test domain:
vip dev-env exec -- wp eval 'var_export( wp_insert_user([
  "user_login"=>"wpvip-jetpack-connection-owner",
  "user_email"=>"vip-jetpack-owner+0@test.com",
  "display_name"=>"WPVIP Jetpack Connection Owner",
  "role"=>"administrator",
  "user_pass"=>"password"
]) );'
10. Make sure you _do_ get an email
```

**Side note:** I tried testing with the Jetpack connection flow itself to mimic the behavior, but we can't do that on dev-env:

```
// using shell bc adding this to `/client-mu-plugins/force-jetpack-org-owner.php` wasn't calling the filter for some reason
vip dev-env shell
mkdir -p /wp/wp-content/mu-plugins
cat > /wp/wp-content/mu-plugins/force-jetpack-org-owner.php <<'PHP'
<?php
add_filter('vip_jetpack_connection_pilot_use_org_owner', '__return_true');
error_log('MU loaded: force-jetpack-org-owner');
PHP

// Connect JP
vip dev-env exec -- wp jetpack-start connect --url=https://vip-security-boost.vipdev.lndo.site/
Warning: ❌ Could not connect Jetpack. Error (jp-cxn-pilot-invalid-environment): This is not a valid WPVIP environment.
``` 