### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
             github.com:443
 
       - name: Check out the source code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Review dependencies
-        uses: actions/dependency-review-action@v4.7.1
+        uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,10 +78,10 @@ jobs:
             wordpress.org:443
 
       - name: Check out repository code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 'lts/*'
           cache: npm
@@ -118,7 +118,7 @@ jobs:
         working-directory: tests/e2e
 
       - name: Archive test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: test-results
@@ -136,10 +136,10 @@ jobs:
           egress-policy: audit
 
       - name: Check out repository code
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v6.0.0
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 'lts/*'
           cache: npm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: mu-plugins cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: mu-plugins
           key: ${{ runner.os }}-build-pr-${{ github.event.pull_request.number }}
@@ -38,7 +38,7 @@ jobs:
           fail-fast: "true"
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,7 +56,7 @@ jobs:
           path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
 
-      - uses: php-actions/composer@v6
+      - uses: php-actions/composer@8a65f0d3c6a1d17ca4800491a40b5756a4c164f3  # v6.1.2
         with:
           php_version: "${{ matrix.config.php }}"
           dev: "yes"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -40,10 +40,10 @@ jobs:
           - { wp: latest, ms: "1", php: "8.4" }
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: mu-plugins cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: mu-plugins
           key: ${{ runner.os }}-build-pr-${{ github.event.pull_request.number }}
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-build-pr-
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: vendor
           key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Pins GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

## Why

Tag references like `actions/checkout@v6` are mutable — a tag can be moved to point at different code after review. Pinning each action to a full 40-character commit SHA (with a trailing `# vX.Y.Z` comment for readability) makes the supply chain immutable and auditable. Grouped Dependabot updates keep the pins current.

## Verification

For each pinned action below, the `gh api` call returns the commit SHA the tag currently points to; it must match the SHA in the workflow file.

```bash
# Confirm each pinned action's SHA matches its trailing version comment, e.g.:
#   gh api repos/<owner>/<repo>/commits/<vX.Y.Z> --jq .sha
# (one call per pinned action; the SHA must match the workflow file)
```

Re-scan the repo for any remaining unpinned references in scope (should print nothing):

```bash
grep -rn 'uses:' .github | grep -v '@[0-9a-f]\{40\}'
```
