### PR TITLE
ci: remove harden-runner

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,48 +35,6 @@ jobs:
     name: Run E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          egress-policy: block
-          allowed-endpoints:
-            1.gravatar.com:443
-            1.gravatar.com:80
-            140.82.114.22:443
-            2.gravatar.com:443
-            2.gravatar.com:80
-            api.github.com:443
-            api.ipify.org:443
-            api.wordpress.org:443
-            api.wordpress.org:80
-            api.wpvip.com:443
-            auth.docker.io:443
-            cdn.playwright.dev:443
-            dl-cdn.alpinelinux.org:443
-            downloads.wordpress.org:443
-            e2e-test-site.vipdev.lndo.site:443
-            geoip.elastic.co:443
-            ghcr.io:443
-            github.com:443
-            nodejs.org:443
-            objects.githubusercontent.com:443
-            pkg-containers.githubusercontent.com:443
-            planet.wordpress.org:443
-            playwright.azureedge.net:443
-            playwright.download.prss.microsoft.com:443
-            production.cloudflare.docker.com:443
-            public-api.wordpress.com:443
-            raw.githubusercontent.com:443
-            registry-1.docker.io:443
-            registry.npmjs.org:443
-            s.w.org:443
-            s0.wp.com:443
-            secure.gravatar.com:443
-            storage.googleapis.com:443
-            update.traefik.io:443
-            vaultpress.com:443
-            wordpress.org:443
-
       - name: Check out repository code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
@@ -130,11 +88,6 @@ jobs:
     name: Run ESLint on E2E tests
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          egress-policy: audit
-
       - name: Check out repository code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
## Description

This PR removes `harden-runner` because, in the current configuration, it is useless:
1. It needs to be maintained (this repo uses a very outdated version).
2. The list of domains needs to be reviewed from time to time.
3. All jobs must be guarded,

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [ ] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [ ] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

N/A