### PR TITLE
[PLTFRM-1567 & PLTFRM-1784] Add a role sanitizer to fix common corrupted roles scenarios

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../utils/configs.php';
 require_once __DIR__ . '/../utils/class-configs.php';
 require_once __DIR__ . '/../utils/class-constants.php';
 require_once __DIR__ . '/../utils/class-capability-utils.php';
+require_once __DIR__ . '/../utils/class-role-sanitizer.php';
 require_once __DIR__ . '/../utils/class-users-query-utils.php';
 require_once __DIR__ . '/../utils/class-logger.php';
 require_once __DIR__ . '/../utils/class-email-utils.php';

--- a/tests/phpunit/test-role-sanitizer.php
+++ b/tests/phpunit/test-role-sanitizer.php
@@ -80,7 +80,7 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 		Role_Sanitizer::maybe_register_role_sanitizers();
 
 		$this->assertNotFalse(
-			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'register_role_option_filter' ] ),
 			'Role sanitizers should hook into switch_blog when repair is needed.'
 		);
 		$this->assertNotFalse(
@@ -97,7 +97,7 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 			'Role sanitizers should not register filters when role metadata is valid.'
 		);
 		$this->assertFalse(
-			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'register_role_option_filter' ] ),
 			'Role sanitizers should not hook switch_blog when repair is not needed.'
 		);
 	}

--- a/tests/phpunit/test-role-sanitizer.php
+++ b/tests/phpunit/test-role-sanitizer.php
@@ -1,0 +1,156 @@
+<?php
+
+use Automattic\VIP\Security\Utils\Role_Sanitizer;
+
+class RoleSanitizerTest extends WP_UnitTestCase {
+
+	/**
+	 * Name of the roles option for the current site.
+	 *
+	 * @var string
+	 */
+	private $roles_option_name;
+
+	/**
+	 * Original option value backup.
+	 *
+	 * @var array|null
+	 */
+	private $original_roles_option;
+
+	/**
+	 * Original $wp_roles instance backup.
+	 *
+	 * @var \WP_Roles|null
+	 */
+	private $original_wp_roles;
+
+	public function setUp(): void {
+		global $wpdb, $wp_roles;
+
+		parent::setUp();
+
+		$blog_id                 = function_exists( 'get_current_blog_id' ) ? (int) get_current_blog_id() : 0;
+		$this->roles_option_name = is_multisite()
+			? $wpdb->get_blog_prefix( $blog_id ) . 'user_roles'
+			: $wpdb->prefix . 'user_roles';
+
+		$this->original_roles_option = get_option( $this->roles_option_name );
+		$this->original_wp_roles     = $wp_roles instanceof WP_Roles ? $wp_roles : null;
+
+		wp_cache_flush();
+	}
+
+	public function tearDown(): void {
+		global $wp_roles;
+
+		Role_Sanitizer::unregister_role_sanitizers();
+
+		if ( null !== $this->original_roles_option ) {
+			update_option( $this->roles_option_name, $this->original_roles_option );
+		} else {
+			delete_option( $this->roles_option_name );
+		}
+
+		if ( $this->original_wp_roles instanceof WP_Roles ) {
+			$wp_roles = $this->original_wp_roles;
+		} else {
+			$wp_roles = null;
+		}
+
+		wp_cache_flush();
+
+		parent::tearDown();
+	}
+
+	public function test_maybe_register_role_sanitizers_registers_filters_when_missing_names() {
+		global $wp_roles;
+
+		$corrupted_roles = $this->original_roles_option;
+		if ( ! is_array( $corrupted_roles ) ) {
+			$corrupted_roles = [];
+		}
+		if ( isset( $corrupted_roles['administrator']['name'] ) ) {
+			unset( $corrupted_roles['administrator']['name'] );
+		}
+
+		update_option( $this->roles_option_name, $corrupted_roles );
+		$wp_roles = null;
+
+		Role_Sanitizer::maybe_register_role_sanitizers();
+
+		$this->assertNotFalse(
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			'Role sanitizers should hook into switch_blog when repair is needed.'
+		);
+		$this->assertNotFalse(
+			has_filter( "option_{$this->roles_option_name}", [ Role_Sanitizer::class, 'repair_roles_array' ] ),
+			'Role sanitizers should register the option filter when names are missing.'
+		);
+	}
+
+	public function test_maybe_register_role_sanitizers_skips_when_roles_are_valid() {
+		Role_Sanitizer::maybe_register_role_sanitizers();
+
+		$this->assertFalse(
+			has_filter( "option_{$this->roles_option_name}", [ Role_Sanitizer::class, 'repair_roles_array' ] ),
+			'Role sanitizers should not register filters when role metadata is valid.'
+		);
+		$this->assertFalse(
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			'Role sanitizers should not hook switch_blog when repair is not needed.'
+		);
+	}
+
+	public function test_ensure_roles_have_names_fills_missing_values() {
+		global $wp_roles;
+
+		$wp_roles                              = new WP_Roles();
+		$wp_roles->roles['subscriber']['name'] = '';
+
+		Role_Sanitizer::ensure_roles_have_names();
+
+		$this->assertNotEmpty(
+			$wp_roles->roles['subscriber']['name'],
+			'Role sanitizers should populate missing role names.'
+		);
+		$this->assertNotEmpty(
+			$wp_roles->role_names['subscriber'],
+			'Role sanitizers should rebuild the role names index after repair.'
+		);
+	}
+
+	public function test_repair_roles_array_preserves_existing_role_information() {
+		$roles = [
+			'administrator' => [
+				'name'         => '',
+				'capabilities' => [
+					'manage_options' => true,
+				],
+			],
+			'editor'        => [
+				'name'         => 'Editor',
+				'capabilities' => [
+					'edit_pages' => true,
+				],
+			],
+		];
+
+		$repaired_roles = Role_Sanitizer::repair_roles_array( $roles );
+
+		$this->assertNotEmpty(
+			$repaired_roles['administrator']['name'],
+			'Administrator role should receive a fallback name.'
+		);
+		$this->assertSame(
+			'Editor',
+			$repaired_roles['editor']['name'],
+			'Repaired roles should not alter valid role names.'
+		);
+		$this->assertSame(
+			$roles['editor']['capabilities'],
+			$repaired_roles['editor']['capabilities'],
+			'Role sanitizer must preserve existing capabilities.'
+		);
+	}
+}

--- a/tests/phpunit/test-role-sanitizer.php
+++ b/tests/phpunit/test-role-sanitizer.php
@@ -110,7 +110,7 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 
 		// Expect a warning to be triggered when repairing the role name
 		$this->expectWarning();
-		$this->expectWarningMessage( "Repaired missing name for role &#039;subscriber&#039; to &#039;Subscriber&#039;. Please review your user roles db data as it might be corrupted." );
+		$this->expectWarningMessage( 'Repaired missing name for role &#039;subscriber&#039; to &#039;Subscriber&#039;. Please review your user roles db data as it might be corrupted.' );
 
 		Role_Sanitizer::ensure_roles_have_names();
 
@@ -142,7 +142,7 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 
 		// Expect a warning to be triggered when repairing the administrator role name
 		$this->expectWarning();
-		$this->expectWarningMessage( "Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted." );
+		$this->expectWarningMessage( 'Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted.' );
 
 		$repaired_roles = Role_Sanitizer::repair_roles_array( $roles );
 

--- a/tests/phpunit/test-role-sanitizer.php
+++ b/tests/phpunit/test-role-sanitizer.php
@@ -108,6 +108,10 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 		$wp_roles                              = new WP_Roles();
 		$wp_roles->roles['subscriber']['name'] = '';
 
+		// Expect a warning to be triggered when repairing the role name
+		$this->expectWarning();
+		$this->expectWarningMessage( "Repaired missing name for role &#039;subscriber&#039; to &#039;Subscriber&#039;. Please review your user roles db data as it might be corrupted." );
+
 		Role_Sanitizer::ensure_roles_have_names();
 
 		$this->assertNotEmpty(
@@ -135,6 +139,10 @@ class RoleSanitizerTest extends WP_UnitTestCase {
 				],
 			],
 		];
+
+		// Expect a warning to be triggered when repairing the administrator role name
+		$this->expectWarning();
+		$this->expectWarningMessage( "Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted." );
 
 		$repaired_roles = Role_Sanitizer::repair_roles_array( $roles );
 

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -458,7 +458,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		// Expect a warning to be triggered when repairing the administrator role
 		$this->expectWarning();
-		$this->expectWarningMessage( "Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted." );
+		$this->expectWarningMessage( 'Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted.' );
 
 		try {
 			$results = Users_Query_Utils::query_users_with_capability_filtering(

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\VIP\Security\Utils\Users_Query_Utils;
+use Automattic\VIP\Security\Utils\Role_Sanitizer;
 
 /**
  * Tests for Automattic\VIP\Security\Utils\Users_Query_Utils
@@ -9,7 +10,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		
+
 		// Ensure we have a clean cache state
 		wp_cache_flush();
 	}
@@ -279,7 +280,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
 		]);
-		
+
 		$new_admin = $this->factory->user->create([
 			'role'            => 'administrator',
 			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-10 days' ) ),
@@ -295,7 +296,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 				],
 			],
 		], 0, true);
-		
+
 		$this->assertGreaterThanOrEqual( 1, $old_admin_count, 'Should find old admin users' );
 
 		// Test with exclude parameter
@@ -304,12 +305,12 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			// phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude -- Testing exclude functionality in controlled test environment
 			'exclude'        => [ $old_admin ],
 		], 0, true);
-		
+
 		// Should find fewer users when excluding the old admin
 		$total_count = Users_Query_Utils::query_users_with_capability_filtering([
 			'capability__in' => [ 'manage_options' ],
 		], 0, true);
-		
+
 		$this->assertLessThan( $total_count, $excluded_count, 'Excluding users should reduce the count' );
 
 		// Clean up
@@ -334,7 +335,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 			0, // should fall back to current site
 			true // count only
 		);
-		
+
 		$this->assertGreaterThanOrEqual( 1, $count, 'Should find admin users on single site' );
 
 		// Clean up
@@ -424,6 +425,130 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		wp_delete_user( $admin_user );
 		wp_delete_user( $editor_user );
 		wp_delete_user( $subscriber_user );
+	}
+
+	/**
+	 * Ensure capability filtering still operates when role metadata is missing the human readable name.
+	 */
+	public function test_capability_filtering_with_roles_array_is_broken() {
+		global $wp_roles;
+		global $wpdb;
+
+		// Create a user with a capability provided via role.
+		$admin_user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		// Determine the roles option name and corrupt it to mimic database issues.
+		$current_blog_id   = function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : null;
+		$roles_option_name = is_multisite()
+			? $wpdb->get_blog_prefix( (int) $current_blog_id ) . 'user_roles'
+			: $wpdb->prefix . 'user_roles';
+		$original_option   = get_option( $roles_option_name );
+		$corrupted_option  = $original_option;
+
+		if ( isset( $corrupted_option['administrator'] ) ) {
+			unset( $corrupted_option['administrator']['name'] );
+		}
+
+		update_option( $roles_option_name, $corrupted_option );
+
+		$original_wp_roles = $wp_roles instanceof WP_Roles ? $wp_roles : null;
+
+		// Force WordPress to rebuild the roles object from the (now corrupted) option.
+		$wp_roles = null;
+
+		$repaired_roles = [];
+		$repaired_names = [];
+
+		try {
+			$results = Users_Query_Utils::query_users_with_capability_filtering(
+				[
+					'capability__in' => [ 'manage_options' ],
+					'include'        => [ $admin_user_id ],
+				],
+				function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : null,
+				false
+			);
+
+			// Trigger roles loading after our query to validate the repair logic.
+			$wp_roles = wp_roles();
+
+			$repaired_roles = $wp_roles->roles;
+			$repaired_names = $wp_roles->role_names;
+		} finally {
+			update_option( $roles_option_name, $original_option );
+
+			if ( $original_wp_roles instanceof WP_Roles ) {
+				$wp_roles = $original_wp_roles;
+			} else {
+				$wp_roles = new WP_Roles();
+			}
+		}
+
+		wp_delete_user( $admin_user_id );
+
+		$this->assertContains( $admin_user_id, $results, 'Administrator should still be matched when the role definition lacks a name.' );
+
+		$this->assertArrayHasKey( 'administrator', $repaired_roles, 'Administrator role should still exist after repair.' );
+		$this->assertArrayHasKey( 'name', $repaired_roles['administrator'], 'Role repair should restore the missing name key.' );
+		$this->assertNotEmpty( $repaired_roles['administrator']['name'], 'Restored role name should not be empty.' );
+
+		$this->assertArrayHasKey( 'administrator', $repaired_names, 'Role names index should be rebuilt for administrator.' );
+		$this->assertNotEmpty( $repaired_names['administrator'], 'Role names index should contain the fallback label.' );
+	}
+
+	/**
+	 * Ensure role sanitization hooks are cleaned up after running a query.
+	 */
+	public function test_role_sanitizer_hooks_removed_after_query() {
+		global $wpdb;
+		global $wp_roles;
+
+		$current_blog_id   = function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : null;
+		$roles_option_name = is_multisite()
+			? $wpdb->get_blog_prefix( (int) $current_blog_id ) . 'user_roles'
+			: $wpdb->prefix . 'user_roles';
+
+		$original_option  = get_option( $roles_option_name );
+		$corrupted_option = $original_option;
+
+		if ( isset( $corrupted_option['administrator'] ) ) {
+			unset( $corrupted_option['administrator']['name'] );
+		}
+
+		update_option( $roles_option_name, $corrupted_option );
+
+		$original_wp_roles = $wp_roles instanceof WP_Roles ? $wp_roles : null;
+
+		// Force rebuild from corrupted option.
+		$wp_roles = null;
+
+		try {
+			Users_Query_Utils::query_users_with_capability_filtering(
+				[
+					'role__in' => [ 'administrator' ],
+				],
+				$current_blog_id,
+				true
+			);
+		} finally {
+			update_option( $roles_option_name, $original_option );
+
+			if ( $original_wp_roles instanceof WP_Roles ) {
+				$wp_roles = $original_wp_roles;
+			} else {
+				$wp_roles = new WP_Roles();
+			}
+		}
+
+		$this->assertFalse(
+			has_filter( "option_{$roles_option_name}", [ Role_Sanitizer::class, 'repair_roles_array' ] ),
+			'Roles option filter should be removed after the query completes.'
+		);
+
+		$this->assertFalse(
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			'Switch blog hook should be removed after the query completes.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -546,7 +546,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse(
-			has_action( 'switch_blog', [ Role_Sanitizer::class, 'handle_switch_blog' ] ),
+			has_action( 'switch_blog', [ Role_Sanitizer::class, 'register_role_option_filter' ] ),
 			'Switch blog hook should be removed after the query completes.'
 		);
 	}

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -456,6 +456,10 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$repaired_roles = [];
 		$repaired_names = [];
 
+		// Expect a warning to be triggered when repairing the administrator role
+		$this->expectWarning();
+		$this->expectWarningMessage( "Repaired missing name for role &#039;administrator&#039; to &#039;Administrator&#039;. Please review your user roles db data as it might be corrupted." );
+
 		try {
 			$results = Users_Query_Utils::query_users_with_capability_filtering(
 				[

--- a/tests/phpunit/test-users-query-utils.php
+++ b/tests/phpunit/test-users-query-utils.php
@@ -453,9 +453,6 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 
 		$original_wp_roles = $wp_roles instanceof WP_Roles ? $wp_roles : null;
 
-		// Force WordPress to rebuild the roles object from the (now corrupted) option.
-		$wp_roles = null;
-
 		$repaired_roles = [];
 		$repaired_names = [];
 
@@ -491,6 +488,7 @@ class UsersQueryUtilsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'administrator', $repaired_roles, 'Administrator role should still exist after repair.' );
 		$this->assertArrayHasKey( 'name', $repaired_roles['administrator'], 'Role repair should restore the missing name key.' );
 		$this->assertNotEmpty( $repaired_roles['administrator']['name'], 'Restored role name should not be empty.' );
+		$this->assertEquals( $repaired_roles['administrator']['name'], 'Administrator' );
 
 		$this->assertArrayHasKey( 'administrator', $repaired_names, 'Role names index should be rebuilt for administrator.' );
 		$this->assertNotEmpty( $repaired_names['administrator'], 'Role names index should contain the fallback label.' );

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -132,34 +132,31 @@ class Role_Sanitizer {
 		if ( ! is_array( $roles ) ) {
 			return $roles;
 		}
-		try {
-			foreach ( $roles as $role_key => &$role_definition ) {
-				if ( ! is_array( $role_definition ) ) {
-					$role_definition = [];
-				}
-				// if the capabilities are a string, convert to array
-				if ( isset( $role_definition['capabilities'] ) && is_string( $role_definition['capabilities'] ) ) {
-					$capability                      = $role_definition['capabilities'];
-					$role_definition['capabilities'] = [ $capability ];
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role capabilities to inform the user
-					trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$capability}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
-				}
-				if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
-					// Ensure capabilities is an array; default to empty array.
-					$role_definition['capabilities'] = [];
-
-				}
-				// if the name is missing
-				if ( ! isset( $role_definition['name'] ) || ! is_string( $role_definition['name'] ) || '' === trim( $role_definition['name'] ) ) {
-
-					$role_definition['name'] = self::build_fallback_role_label( $role_key );
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role name to inform the user
-					trigger_error( esc_html( "Repaired missing name for role '{$role_key}' to '{$role_definition['name']}'. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
-				}
+		foreach ( $roles as $role_key => &$role_definition ) {
+			if ( ! is_array( $role_definition ) ) {
+				$role_definition = [];
 			}
-		} finally {
-			return $roles;
+			// if the capabilities are a string, convert to array
+			if ( isset( $role_definition['capabilities'] ) && is_string( $role_definition['capabilities'] ) ) {
+				$capability                      = $role_definition['capabilities'];
+				$role_definition['capabilities'] = [ $capability ];
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role capabilities to inform the user
+				trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$capability}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
+			}
+			if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
+				// Ensure capabilities is an array; default to empty array.
+				$role_definition['capabilities'] = [];
+
+			}
+			// if the name is missing
+			if ( ! isset( $role_definition['name'] ) || ! is_string( $role_definition['name'] ) || '' === trim( $role_definition['name'] ) ) {
+
+				$role_definition['name'] = self::build_fallback_role_label( $role_key );
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role name to inform the user
+				trigger_error( esc_html( "Repaired missing name for role '{$role_key}' to '{$role_definition['name']}'. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
+			}
 		}
+		return $roles;
 	}
 
 	/**

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -43,7 +43,7 @@ class Role_Sanitizer {
 		self::$sanitizers_registered = true;
 
 		self::register_role_option_filter();
-		add_action( 'switch_blog', [ __CLASS__, 'register_role_option_filter' ], 10, 2 );
+		add_action( 'switch_blog', [ __CLASS__, 'register_role_option_filter' ], 10, 1 );
 	}
 
 	/**
@@ -168,9 +168,10 @@ class Role_Sanitizer {
 				}
 				// if the capabilities are a string, convert to array
 				if ( isset( $role_definition['capabilities'] ) && is_string( $role_definition['capabilities'] ) ) {
-					$role_definition['capabilities'] = [ $role_definition['capabilities'] ];
+					$capability                      = $role_definition['capabilities'];
+					$role_definition['capabilities'] = [ $capability ];
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role capabilities to inform the user
-					trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$role_definition['capabilities']}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
+					trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$capability}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
 				}
 				if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
 					// if capabilities are a string, convert to array

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Automattic\VIP\Security\Utils;
+
+class Role_Sanitizer {
+	/**
+	 * Track which role option filters are registered.
+	 *
+	 * @var array<string,bool>
+	 */
+	private static $role_option_filters = [];
+
+	/**
+	 * Whether role sanitizers are currently registered.
+	 *
+	 * @var bool
+	 */
+	private static $sanitizers_registered = false;
+
+	/**
+	 * Register role sanitizers only when corrupted role metadata is detected.
+	 *
+	 * @return void
+	 */
+	public static function maybe_register_role_sanitizers() {
+		if ( ! self::roles_array_is_broken() ) {
+			return;
+		}
+
+		self::register_role_sanitizers();
+	}
+
+	/**
+	 * Register filters that repair the serialized roles option before WordPress reads it.
+	 *
+	 * @return void
+	 */
+	public static function register_role_sanitizers() {
+		if ( self::$sanitizers_registered ) {
+			return;
+		}
+
+		self::$sanitizers_registered = true;
+
+		self::register_role_option_filter();
+		add_action( 'switch_blog', [ __CLASS__, 'register_role_option_filter' ], 10, 2 );
+	}
+
+	/**
+	 * Ensure each registered role includes a non-empty name to keep WP_User_Query happy when the roles option is corrupted.
+	 *
+	 * WordPress expects role definitions to always provide a translated `name`, but in some environments
+	 * (for example after direct database edits) the option can lose that key which triggers warnings during query preparation.
+	 * We repair the in-memory role definitions with a sensible fallback label so core APIs continue to function.
+	 *
+	 * @return void
+	 */
+	public static function ensure_roles_have_names() {
+		global $wp_roles;
+
+		if ( ! $wp_roles instanceof \WP_Roles ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Initializing $wp_roles if not set, standard WordPress pattern
+			$wp_roles = new \WP_Roles();
+		}
+
+		$wp_roles->roles = self::repair_roles_array( $wp_roles->roles );
+
+		// Rebuild the role_names index after repair
+		$wp_roles->role_names = [];
+		foreach ( $wp_roles->roles as $role_key => $role_data ) {
+			if ( isset( $role_data['name'] ) ) {
+				$wp_roles->role_names[ $role_key ] = $role_data['name'];
+			}
+		}
+	}
+
+	/**
+	 * Get all roles that have a specific capability.
+	 *
+	 * @param string $capability The capability to check for.
+	 * @return array Array of role names that have the capability.
+	 */
+	public static function get_roles_with_capability( $capability ) {
+		global $wp_roles;
+
+		self::maybe_register_role_sanitizers();
+		self::ensure_roles_have_names();
+
+		if ( ! $wp_roles instanceof \WP_Roles ) {
+			return [];
+		}
+
+		$roles_with_capability = [];
+
+		foreach ( $wp_roles->roles as $role_name => $role_info ) {
+			if ( isset( $role_info['capabilities'][ $capability ] ) && $role_info['capabilities'][ $capability ] ) {
+				$roles_with_capability[] = $role_name;
+			}
+		}
+
+		return $roles_with_capability;
+	}
+
+
+	/**
+	 * Remove any temporary hooks registered for role sanitization.
+	 *
+	 * @return void
+	 */
+	public static function unregister_role_sanitizers() {
+		foreach ( self::$role_option_filters as $role_option => $registered ) {
+			if ( $registered ) {
+				remove_filter(
+					"option_{$role_option}",
+					[ __CLASS__, 'repair_roles_array' ],
+					5
+				);
+			}
+		}
+
+		remove_action( 'switch_blog', [ __CLASS__, 'register_role_option_filter' ], 10 );
+
+		self::$role_option_filters   = [];
+		self::$sanitizers_registered = false;
+	}
+
+	/**
+	 * Ensure our option filter is active for the provided site.
+	 *
+	 * @param int|null $site_id Site ID the filter should target.
+	 * @return void
+	 */
+	public static function register_role_option_filter( $site_id = null ) {
+		$role_option = self::get_role_option_name( $site_id );
+
+		if ( '' === $role_option ) {
+			return;
+		}
+
+		if ( isset( self::$role_option_filters[ $role_option ] ) ) {
+			return;
+		}
+
+		add_filter(
+			"option_{$role_option}",
+			[ __CLASS__, 'repair_roles_array' ],
+			5,
+			1
+		);
+
+		self::$role_option_filters[ $role_option ] = true;
+	}
+
+	/**
+	 * Normalize role arrays to always contain a human readable name and capabilities array.
+	 *
+	 * @param mixed $roles Raw roles array.
+	 * @return mixed
+	 */
+	public static function repair_roles_array( $roles ) {
+		if ( ! is_array( $roles ) ) {
+			return $roles;
+		}
+		try {
+			foreach ( $roles as $role_key => &$role_definition ) {
+				if ( ! is_array( $role_definition ) ) {
+					$role_definition = [];
+				}
+				// if the capabilities are a string, convert to array
+				if ( isset( $role_definition['capabilities'] ) && is_string( $role_definition['capabilities'] ) ) {
+					$role_definition['capabilities'] = [ $role_definition['capabilities'] ];
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role capabilities to inform the user
+					trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$role_definition['capabilities']}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
+				}
+				if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
+					// if capabilities are a string, convert to array
+						$role_definition['capabilities'] = [];
+
+				}
+				// if the name is missing
+				if ( ! isset( $role_definition['name'] ) || ! is_string( $role_definition['name'] ) || '' === trim( $role_definition['name'] ) ) {
+
+					$role_definition['name'] = self::build_fallback_role_label( $role_key );
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role name to inform the user
+					trigger_error( esc_html( "Repaired missing name for role '{$role_key}' to '{$role_definition['name']}'. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
+				}
+			}
+		} finally {
+			return $roles;
+		}
+	}
+
+	/**
+	 * Determine if any role definitions are missing their name key.
+	 *
+	 * @return bool
+	 */
+	private static function roles_array_is_broken() {
+		global $wp_roles;
+
+		if ( $wp_roles instanceof \WP_Roles && self::roles_array_missing_names_or_wrong_capabilities_types( $wp_roles->roles ) ) {
+			return true;
+		}
+
+		$role_option = self::get_role_option_name();
+
+		if ( '' === $role_option ) {
+			return false;
+		}
+
+		$stored_roles = get_option( $role_option );
+
+		return self::roles_array_missing_names_or_wrong_capabilities_types( $stored_roles );
+	}
+
+	/**
+	 * Helper to inspect a roles array for missing name keys.
+	 *
+	 * @param mixed $roles Role definitions.
+	 * @return bool
+	 */
+	private static function roles_array_missing_names_or_wrong_capabilities_types( $roles ) {
+		if ( ! is_array( $roles ) ) {
+			return false;
+		}
+
+		foreach ( $roles as $role_definition ) {
+			if ( ! is_array( $role_definition ) ) {
+				return true;
+			}
+
+			if ( ! isset( $role_definition['name'] ) || ! is_string( $role_definition['name'] ) ) {
+				return true;
+			}
+
+			if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build a human readable fallback label from a role key.
+	 *
+	 * @param string $role_key Role slug.
+	 * @return string
+	 */
+	private static function build_fallback_role_label( $role_key ) {
+		$role_key = (string) $role_key;
+
+		if ( '' === $role_key ) {
+			return '';
+		}
+
+		$label = str_replace( [ '_', '-' ], ' ', $role_key );
+
+		return ucwords( $label );
+	}
+
+
+	/**
+	 * Get the option name WordPress uses to load roles for the requested site.
+	 *
+	 * @param int|null $site_id Optional site ID.
+	 * @return string
+	 */
+	private static function get_role_option_name( $site_id = null ) {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return '';
+		}
+
+		if ( null === $site_id ) {
+			if ( isset( $wpdb->blogid ) && $wpdb->blogid ) {
+				$site_id = (int) $wpdb->blogid;
+			} else {
+				$site_id = (int) get_current_blog_id();
+			}
+		}
+
+		$prefix = is_multisite() ? $wpdb->get_blog_prefix( $site_id ) : $wpdb->prefix;
+
+		if ( ! is_string( $prefix ) || '' === $prefix ) {
+			return '';
+		}
+
+		return $prefix . 'user_roles';
+	}
+}

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -145,8 +145,8 @@ class Role_Sanitizer {
 					trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$capability}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
 				}
 				if ( ! isset( $role_definition['capabilities'] ) || ! is_array( $role_definition['capabilities'] ) ) {
-					// if capabilities are a string, convert to array
-						$role_definition['capabilities'] = [];
+					// Ensure capabilities is an array; default to empty array.
+					$role_definition['capabilities'] = [];
 
 				}
 				// if the name is missing

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -73,35 +73,6 @@ class Role_Sanitizer {
 			}
 		}
 	}
-
-	/**
-	 * Get all roles that have a specific capability.
-	 *
-	 * @param string $capability The capability to check for.
-	 * @return array Array of role names that have the capability.
-	 */
-	public static function get_roles_with_capability( $capability ) {
-		global $wp_roles;
-
-		self::maybe_register_role_sanitizers();
-		self::ensure_roles_have_names();
-
-		if ( ! $wp_roles instanceof \WP_Roles ) {
-			return [];
-		}
-
-		$roles_with_capability = [];
-
-		foreach ( $wp_roles->roles as $role_name => $role_info ) {
-			if ( isset( $role_info['capabilities'][ $capability ] ) && $role_info['capabilities'][ $capability ] ) {
-				$roles_with_capability[] = $role_name;
-			}
-		}
-
-		return $roles_with_capability;
-	}
-
-
 	/**
 	 * Remove any temporary hooks registered for role sanitization.
 	 *

--- a/utils/class-role-sanitizer.php
+++ b/utils/class-role-sanitizer.php
@@ -139,7 +139,7 @@ class Role_Sanitizer {
 			// if the capabilities are a string, convert to array
 			if ( isset( $role_definition['capabilities'] ) && is_string( $role_definition['capabilities'] ) ) {
 				$capability                      = $role_definition['capabilities'];
-				$role_definition['capabilities'] = [ $capability ];
+				$role_definition['capabilities'] = [ $capability => true ]; // TODO: should we hide the capability instead of setting it to true?
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Logging a warning when repairing role capabilities to inform the user
 				trigger_error( esc_html( "Repaired capabilities for role '{$role_key}' from string to array. Previous value: {$capability}. Please review your user roles db data as it might be corrupted." ), E_USER_WARNING );
 			}

--- a/utils/class-users-query-utils.php
+++ b/utils/class-users-query-utils.php
@@ -48,78 +48,83 @@ class Users_Query_Utils {
 	 */
 	public static function query_users_with_capability_filtering( $query_args, $blog_id = null, $count_only = true ) {
 		global $wpdb;
+		Role_Sanitizer::maybe_register_role_sanitizers();
 
-		// Single blog query
-		if ( ! is_multisite() || 0 !== $blog_id ) {
-			$query_args['blog_id'] = $blog_id;
-			$query_args['fields']  = 'ID';
+		try {
+			// Single blog query
+			if ( ! is_multisite() || 0 !== $blog_id ) {
+				$query_args['blog_id'] = $blog_id;
+				$query_args['fields']  = 'ID';
 
-			if ( $count_only ) {
-				$query_args['count_total'] = true;
-				$query_args['number']      = 1; // We only need the count
-			}
+				if ( $count_only ) {
+					$query_args['count_total'] = true;
+					$query_args['number']      = 1; // We only need the count
+				}
 
-			$user_query = new \WP_User_Query();
-			$user_query->prepare_query( $query_args );
+				$user_query = new \WP_User_Query();
+				$user_query->prepare_query( $query_args );
 
-			if ( $count_only ) {
-				// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
-				$user_query->query_fields = 'COUNT(DISTINCT ' . $wpdb->users . '.ID)';
-			}
+				if ( $count_only ) {
+					// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users
+					$user_query->query_fields = 'COUNT(DISTINCT ' . $wpdb->users . '.ID)';
+				}
 
-			$request =
+				$request =
 				"SELECT {$user_query->query_fields}
 				{$user_query->query_from}
 				{$user_query->query_where}
 				{$user_query->query_orderby}
 				{$user_query->query_limit}";
 
-			if ( $count_only ) {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				return (int) $wpdb->get_var( $request );
-			} else {
-				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-				return array_map( 'intval', $wpdb->get_col( $request ) );
+				if ( $count_only ) {
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+					return (int) $wpdb->get_var( $request );
+				} else {
+					// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+					return array_map( 'intval', $wpdb->get_col( $request ) );
+				}
 			}
-		}
 
-		// Network-wide query
-		$capabilities = $query_args['capability__in'] ?? [];
-		$roles        = $query_args['role__in'] ?? [];
+			// Network-wide query
+			$capabilities = $query_args['capability__in'] ?? [];
+			$roles        = $query_args['role__in'] ?? [];
 
-		// Remove capability/role filters from query args and let WP_User_Query build the base query
-		$base_query_args = $query_args;
-		unset( $base_query_args['capability__in'], $base_query_args['role__in'] );
-		$base_query_args['fields']  = 'ID';
-		$base_query_args['blog_id'] = 0;
+			// Remove capability/role filters from query args and let WP_User_Query build the base query
+			$base_query_args = $query_args;
+			unset( $base_query_args['capability__in'], $base_query_args['role__in'] );
+			$base_query_args['fields']  = 'ID';
+			$base_query_args['blog_id'] = 0;
 
-		// Create WP_User_Query to get the base SQL clauses
-		$temp_query = new \WP_User_Query();
-		$temp_query->prepare_query( $base_query_args );
+			// Create WP_User_Query to get the base SQL clauses
+			$temp_query = new \WP_User_Query();
+			$temp_query->prepare_query( $base_query_args );
 
-		// Build our network-wide capability filtering clause
-		$capability_where = self::build_network_capability_where_clause( $capabilities, $roles );
+			// Build our network-wide capability filtering clause
+			$capability_where = self::build_network_capability_where_clause( $capabilities, $roles );
 
-		if ( empty( $capability_where ) ) {
-			// No capability/role filtering needed, use the temp query results
-			return $count_only ? $temp_query->get_total() : array_map( 'intval', $temp_query->get_results() );
-		}
+			if ( empty( $capability_where ) ) {
+				// No capability/role filtering needed, use the temp query results
+				return $count_only ? $temp_query->get_total() : array_map( 'intval', $temp_query->get_results() );
+			}
 
-		// Build the final query using WP_User_Query's SQL with our additional WHERE clause
-		if ( $count_only ) {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
-			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
-			$sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$result = $wpdb->get_var( $sql );
-			return (int) $result;
-		} else {
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
-			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
-			$sql = "SELECT DISTINCT {$wpdb->users}.ID {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
-			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$results = $wpdb->get_col( $sql );
-			return array_map( 'intval', $results );
+			// Build the final query using WP_User_Query's SQL with our additional WHERE clause
+			if ( $count_only ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
+				// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
+				$sql = "SELECT COUNT(DISTINCT {$wpdb->users}.ID) {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$result = $wpdb->get_var( $sql );
+				return (int) $result;
+			} else {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SQL is built by WP_User_Query and internal methods
+				// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.user_meta__wpdb__users -- Required for network-wide user capability filtering
+				$sql = "SELECT DISTINCT {$wpdb->users}.ID {$temp_query->query_from} {$temp_query->query_where} AND ({$capability_where})";
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$results = $wpdb->get_col( $sql );
+				return array_map( 'intval', $results );
+			}
+		} finally {
+			Role_Sanitizer::unregister_role_sanitizers();
 		}
 	}
 

--- a/vip-security-boost.php
+++ b/vip-security-boost.php
@@ -24,6 +24,7 @@ require_once __DIR__ . '/utils/class-email-utils.php';
 require_once __DIR__ . '/utils/class-constants.php';
 require_once __DIR__ . '/utils/class-logger.php';
 require_once __DIR__ . '/utils/class-tracking.php';
+require_once __DIR__ . '/utils/class-role-sanitizer.php';
 
 use function Automattic\VIP\Security\Utils\load_integration_configs_from_headers;
 use function Automattic\VIP\Security\Utils\load_integration_configs_from_url;


### PR DESCRIPTION
## Description

This is a first attempt at catching possible Roles/Capabilities errors and fixing it when needed. While, ideally, this should happen at the DB level, I wanted to explore if it was possible for us to selectively fix it so that we could run the queries when needed.

This is a first attempt at this fix, testing it was probably the hardest part as you need to intentionally break the DB.

I've also added 2 error logs, intentionally, to make sure that there's some visibility on this error, in case a customer runs into it.

This PR addresses 2 issues
1. If a role doesn't have a name (this causes the `Undefined array key "name" in /wp/wp-includes/class-wp-roles.php`)
2. If the `capabilities` are a string and not an array. (this leads to the `PHP message: Fatal error: Uncaught TypeError: array_filter(): Argument #1 ($array) must be of type array, string given in /wp/wp-includes/class-wp-user-query.php`)

Both "errors" are usually caused by the DB being corrupted or having invalid data.

This PR will only fix the issue while we call our query

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

**To test this you'll need to first break your DB :)**
To do so, edit your `wp_options.wp_user_roles`  with these 2 changes
* Replace `a:7:{s:13:"administrator";a:2:{s:4:"name";s:13:"Administrator";s:12` with `a:7:{s:13:"administrator";a:2:{s:4:"n4me";s:13:"Administrator";s:12` (this will trigger error 1)
* replace `s:11:"contributor";a:2:{s:4:"name";s:11:"Contributor";s:12:"capabilities";a:5:{s:10:"edit_posts";b:1;s:4:"read";b:1;s:7:"level_1";b:1;s:7:"level_0";b:1;s:12:"delete_posts";b:1;}}` with `s:11:"contributor";a:2:{s:4:"name";s:18:"Broken Contributor";s:12:"capabilities";s:4:"read";}` (to trigger error 2).

Flush the cache to make sure you're using the broken roles `vip dev-env exec -- wp cache flush`

The second step is to ensure the cache doesn't get in the way, so please change this line
https://github.com/Automattic/vip-security-boost/blob/3a7edd5ab415cfa536830a6b5b50a5e72e8e2946/modules/forced-mfa-users/class-forced-mfa-users.php#L226
to 
`		$cached_count = false;`

Last but not least, in the `vip-security-boost.php` file, add this, so we can easily test it locally and have less noise (other parts of WordPress will break with this change and logs will become more noisy unless we isolate the caller)

```
// curl -X GET "http://vip-security-boost.vipdev.lndo.site/wp-json/vip-security-boost/v1/status"
add_action(
	'rest_api_init',
	function () {
		// expose a public rest api to call vip-security-boost functions
		register_rest_route( 'vip-security-boost/v1', '/status', array(
			'methods'  => 'GET',
			'callback' => function () {
				$test_data = apply_filters( 'vip_site_details_index_security_boost_data', [] );
				return array(
					'status'                            => 'VIP Security Boost is active',
					'users_without_2fa_count'           => $test_data['users_without_2fa_count'],
					'users_without_2fa_count_all_blogs' => $test_data['users_without_2fa_count_all_blogs'],
				);
			},
		) );
	}
);

remove_action( 'plugins_loaded', 'wpcom_vip_qm_require', 1 );
```

Now, with these changes (that you can also apply to the `production` code, to see the differences) run 
* `curl -X GET "http://vip-security-boost.vipdev.lndo.site/wp-json/vip-security-boost/v1/status"`

And check the logs via `vip dev-env logs -f -S php`