### PR TITLE
Allow proxied requests to bypass XML-RPC restrictions

### DIFF
--- a/modules/xml-rpc/class-xml-rpc.php
+++ b/modules/xml-rpc/class-xml-rpc.php
@@ -15,6 +15,11 @@ class Xml_Rpc {
 			return;
 		}
 
+		if ( is_proxied_request() ) {
+			// Requests via the Automattic proxy are allowed to use XML-RPC.
+			return;
+		}
+
 		switch ( self::$mode ) {
 			case 'DISABLE':
 				// Completely disable XML-RPC.


### PR DESCRIPTION
## Description

Allow requests via the Automattic proxy, which is only available to Automatticians, to access Jetpack endpoints.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

As a proxied Automattician, ping the Jetpack XML-RPC endpoint:

```
curl --socks5 127.0.0.1:8080 -A "Jetpack by WordPress.com" -is \
  -H 'Content-Type: text/xml' \
  --data '<?xml version="1.0"?><methodCall><methodName>system.listMethods</methodName><params/></methodCall>' \
  'https://example.com/xmlrpc.php?for=jetpack' && echo
```