### PR TITLE
fix: render inactive-user badge without mutating WP_User

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -329,9 +329,24 @@ class Inactive_Users {
 					}
 				}
 
-				var link = document.querySelector( 'a[href*="user_id=' + id + '"]' );
-				if ( link && link.closest ) {
-					return link.closest( 'tr' );
+				// Match the edit link by the exact `user_id` query value. A bare
+				// substring match (`user_id=1`) would also match `user_id=10`, so
+				// confirm the captured value equals the target ID.
+				var wanted = String( id );
+				var links  = document.querySelectorAll( 'a[href*="user_id=' + id + '"]' );
+				for ( var i = 0; i < links.length; i++ ) {
+					if ( ! links[ i ].closest ) {
+						continue;
+					}
+
+					var href = links[ i ].getAttribute( 'href' ) || '';
+					var re   = /[?&]user_id=(\d+)/g;
+					var match;
+					while ( ( match = re.exec( href ) ) !== null ) {
+						if ( match[ 1 ] === wanted ) {
+							return links[ i ].closest( 'tr' );
+						}
+					}
 				}
 
 				return null;

--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -226,6 +226,19 @@ class Inactive_Users {
 		return $available;
 	}
 
+	/**
+	 * Render the "Inactive User" / "Blocked: Inactivity" badge in the username
+	 * column of the Users list table.
+	 *
+	 * The badge is injected into the rendered username cell via a small inline
+	 * script keyed on the core `#user-{ID}` row id. We deliberately do NOT mutate
+	 * the `WP_User` objects in `$wp_list_table->items`: those objects are shared
+	 * by reference and are passed to the `user_row_actions` filter (and other
+	 * consumers) during row rendering. Appending badge markup to `user_login`
+	 * corrupts that value for every such consumer — e.g. Co-Authors Plus reads
+	 * `$user_object->user_login` to look up a linked guest author and would no
+	 * longer find a match (PLTFRM-2468).
+	 */
 	public static function modify_users_list_table_items() {
 		global $wp_list_table;
 
@@ -244,31 +257,129 @@ class Inactive_Users {
 			return;
 		}
 
-		// Modify each user item to add badge to username
+		$badge_class = self::is_block_action_enabled() ? 'blocked' : 'inactive';
+		$badge_text  = self::is_block_action_enabled() ?
+			__( 'Blocked: Inactivity', 'wpvip' ) :
+			__( 'Inactive User', 'wpvip' );
+
+		// Collect the IDs of inactive users to badge. We only need the IDs; the
+		// markup is built client-side so the WP_User objects stay pristine.
+		$inactive_user_ids = array();
 		foreach ( $items as $user ) {
-			if ( ! self::is_considered_inactive( $user->ID ) ) {
+			if ( ! isset( $user->ID ) ) {
 				continue;
 			}
 
-			// Create the badge
-			$badge_text = self::is_block_action_enabled() ?
-			esc_html__( 'Blocked: Inactivity', 'wpvip' ) :
-			esc_html__( 'Inactive User', 'wpvip' );
-
-			$badge_class = self::is_block_action_enabled() ? 'blocked' : 'inactive';
-
-			$badge = sprintf(
-				'<span class="inactive-user-badge inactive-user-badge--%s">%s</span>',
-				$badge_class,
-				$badge_text
-			);
-
-			// Add the badge to the user_login field (which is what gets displayed in the username column)
-			$user->user_login = esc_html( $user->user_login ) . '&nbsp;&nbsp;' . $badge;
+			if ( self::is_considered_inactive( $user->ID ) ) {
+				$inactive_user_ids[] = (int) $user->ID;
+			}
 		}
 
-		// Update the list table items
-		$wp_list_table->items = $items;
+		if ( empty( $inactive_user_ids ) ) {
+			return;
+		}
+
+		self::render_username_badges_script( $inactive_user_ids, $badge_class, $badge_text );
+	}
+
+	/**
+	 * Print an inline script that appends the inactivity badge to the username
+	 * cell of each inactive user's row, without mutating any WP_User object.
+	 *
+	 * @param int[]  $inactive_user_ids IDs of users that should receive a badge.
+	 * @param string $badge_class       Badge modifier class: `inactive` or `blocked`.
+	 * @param string $badge_text        Human-readable badge label.
+	 */
+	protected static function render_username_badges_script( array $inactive_user_ids, $badge_class, $badge_text ) {
+		// Harden the JSON so a translated badge string can never break out of the
+		// inline <script> (e.g. a `</script>` sequence injected via a translation
+		// or the `gettext` filter).
+		$payload = wp_json_encode(
+			array(
+				'ids'   => array_values( $inactive_user_ids ),
+				'class' => 'inactive-user-badge inactive-user-badge--' . $badge_class,
+				'text'  => $badge_text,
+			),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+		);
+
+		if ( false === $payload ) {
+			return;
+		}
+		?>
+		<script type="text/javascript">
+		( function () {
+			var data = <?php echo $payload; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_json_encode with JSON_HEX_* flags is script-context safe. ?>;
+
+			// Locate a user's row across both the single-site and network Users
+			// tables. Single-site rows expose `id="user-{ID}"`; network rows have
+			// no row id, so fall back to the row's checkbox (`#blog_{ID}`, present
+			// for non-super-admins) and finally to the edit link (`user_id={ID}`).
+			function findRow( id ) {
+				var row = document.getElementById( 'user-' + id );
+				if ( row ) {
+					return row;
+				}
+
+				var checkbox = document.getElementById( 'blog_' + id );
+				if ( checkbox && checkbox.closest ) {
+					row = checkbox.closest( 'tr' );
+					if ( row ) {
+						return row;
+					}
+				}
+
+				var link = document.querySelector( 'a[href*="user_id=' + id + '"]' );
+				if ( link && link.closest ) {
+					return link.closest( 'tr' );
+				}
+
+				return null;
+			}
+
+			function addBadges() {
+				if ( ! data || ! Array.isArray( data.ids ) ) {
+					return;
+				}
+
+				data.ids.forEach( function ( id ) {
+					var row = findRow( id );
+					if ( ! row ) {
+						return;
+					}
+
+					var cell = row.querySelector( '.column-username' );
+					if ( ! cell || cell.querySelector( '.inactive-user-badge' ) ) {
+						return;
+					}
+
+					var badge = document.createElement( 'span' );
+					badge.className = data.class;
+					badge.textContent = data.text;
+
+					// Anchor after the username label (the <strong> wrapping the
+					// login), falling back to the cell itself.
+					var label = cell.querySelector( 'strong' ) || cell;
+					var spacer = document.createTextNode( '\u00A0\u00A0' );
+
+					if ( label === cell ) {
+						cell.appendChild( spacer );
+						cell.appendChild( badge );
+					} else {
+						label.parentNode.insertBefore( spacer, label.nextSibling );
+						label.parentNode.insertBefore( badge, spacer.nextSibling );
+					}
+				} );
+			}
+
+			if ( 'loading' === document.readyState ) {
+				document.addEventListener( 'DOMContentLoaded', addBadges );
+			} else {
+				addBadges();
+			}
+		} )();
+		</script>
+		<?php
 	}
 
 	public static function add_username_badge_styles() {

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -352,6 +352,9 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( "'user-'", $output );
 		$this->assertStringContainsString( "'blog_'", $output );
 		$this->assertStringContainsString( 'user_id=', $output );
+		// The edit-link fallback must match the user_id value exactly so that,
+		// e.g., user_id=1 does not also match user_id=10 (PR #110 review).
+		$this->assertStringContainsString( 'user_id=(\d+)', $output );
 		// And the WP_User object is still untouched.
 		$this->assertEquals( 'testuser', $wp_list_table->items[0]->user_login );
 	}

--- a/tests/phpunit/test-inactive-users.php
+++ b/tests/phpunit/test-inactive-users.php
@@ -170,7 +170,8 @@ class InactiveUsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that modify_users_list_table_items adds badges to inactive users
+	 * Test that modify_users_list_table_items emits badge markup for inactive
+	 * users without mutating the shared WP_User objects (PLTFRM-2468).
 	 */
 	public function test_modify_users_list_table_items_adds_badges() {
 		// Create a mock WP_Users_List_Table
@@ -197,14 +198,19 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Make the first user inactive
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 
-		// Call the method
+		// Capture the inline script output.
+		ob_start();
 		Inactive_Users::modify_users_list_table_items();
+		$output = ob_get_clean();
 
-		// Check that the inactive user has a badge added
-		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
-		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+		// The badge markup/payload references the inactive user, not the active one.
+		$this->assertStringContainsString( 'inactive-user-badge', $output );
+		$this->assertStringContainsString( (string) $this->user_id, $output );
+		$this->assertStringNotContainsString( (string) $active_user->ID, $output );
 
-		// Check that the active user doesn't have a badge
+		// The shared WP_User objects must be left untouched so consumers such as
+		// Co-Authors Plus still read a clean user_login.
+		$this->assertEquals( 'testuser', $wp_list_table->items[0]->user_login );
 		$this->assertEquals( 'activeuser', $wp_list_table->items[1]->user_login );
 
 		// Clean up
@@ -231,18 +237,123 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Make the user inactive
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 
-		// Test that a badge is added (the specific text depends on the current config)
+		// Capture the inline script output.
+		ob_start();
 		Inactive_Users::modify_users_list_table_items();
-		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
-		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+		$output = ob_get_clean();
+
+		// The badge markup is emitted (text depends on the current config) and
+		// the user_login is never mutated.
+		$this->assertStringContainsString( 'inactive-user-badge', $output );
+		$this->assertEquals( 'testuser', $wp_list_table->items[0]->user_login );
 
 		// Should contain either "Blocked: Inactivity" or "Inactive User"
-		$login_text = $wp_list_table->items[0]->user_login;
 		$this->assertTrue(
-			strpos( $login_text, 'Blocked: Inactivity' ) !== false ||
-			strpos( $login_text, 'Inactive User' ) !== false,
+			strpos( $output, 'Blocked: Inactivity' ) !== false ||
+			strpos( $output, 'Inactive User' ) !== false,
 			'Badge should contain either "Blocked: Inactivity" or "Inactive User"'
 		);
+	}
+
+	/**
+	 * Regression test for PLTFRM-2468: the badge must never be appended to the
+	 * shared WP_User->user_login, because that value is read by user_row_actions
+	 * consumers such as Co-Authors Plus (linked-account lookups).
+	 */
+	public function test_modify_users_list_table_items_does_not_mutate_user_login() {
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
+		$inactive_user->user_login = 'linked-user@example.com';
+
+		$wp_list_table->items = [ $inactive_user ];
+
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		ob_start();
+		Inactive_Users::modify_users_list_table_items();
+		ob_end_clean();
+
+		// The login must be byte-for-byte preserved: no badge markup, no padding.
+		$this->assertSame( 'linked-user@example.com', $wp_list_table->items[0]->user_login );
+		$this->assertStringNotContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
+	}
+
+	/**
+	 * The inline payload must be hardened so a translated badge string can never
+	 * break out of the <script> element.
+	 */
+	public function test_modify_users_list_table_items_payload_is_script_safe() {
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
+		$inactive_user->user_login = 'testuser';
+		$wp_list_table->items      = [ $inactive_user ];
+
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		// Inject a hostile translation for the badge text.
+		$malicious = 'Inactive </script><script>window.__xss=1;</script>';
+		$filter    = static function ( $translation, $text ) use ( $malicious ) {
+			if ( 'Blocked: Inactivity' === $text || 'Inactive User' === $text ) {
+				return $malicious;
+			}
+			return $translation;
+		};
+		add_filter( 'gettext', $filter, 10, 2 );
+
+		ob_start();
+		Inactive_Users::modify_users_list_table_items();
+		$output = ob_get_clean();
+
+		remove_filter( 'gettext', $filter, 10 );
+
+		// The raw closing-script sequence must not survive into the output: with
+		// JSON_HEX_TAG the `<`/`>` are escaped, so the hostile string can no longer
+		// break out of the inline <script>. The escaped text remaining inside the
+		// JS string literal is inert.
+		$this->assertStringNotContainsString( '</script><script>', $output );
+		$this->assertStringNotContainsString( '<script>window', $output );
+		$this->assertStringContainsString( '\u003C', $output );
+	}
+
+	/**
+	 * The badge script must be able to locate rows in the network (multisite)
+	 * Users table, whose rows carry no `id` attribute. We assert the emitted
+	 * script includes the fallback selectors used for that table.
+	 */
+	public function test_modify_users_list_table_items_supports_network_rows() {
+		global $wp_list_table;
+		$wp_list_table = $this->getMockBuilder( 'WP_MS_Users_List_Table' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$inactive_user             = new stdClass();
+		$inactive_user->ID         = $this->user_id;
+		$inactive_user->user_login = 'testuser';
+		$wp_list_table->items      = [ $inactive_user ];
+
+		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
+
+		ob_start();
+		Inactive_Users::modify_users_list_table_items();
+		$output = ob_get_clean();
+
+		// The script emits the network fallbacks (checkbox id and edit-link href)
+		// in addition to the single-site row id.
+		$this->assertStringContainsString( "'user-'", $output );
+		$this->assertStringContainsString( "'blog_'", $output );
+		$this->assertStringContainsString( 'user_id=', $output );
+		// And the WP_User object is still untouched.
+		$this->assertEquals( 'testuser', $wp_list_table->items[0]->user_login );
 	}
 
 	/**
@@ -401,12 +512,15 @@ class InactiveUsersTest extends WP_UnitTestCase {
 		// Make the user inactive
 		update_user_meta( $this->user_id, Inactive_Users::LAST_SEEN_META_KEY, strtotime( '-91 days' ) );
 
-		// Call the method
+		// Capture the inline script output.
+		ob_start();
 		Inactive_Users::modify_users_list_table_items();
+		$output = ob_get_clean();
 
-		// Check that the inactive user has a badge added
-		$this->assertStringContainsString( 'inactive-user-badge', $wp_list_table->items[0]->user_login );
-		$this->assertStringContainsString( 'testuser', $wp_list_table->items[0]->user_login );
+		// Check that the inactive user is badged via output, not via mutation.
+		$this->assertStringContainsString( 'inactive-user-badge', $output );
+		$this->assertStringContainsString( (string) $this->user_id, $output );
+		$this->assertEquals( 'testuser', $wp_list_table->items[0]->user_login );
 	}
 
 	/**


### PR DESCRIPTION
## Description

The Users list "Inactive User" / "Blocked: Inactivity" badge was being appended directly to `WP_User->user_login` for every inactive item in `$wp_list_table->items`, on the `admin_head-users.php` / `admin_head-users-network.php` actions.

Those `WP_User` objects are shared by reference and are passed to the `user_row_actions` filter while WordPress renders each row. Any consumer that reads `$user_object->user_login` there received the badge HTML appended to the login instead of the real value. Co-Authors Plus looks up a linked guest author by an exact `user_login` match, so linked **inactive** users were shown its "Create Profile" action instead of "Edit Profile" (the linked-account lookup no longer matched).

This change renders the badge at the output layer instead of mutating the model object:

- `modify_users_list_table_items()` no longer touches `WP_User`. It collects the IDs of inactive users and prints a small inline script.
- The script appends the badge `<span>` to the rendered username cell (`.column-username`) for each inactive user, using `document.createElement` + `textContent` (no `innerHTML`), guarded against double-adding.
- Row resolution works on both tables: single-site rows expose `id="user-{ID}"`; network admin rows have no row id, so the script falls back to the row checkbox (`#blog_{ID}`) and finally the edit-link href (`user_id={ID}`).
- The JSON payload is encoded with `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT` so a translated badge string can never break out of the inline `<script>`.

The fix is entirely in this plugin; no change is needed in any consumer, whose `user_login` read is legitimate.

Tradeoff: the badge is now applied client-side, so it does not appear with JavaScript disabled. The badge is purely informational — the inactivity enforcement (auth / application-password / REST blocking in BLOCK mode) is server-side and unchanged.

## Changelog Description

### Fixed
- Inactive-user badge on the Users list no longer modifies the underlying user object, fixing a conflict where plugins reading the username (such as Co-Authors Plus) saw badge markup instead of the real login.

## Pre-review checklist

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [x] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Steps to Test

1. Check out the PR with Co-Authors Plus active.
2. Link a guest author to a user (set the guest author's linked account to that user's login).
3. Flag that user as inactive so the "Inactive User" badge renders on `wp-admin/users.php`.
4. Optionally add `add_filter( 'coauthors_show_create_profile_user_link', '__return_true' );` to make the action visible.
5. Visit `users.php`: the inactive, linked user now shows **Edit Profile** (previously **Create Profile**), and the badge still appears in the username column.
6. Confirm the badge still renders for inactive/blocked users on both `users.php` and (multisite) `users-network.php`.
7. Confirm a `user_row_actions` probe logging `strlen( $user_object->user_login )` reports the clean login length for inactive users.