### PR TITLE
fix(ci): update PHP version from 8.1 to 8.3 in CI matrix and composer…

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,19 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # PHP 8.1
-          - { wp: 6.5, ms: "0", php: "8.1" }
-          - { wp: 6.5, ms: "1", php: "8.1" }
-          - { wp: 6.6, ms: "0", php: "8.1" }
-          - { wp: 6.6, ms: "1", php: "8.1" }
-          - { wp: 6.7, ms: "0", php: "8.1" }
-          - { wp: 6.7, ms: "1", php: "8.1" }
-          - { wp: 6.8, ms: "0", php: "8.1" }
-          - { wp: 6.8, ms: "1", php: "8.1" }
-          - { wp: latest, ms: "0", php: "8.1" }
-          - { wp: latest, ms: "1", php: "8.1" }
-          - { wp: nightly, ms: "0", php: "8.1" }
-          - { wp: nightly, ms: "1", php: "8.1" }
+          # PHP 8.3
+          - { wp: 6.5, ms: "0", php: "8.3" }
+          - { wp: 6.5, ms: "1", php: "8.3" }
+          - { wp: 6.6, ms: "0", php: "8.3" }
+          - { wp: 6.6, ms: "1", php: "8.3" }
+          - { wp: 6.7, ms: "0", php: "8.3" }
+          - { wp: 6.7, ms: "1", php: "8.3" }
+          - { wp: 6.8, ms: "0", php: "8.3" }
+          - { wp: 6.8, ms: "1", php: "8.3" }
+          - { wp: latest, ms: "0", php: "8.3" }
+          - { wp: latest, ms: "1", php: "8.3" }
+          - { wp: nightly, ms: "0", php: "8.3" }
+          - { wp: nightly, ms: "1", php: "8.3" }
           # PHP 8.2
           - { wp: 6.8, ms: "0", php: "8.2" }
           - { wp: 6.8, ms: "1", php: "8.2" }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/automattic/vip-security-boost-integration",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.1",
+		"php": ">=8.3",
 		"spatie/mjml-php": "^1.2"
 	},
 	"require-dev": {
@@ -26,7 +26,7 @@
 	"config": {
 		"sort-packages": true,
 		"platform": {
-			"php": "8.1"
+			"php": "8.3"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
@@ -38,10 +38,10 @@
 		"analyze": "./vendor/bin/phpstan analyse --memory-limit=1024M",
 		"format": "./vendor/bin/phpcbf --standard=.phpcs.xml.dist",
 		"phpcs": "./vendor/bin/phpcs",
-		"test": "./bin/test.sh --php 8.1 --wp 6.8",
-		"test-noninteractive": "CI=true ./bin/test.sh --php 8.1 --wp 6.8",
+		"test": "./bin/test.sh --php 8.3 --wp 6.8",
+		"test-noninteractive": "CI=true ./bin/test.sh --php 8.3 --wp 6.8",
 		"test-ci": "./bin/test.sh ",
-		"test:multisite": "./bin/test.sh --php 8.1 --wp 6.8 --multisite 1",
+		"test:multisite": "./bin/test.sh --php 8.3 --wp 6.8 --multisite 1",
 		"test:integration": "./vendor/bin/phpunit --bootstrap tests/integration/bootstrap.php tests/integration/",
 		"build-mjml": "./scripts/build-mjml.sh"
 	}

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"homepage": "https://github.com/automattic/vip-security-boost-integration",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"php": ">=8.3",
+		"php": ">=8.2",
 		"spatie/mjml-php": "^1.2"
 	},
 	"require-dev": {
@@ -26,7 +26,7 @@
 	"config": {
 		"sort-packages": true,
 		"platform": {
-			"php": "8.3"
+			"php": "8.2"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "523bb8df61284b1d71833a238d7fc8d8",
+	"content-hash": "fea2b10178c650a47c33c1fe37e5feaa",
 	"packages": [
 		{
 			"name": "spatie/mjml-php",
@@ -3545,11 +3545,11 @@
 	"prefer-stable": false,
 	"prefer-lowest": false,
 	"platform": {
-		"php": ">=8.1"
+		"php": ">=8.3"
 	},
 	"platform-dev": {},
 	"platform-overrides": {
-		"php": "8.1"
+		"php": "8.3"
 	},
 	"plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
 		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
 		"This file is @generated automatically"
 	],
-	"content-hash": "fea2b10178c650a47c33c1fe37e5feaa",
+	"content-hash": "fde78a4fc6b1bbc2834c25f1da8d1973",
 	"packages": [
 		{
 			"name": "spatie/mjml-php",
@@ -3545,11 +3545,11 @@
 	"prefer-stable": false,
 	"prefer-lowest": false,
 	"platform": {
-		"php": ">=8.3"
+		"php": ">=8.2"
 	},
 	"platform-dev": {},
 	"platform-overrides": {
-		"php": "8.3"
+		"php": "8.2"
 	},
 	"plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Description

 The `wp-test-runner` Docker image no longer supports PHP 8.1, causing all 12 PHP 8.1 CI jobs to fail with "Unsupported PHP version: 8.1" before any tests run.

This PR updates:
  - `.github/workflows/unit-tests.yml` — Replaces PHP 8.1 matrix entries with 8.3
  - `composer.json` — Updates require constraint and platform config to PHP 8.2 (matching CI minimum), and bumps local test scripts to PHP 8.3
  - `composer.lock` — Regenerated after platform change

## Changelog Description

### Fixed
  - Fixed CI test failures by replacing unsupported PHP 8.1 with PHP 8.3 in the test matrix and updating the minimum platform requirement to PHP 8.2.

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [x] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 
No alerts were added or updated — N/A.

## Steps to Test

1. Check out PR.
2. Verify CI jobs pass — PHP 8.2, 8.3, and 8.4 matrix entries should all run successfully.
3. Confirm no PHP 8.1 jobs remain in the workflow run.