### PR TITLE
Inactive Users: REPORT mode creates permanent inactive flag

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -144,14 +144,9 @@ class Inactive_Users {
 			return;
 		}
 
-		if ( self::is_considered_inactive( $user_id ) ) {
-			if ( self::is_block_action_enabled() ) {
-				// User needs to be unblocked first.
-				return;
-			}
-
-			// In REPORT mode, clear the stale last seen meta so the user starts fresh.
-			delete_user_meta( $user_id, self::LAST_SEEN_META_KEY );
+		if ( self::is_block_action_enabled() && self::is_considered_inactive( $user_id ) ) {
+			// User needs to be unblocked first.
+			return;
 		}
 
 	// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -144,7 +144,7 @@ class Inactive_Users {
 			return;
 		}
 
-		if ( self::is_considered_inactive( $user_id ) ) {
+		if ( self::is_block_action_enabled() && self::is_considered_inactive( $user_id ) ) {
 			// User needs to be unblocked first
 			return;
 		}

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -144,9 +144,14 @@ class Inactive_Users {
 			return;
 		}
 
-		if ( self::is_block_action_enabled() && self::is_considered_inactive( $user_id ) ) {
-			// User needs to be unblocked first
-			return;
+		if ( self::is_considered_inactive( $user_id ) ) {
+			if ( self::is_block_action_enabled() ) {
+				// User needs to be unblocked first.
+				return;
+			}
+
+			// In REPORT mode, clear the stale last seen meta so the user starts fresh.
+			delete_user_meta( $user_id, self::LAST_SEEN_META_KEY );
 		}
 
 	// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -1041,7 +1041,8 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that record_activity() updates last seen meta for an inactive user in REPORT mode.
+	 * Test that record_activity() clears stale last seen meta and records fresh
+	 * activity for an inactive user in REPORT mode.
 	 *
 	 * This is a regression test for the bug where REPORT mode created a permanent
 	 * inactive flag: the early-return in record_activity() only checked
@@ -1049,7 +1050,7 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * so once a user was flagged inactive in REPORT mode, their activity was
 	 * never recorded again — making the flag permanent.
 	 */
-	public function test_record_activity_updates_last_seen_in_report_mode_for_inactive_user() {
+	public function test_record_activity_clears_meta_and_records_activity_in_report_mode() {
 		// Create anonymous subclass to set mode to REPORT.
 		$inactive_users_class = new class() extends Inactive_Users {
 			public static function reset_for_test() {
@@ -1078,12 +1079,13 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 		wp_cache_delete( $user_id, Inactive_Users::LAST_SEEN_CACHE_GROUP );
 
-		// Call record_activity() — in REPORT mode this should NOT early-return.
+		// Call record_activity() — in REPORT mode this should clear stale meta and record fresh activity.
 		Inactive_Users::record_activity();
 
-		// The last seen timestamp should have been updated.
+		// The user should no longer be considered inactive.
 		$new_timestamp = get_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, true );
-		$this->assertGreaterThan( $old_timestamp, (int) $new_timestamp, 'record_activity() should update last_seen in REPORT mode even for inactive users' );
+		$this->assertGreaterThan( $old_timestamp, (int) $new_timestamp, 'record_activity() should record fresh last_seen in REPORT mode for inactive users' );
+		$this->assertFalse( Inactive_Users::is_considered_inactive( $user_id ), 'User should no longer be considered inactive after record_activity() in REPORT mode' );
 
 		// Clean up.
 		wp_delete_user( $user_id );

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -1041,6 +1041,92 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that record_activity() updates last seen meta for an inactive user in REPORT mode.
+	 *
+	 * This is a regression test for the bug where REPORT mode created a permanent
+	 * inactive flag: the early-return in record_activity() only checked
+	 * is_considered_inactive() without also checking is_block_action_enabled(),
+	 * so once a user was flagged inactive in REPORT mode, their activity was
+	 * never recorded again — making the flag permanent.
+	 */
+	public function test_record_activity_updates_last_seen_in_report_mode_for_inactive_user() {
+		// Create anonymous subclass to set mode to REPORT.
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function reset_for_test() {
+				self::$mode                           = 'REPORT';
+				self::$elevated_roles                 = [ 'administrator' ];
+				self::$considered_inactive_after_days = 90;
+			}
+		};
+
+		$inactive_users_class::reset_for_test();
+
+		// Create an inactive admin user.
+		$user_id = $this->factory->user->create( [
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		] );
+		delete_user_meta( $user_id, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+
+		$old_timestamp = strtotime( '-91 days' );
+		update_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, $old_timestamp );
+
+		// Confirm the user is considered inactive.
+		$this->assertTrue( Inactive_Users::is_considered_inactive( $user_id ) );
+
+		// Simulate the user being logged in and clear the cache so record_activity() proceeds.
+		wp_set_current_user( $user_id );
+		wp_cache_delete( $user_id, Inactive_Users::LAST_SEEN_CACHE_GROUP );
+
+		// Call record_activity() — in REPORT mode this should NOT early-return.
+		Inactive_Users::record_activity();
+
+		// The last seen timestamp should have been updated.
+		$new_timestamp = get_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, true );
+		$this->assertGreaterThan( $old_timestamp, (int) $new_timestamp, 'record_activity() should update last_seen in REPORT mode even for inactive users' );
+
+		// Clean up.
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test that record_activity() still skips updating last seen for inactive users in BLOCK mode.
+	 *
+	 * In BLOCK mode, inactive users must be manually unblocked by an admin before
+	 * their activity is recorded again.
+	 */
+	public function test_record_activity_skips_inactive_user_in_block_mode() {
+		// The setUp() already defines mode as BLOCK via VIP_SECURITY_BOOST_CONFIGS.
+
+		// Create an inactive admin user.
+		$user_id = $this->factory->user->create( [
+			'role'            => 'administrator',
+			'user_registered' => gmdate( 'Y-m-d H:i:s', strtotime( '-100 days' ) ),
+		] );
+		delete_user_meta( $user_id, Inactive_Users::LAST_SEEN_IGNORE_INACTIVITY_CHECK_UNTIL_META_KEY );
+
+		$old_timestamp = strtotime( '-91 days' );
+		update_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, $old_timestamp );
+
+		// Confirm the user is considered inactive.
+		$this->assertTrue( Inactive_Users::is_considered_inactive( $user_id ) );
+
+		// Simulate the user being logged in and clear the cache.
+		wp_set_current_user( $user_id );
+		wp_cache_delete( $user_id, Inactive_Users::LAST_SEEN_CACHE_GROUP );
+
+		// Call record_activity() — in BLOCK mode this should early-return.
+		Inactive_Users::record_activity();
+
+		// The last seen timestamp should NOT have been updated.
+		$new_timestamp = get_user_meta( $user_id, Inactive_Users::LAST_SEEN_META_KEY, true );
+		$this->assertEquals( $old_timestamp, (int) $new_timestamp, 'record_activity() should NOT update last_seen in BLOCK mode for inactive users' );
+
+		// Clean up.
+		wp_delete_user( $user_id );
+	}
+
+	/**
 	 * Test XML-RPC authentication for inactive users returns proper error message
 	 */
 	public function test_xmlrpc_authentication_inactive_user_error_message() {

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -1098,7 +1098,16 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	 * their activity is recorded again.
 	 */
 	public function test_record_activity_skips_inactive_user_in_block_mode() {
-		// The setUp() already defines mode as BLOCK via VIP_SECURITY_BOOST_CONFIGS.
+		// Explicitly reset mode to BLOCK, since prior tests may have changed the static property.
+		$inactive_users_class = new class() extends Inactive_Users {
+			public static function reset_for_test() {
+				self::$mode                           = 'BLOCK';
+				self::$elevated_roles                 = [ 'administrator' ];
+				self::$considered_inactive_after_days = 90;
+			}
+		};
+
+		$inactive_users_class::reset_for_test();
 
 		// Create an inactive admin user.
 		$user_id = $this->factory->user->create( [


### PR DESCRIPTION
## Description
In the Inactive Users module, when the mode is set to `REPORT` (flag only), users flagged as inactive can never have their status cleared through normal login activity.

The `record_activity()` method unconditionally skips recording activity for users already considered inactive, but the "Unblock" UI that provides the only way to clear the flag is only available in `BLOCK` mode. This creates a permanent "Inactive User" badge with no built-in resolution path in `REPORT` mode.

The fix gates the early return in `record_activity()` on `BLOCK` mode only, so that in `REPORT` mode logging in naturally records activity and clears the inactive flag.

## Changelog Description

 ### Fixed
  - Fixed a bug where users flagged as inactive in REPORT mode were permanently stuck with the inactive flag after logging back in, because stale `last_seen` meta was never cleared on login


## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

1. Check out this PR.
2. Set the inactive users module to **REPORT** mode.
3. Create or use a test user and allow them to become flagged as inactive (i.e., their `last_seen` meta is older than the inactivity threshold).
4. Verify the user appears in the inactive users report.
5. Log in as the flagged user.
6. Verify that the stale `last_seen` meta is cleared on login and the user is no longer flagged as inactive.
7. Run the unit tests: `phpunit --filter test-inactive-users` and verify all tests pass.
