### PR TITLE
Fix: avoid sprintf ArgumentCountError in Last Seen column when URL contains encoded characters

### DIFF
--- a/modules/inactive-users/class-inactive-users.php
+++ b/modules/inactive-users/class-inactive-users.php
@@ -618,7 +618,7 @@ class Inactive_Users {
 
 			$unblock_link = "<div class='row-actions'><span>User blocked due to inactivity. <a class='reset_last_seen_action' href='" . esc_url( $url ) . "'>" . __( 'Unblock', 'wpvip' ) . '</a></span></div>';
 		}
-		return sprintf( '<span class="wp-ui-text-notification">%s</span>' . $unblock_link, esc_html( $date ) );
+		return sprintf( '<span class="wp-ui-text-notification">%s</span>', esc_html( $date ) ) . $unblock_link;
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,7 +28,6 @@ require_once __DIR__ . '/../mu-plugins/000-pre-vip-config/requires.php';
 
 function _manually_load_plugin() {
 	require_once __DIR__ . '/../mu-plugins/000-pre-vip-config/requires.php';
-	require_once __DIR__ . '/../mu-plugins/lib/helpers/php-compat.php';
 	require_once __DIR__ . '/../mu-plugins/000-vip-init.php';
 	require_once __DIR__ . '/../mu-plugins/001-core.php';
 	require_once __DIR__ . '/../mu-plugins/a8c-files.php';


### PR DESCRIPTION
## Problem

`add_last_seen_column_date()` concatenates `$unblock_link` into the sprintf *format*
string instead of passing it as an argument:

    return sprintf( '<span class="wp-ui-text-notification">%s</span>' . $unblock_link, esc_html( $date ) );

`$unblock_link` is built from the current request URL via `add_query_arg()` + `esc_url()`.
When an admin filters or searches the (network) Users list by a URL-encoded value - most
commonly searching a user by email, where `@` becomes `%40` - that percent sequence ends up
inside the format string. sprintf then reads it as a conversion directive (e.g. `%40f` from
`...%40fareharbor...`), expects an argument that is never passed, and throws:

    Uncaught Error: 3 arguments are required, 2 given

This fatals the Users list page and, because the row is a blocked/inactive user, also
prevents admins from reaching the "Unblock" action.

Conditions required to hit it:
- BLOCK mode enabled, the row's user is considered inactive, and current user can `edit_user`
  (this is the only branch that builds `$unblock_link`), and
- the current page URL contains a `%XX` sequence followed by a valid sprintf conversion char.

## Fix

Move `$unblock_link` out of the format string and concatenate it onto the result, so its
contents can never be interpreted as sprintf directives:

    return sprintf( '<span class="wp-ui-text-notification">%s</span>', esc_html( $date ) ) . $unblock_link;

This matches the pattern already used in the non-blocked branch just above. Output is
identical except that encoded characters now render literally. No escaping changes: the date
is still `esc_html()`'d and the URL inside `$unblock_link` is still `esc_url()`'d at build time
(sprintf never sanitized `$unblock_link` - it was in the format string, not an argument).

## Testing

- Enable BLOCK mode and flag a user inactive.
- Go to the network Users list and search by an email address (e.g. `name@example.com`).
- Before: the page fatals with the ArgumentCountError above.
- After: the list renders and the "Unblock" link works.

Refs: Zendesk 229826
