### PR TITLE
chore(dev-deps): update `playwright` and its eslint plugin

### DIFF
--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -10,12 +10,12 @@
 			"devDependencies": {
 				"@automattic/eslint-plugin-wpvip": "^0.13.0",
 				"@babel/plugin-syntax-decorators": "^7.22.10",
-				"@playwright/test": "^1.39.0",
+				"@playwright/test": "^1.60.0",
 				"@types/node": "^24.0.3",
 				"asana-phrase": "^0.0.8",
 				"eslint": "^8.51.0",
 				"eslint-plugin-deprecation": "^3.0.0",
-				"eslint-plugin-playwright": "^2.0.1",
+				"eslint-plugin-playwright": "^2.10.4",
 				"typescript": "^5.2.2"
 			}
 		},
@@ -687,13 +687,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
-			"integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.56.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2204,19 +2204,32 @@
 			}
 		},
 		"node_modules/eslint-plugin-playwright": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.2.2.tgz",
-			"integrity": "sha512-j0jKpndIPOXRRP9uMkwb9l/nSmModOU3452nrFdgFJoEv/435J1onk8+aITzjDW8DfypxgmVaDMdmVIa6F7I0w==",
+			"version": "2.10.4",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.10.4.tgz",
+			"integrity": "sha512-l0V/VxyqfFbtqCTxj5AdRn3Q6S/hIW4nKBnKZVleVbZ24N2My6Usj//ytX3dKKqAoSbvKck9YtSytfdZ5qjLuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"globals": "^13.23.0"
+				"globals": "^17.3.0"
 			},
 			"engines": {
-				"node": ">=16.6.0"
+				"node": ">=16.9.0"
 			},
 			"peerDependencies": {
 				"eslint": ">=8.40.0"
+			}
+		},
+		"node_modules/eslint-plugin-playwright/node_modules/globals": {
+			"version": "17.6.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+			"integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
@@ -4199,13 +4212,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-			"integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.56.1"
+				"playwright-core": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4218,9 +4231,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.56.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-			"integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -13,12 +13,12 @@
 	"devDependencies": {
 		"@automattic/eslint-plugin-wpvip": "^0.13.0",
 		"@babel/plugin-syntax-decorators": "^7.22.10",
-		"@playwright/test": "^1.39.0",
+		"@playwright/test": "^1.60.0",
 		"@types/node": "^24.0.3",
 		"asana-phrase": "^0.0.8",
 		"eslint": "^8.51.0",
 		"eslint-plugin-deprecation": "^3.0.0",
-		"eslint-plugin-playwright": "^2.0.1",
+		"eslint-plugin-playwright": "^2.10.4",
 		"typescript": "^5.2.2"
 	}
 }


### PR DESCRIPTION
## Description

This PR updates `@playwright/test` and `eslint-plugin-playwright` to their latest versions.

This fixes the freezing of `npx playwright install` that affects all E2E CI jobs. 

## Pre-review checklist

Please make sure the items below have been covered before requesting a review:

- [x] This change works and has been tested locally or in Codespaces (or has an appropriate fallback).
- [ ] This change has relevant unit tests (if applicable).
- [ ] This change has relevant documentation additions / updates (if applicable).
- [x] I've created a changelog description that aligns with the provided examples.

## Pre-deploy checklist

- [ ] VIP staff: Ensure any alerts added/updated conform to internal standards (see internal documentation). 

## Steps to Test

CI must pass.